### PR TITLE
Make Device hashable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ bitflags!(
 /// A struct containing the device's major and minor numbers
 ///
 /// Also allows conversion to/from a single 64bit value.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct Device {
     /// Device major number
     pub major: u32,


### PR DESCRIPTION
Required for Device to be a key in a HashMap or HashSet.

Signed-off-by: mulhern <amulhern@redhat.com>