### PR TITLE
move LinearDev to DM, add logging, move IEC constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ clippy = { version = "0", optional = true }
 newtype_derive = "0.1"
 custom_derive = "0.1"
 serde = "0"
+log = "0.3"
+env_logger="0.3.5"

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -4,3 +4,22 @@
 
 /// disk sector size in bytes
 pub const SECTOR_SIZE: usize = 512;
+
+#[allow(non_upper_case_globals)]
+#[allow(non_snake_case)]
+/// International Electrotechnical Commission Units Standards
+pub mod IEC {
+    /// kibi
+    pub const Ki: u64 = 1024;
+    /// mebi
+    pub const Mi: u64 = 1024 * Ki;
+    /// gibi
+    pub const Gi: u64 = 1024 * Mi;
+    /// tebi
+    pub const Ti: u64 = 1024 * Gi;
+    /// pebi
+    pub const Pi: u64 = 1024 * Ti;
+    /// exbi
+    pub const Ei: u64 = 1024 * Pi;
+    // Ei is the maximum IEC unit expressible in u64.
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,8 @@ pub struct Device {
 }
 
 impl Device {
-    /// Returns the path in `/dev` that corresponds with the device number.
-    pub fn path(&self) -> Option<PathBuf> {
+    /// Returns the path in `/dev` that corresponds with the device number/devnode.
+    pub fn devnode(&self) -> Option<PathBuf> {
         let f = File::open("/proc/partitions").expect("Could not open /proc/partitions");
 
         let reader = BufReader::new(f);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,24 @@ extern crate serde;
 #[macro_use]
 extern crate bitflags;
 
+#[macro_use]
+extern crate log;
+
 #[allow(dead_code, non_camel_case_types)]
 mod dm_ioctl;
-mod util;
-/// Module for basic types (Bytes, Sectors, DataBlocks)
+/// public utilities
+pub mod util;
+/// basic types (Bytes, Sectors, DataBlocks)
 pub mod types;
-/// Module for shared constants
+/// shared constants
 pub mod consts;
+/// functions to create continuous linear space given device segments
+pub mod lineardev;
+/// struct to represent a location, offset and size of a set of disk sectors
+pub mod segment;
+/// return results container
+pub mod result;
+
 
 use std::fs::File;
 use std::io;
@@ -78,6 +89,8 @@ use std::collections::BTreeSet;
 use std::os::unix::fs::MetadataExt;
 use std::cmp;
 use std::borrow::Borrow;
+use std::thread;
+use std::time::Duration;
 
 use nix::sys::ioctl::ioctl as nix_ioctl;
 use nix::sys::ioctl::libc::c_ulong;
@@ -225,10 +238,11 @@ pub fn dev_majors() -> BTreeSet<u32> {
 
     let reader = BufReader::new(f);
 
-    for line in reader.lines()
-        .filter_map(|x| x.ok())
-        .skip_while(|x| x != "Block devices:")
-        .skip(1) {
+    for line in reader
+            .lines()
+            .filter_map(|x| x.ok())
+            .skip_while(|x| x != "Block devices:")
+            .skip(1) {
         let spl: Vec<_> = line.split_whitespace().collect();
 
         if spl[1] == "device-mapper" {
@@ -316,6 +330,12 @@ impl DM {
         Ok(DM { file: try!(File::open(DM_CTL_PATH)) })
     }
 
+    /// The /dev/mapper/<name> device is not immediately available for use.
+    /// TODO: Implement wait for event or poll.
+    pub fn wait_for_dm() {
+        thread::sleep(Duration::from_millis(500))
+    }
+
     fn initialize_hdr(hdr: &mut dmi::Struct_dm_ioctl, flags: DmFlags) -> () {
         hdr.version[0] = DM_VERSION_MAJOR;
         hdr.version[1] = DM_VERSION_MINOR;
@@ -376,12 +396,16 @@ impl DM {
         let op = iorw!(DM_IOCTL, ioctl, size_of::<dmi::Struct_dm_ioctl>()) as c_ulong;
         loop {
             if let Err(_) = unsafe {
-                convert_ioctl_res!(nix_ioctl(self.file.as_raw_fd(), op, v.as_mut_ptr()))
-            } {
+                   convert_ioctl_res!(nix_ioctl(self.file.as_raw_fd(), op, v.as_mut_ptr()))
+               } {
                 return Err((Error::last_os_error()));
             }
 
-            let hdr = unsafe { (v.as_mut_ptr() as *mut dmi::Struct_dm_ioctl).as_mut().unwrap() };
+            let hdr = unsafe {
+                (v.as_mut_ptr() as *mut dmi::Struct_dm_ioctl)
+                    .as_mut()
+                    .unwrap()
+            };
 
             if (hdr.flags & DM_BUFFER_FULL.bits) == 0 {
                 break;
@@ -392,7 +416,11 @@ impl DM {
             hdr.data_size = v.len() as u32;
         }
 
-        let hdr = unsafe { (v.as_mut_ptr() as *mut dmi::Struct_dm_ioctl).as_mut().unwrap() };
+        let hdr = unsafe {
+            (v.as_mut_ptr() as *mut dmi::Struct_dm_ioctl)
+                .as_mut()
+                .unwrap()
+        };
 
         // hdr possibly modified so copy back
         hdr_slc.clone_from_slice(&v[..hdr.data_start as usize]);
@@ -448,7 +476,9 @@ impl DM {
 
             loop {
                 let device = unsafe {
-                    (result.as_ptr() as *const dmi::Struct_dm_name_list).as_ref().unwrap()
+                    (result.as_ptr() as *const dmi::Struct_dm_name_list)
+                        .as_ref()
+                        .unwrap()
                 };
 
                 let slc = slice_to_null(&result[size_of::<dmi::Struct_dm_name_list>()..])
@@ -765,14 +795,16 @@ impl DM {
         let mut devs = Vec::new();
         if !data_out.is_empty() {
             let result = &data_out[..];
-            let target_deps =
-                unsafe { (result.as_ptr() as *const dmi::Struct_dm_target_deps).as_ref().unwrap() };
+            let target_deps = unsafe {
+                (result.as_ptr() as *const dmi::Struct_dm_target_deps)
+                    .as_ref()
+                    .unwrap()
+            };
 
             let dev_slc = unsafe {
-                slice::from_raw_parts(
-                    result[size_of::<dmi::Struct_dm_target_deps>()..]
-                        .as_ptr() as *const u64,
-                    target_deps.count as usize)
+                slice::from_raw_parts(result[size_of::<dmi::Struct_dm_target_deps>()..].as_ptr() as
+                                      *const u64,
+                                      target_deps.count as usize)
             };
 
             for dev in dev_slc {
@@ -794,7 +826,9 @@ impl DM {
             for _ in 0..count {
                 result = &result[next_off..];
                 let targ = unsafe {
-                    (result.as_ptr() as *const dmi::Struct_dm_target_spec).as_ref().unwrap()
+                    (result.as_ptr() as *const dmi::Struct_dm_target_spec)
+                        .as_ref()
+                        .unwrap()
                 };
 
                 let target_type = unsafe {
@@ -884,8 +918,8 @@ impl DM {
                         .unwrap()
                 };
 
-                let name_slc =
-                    slice_to_null(&result[size_of::<dmi::Struct_dm_target_versions>()..])
+                let name_slc = slice_to_null(&result
+                                                  [size_of::<dmi::Struct_dm_target_versions>()..])
                         .expect("bad data from ioctl");
                 let name = String::from_utf8_lossy(name_slc).into_owned();
                 targets.push((name, tver.version[0], tver.version[1], tver.version[2]));

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use {DM, DevId, DeviceInfo, DmFlags};
+use segment::Segment;
+use std::fmt;
+use std::fs::File;
+use std::path::PathBuf;
+
+use util::blkdev_size;
+use result::{DmResult, DmError, InternalError};
+use types::{Bytes, Sectors};
+
+/// A DM construct of combined Segments
+pub struct LinearDev {
+    /// Device mapper file name - /dev/mapper/<name>
+    name: String,
+    /// Data about the device
+    dev_info: DeviceInfo,
+}
+
+impl fmt::Debug for LinearDev {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name())
+    }
+}
+
+/// Use DM to concatenate a set of blockdevs together into a
+/// /dev/mapper/xxx block device of continuous sectors.
+impl LinearDev {
+    /// Construct a new block device by concatenating the given block_devs
+    /// into linear space.  Use DM to reserve enough space for the stratis
+    /// metadata on each DmDev.
+    pub fn new(name: &str, dm: &DM, block_devs: &[&Segment]) -> DmResult<LinearDev> {
+
+        try!(dm.device_create(&name, None, DmFlags::empty()));
+        let table = LinearDev::dm_table(block_devs);
+        let id = &DevId::Name(&name);
+        let dev_info = try!(dm.table_load(id, &table));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        DM::wait_for_dm();
+        Ok(LinearDev {
+               name: name.to_owned(),
+               dev_info: dev_info,
+           })
+    }
+
+    /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
+    /// <logical start sec> <length> "linear" /dev/xxx <start offset>
+    fn dm_table(block_devs: &[&Segment]) -> Vec<(u64, u64, String, String)> {
+        let mut table = Vec::new();
+        let mut logical_start_sector = Sectors(0);
+        for block_dev in block_devs {
+            let (start, length) = block_dev.range();
+            let dstr = block_dev.dstr();
+            let line = (*logical_start_sector,
+                        *length,
+                        "linear".to_owned(),
+                        format!("{} {}", dstr, *start));
+            debug!("dmtable line : {:?}", line);
+            table.push(line);
+            logical_start_sector = logical_start_sector + length;
+        }
+
+        table
+    }
+
+    /// DM name - from the DeviceInfo struct
+    pub fn name(&self) -> &str {
+        self.dev_info.name()
+    }
+
+    /// return the total size of the linear device
+    pub fn size(&self) -> DmResult<Bytes> {
+        let blockdev_path = try!(self.devnode());
+        let f = try!(File::open(blockdev_path));
+        blkdev_size(&f)
+    }
+
+    /// path of the device
+    pub fn devnode(&self) -> DmResult<PathBuf> {
+        self.dev_info
+            .device()
+            .devnode()
+            .ok_or(DmError::Dm(InternalError("No path associated with dev_info".into())))
+    }
+
+    /// Remove the device from DM
+    pub fn teardown(&self, dm: &DM) -> DmResult<()> {
+        try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
+        Ok(())
+    }
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt;
+use std::io;
+use nix;
+
+///
+#[derive(Debug)]
+pub struct InternalError(pub Cow<'static, str>);
+
+///
+#[derive(Debug, Clone)]
+pub enum ErrorEnum {
+    /// generic error code
+    Error,
+    /// returned for failure to open a File
+    FailedToOpen,
+}
+
+/// Define a common error enum.
+/// See http://blog.burntsushi.net/rust-error-handling/
+#[derive(Debug)]
+pub enum DmError {
+    /// DM errors
+    Dm(InternalError),
+    /// IO errors
+    Io(io::Error),
+    /// *nix Errors
+    Nix(nix::Error),
+}
+
+/// return result for DM functions
+pub type DmResult<T> = Result<T, DmError>;
+
+impl From<InternalError> for DmError {
+    fn from(err: InternalError) -> DmError {
+        DmError::Dm(err)
+    }
+}
+
+impl From<io::Error> for DmError {
+    fn from(err: io::Error) -> DmError {
+        DmError::Io(err)
+    }
+}
+
+impl From<nix::Error> for DmError {
+    fn from(err: nix::Error) -> DmError {
+        DmError::Nix(err)
+    }
+}
+
+impl fmt::Display for InternalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for InternalError {
+    fn description(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DmError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DmError::Dm(ref err) => write!(f, "Stratis error: {}", err.0),
+            DmError::Io(ref err) => write!(f, "IO error: {}", err),
+            DmError::Nix(ref err) => write!(f, "Nix error: {}", err.errno().desc()),
+        }
+    }
+}
+
+
+impl Error for DmError {
+    fn description(&self) -> &str {
+        match *self {
+            DmError::Dm(ref err) => &err.0,
+            DmError::Io(ref err) => err.description(),
+            DmError::Nix(ref err) => err.errno().desc(),
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            DmError::Dm(ref err) => Some(err),
+            DmError::Io(ref err) => Some(err),
+            DmError::Nix(ref err) => Some(err),
+        }
+    }
+}

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use types::Sectors;
+
+use Device;
+
+/// struct to represent a continuous set of sectors on a disk
+#[derive(Debug)]
+pub struct Segment {
+    start: Sectors,
+    length: Sectors,
+    device: Device,
+}
+
+
+impl Segment {
+    /// Create a new Segment with given attributes
+    pub fn new(device: Device, start: u64, length: u64) -> Segment {
+        Segment {
+            device: device,
+            start: Sectors(start),
+            length: Sectors(length),
+        }
+    }
+
+    /// Return the start and length sectors
+    pub fn range(&self) -> (Sectors, Sectors) {
+        (self.start, self.length)
+    }
+
+    /// Get the "x:y" device string for this blockdev
+    pub fn dstr(&self) -> String {
+        self.device.dstr()
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,8 +2,27 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use result::{DmResult, DmError};
+use types::Bytes;
+use std::fs::File;
+use std::os::unix::prelude::AsRawFd;
+
+/// send IOCTL via blkgetsize64
+ioctl!(read blkgetsize64 with 0x12, 114; u64);
+
+/// TODO document
 pub fn align_to(num: usize, align_to: usize) -> usize {
     let agn = align_to - 1;
 
     (num + agn) & !agn
+}
+
+/// get the size of a given block device file
+pub fn blkdev_size(file: &File) -> DmResult<Bytes> {
+    let mut val: u64 = 0;
+
+    match unsafe { blkgetsize64(file.as_raw_fd(), &mut val) } {
+        Err(x) => Err(DmError::Nix(x)),
+        Ok(_) => Ok(Bytes(val)),
+    }
 }


### PR DESCRIPTION
Move LinearDev from Stratis to devicemapper-rs.

Updated LinearDev::new() to take a vector of struct Segment.
Changed LinearDev functions to return DmResult
Moved wait_for_dm to DM.
Use DM::wait_for_dm() for lineardev.

Misc:
Moved IEC constants 
Added logging for debug!() used in LinearDev