### PR TITLE
Move thindev and thinpool from Stratis to devicemapper-rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,10 @@ pub mod types;
 pub mod consts;
 /// functions to create continuous linear space given device segments
 pub mod lineardev;
+/// allocate a device from a pool
+pub mod thindev;
+/// thinpooldev is shared space for  other thin provisioned devices to use
+pub mod thinpooldev;
 /// struct to represent a location, offset and size of a set of disk sectors
 pub mod segment;
 /// return results container

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -14,8 +14,6 @@ use types::{Bytes, Sectors};
 
 /// A DM construct of combined Segments
 pub struct LinearDev {
-    /// Device mapper file name - /dev/mapper/<name>
-    name: String,
     /// Data about the device
     dev_info: DeviceInfo,
 }
@@ -41,10 +39,7 @@ impl LinearDev {
         try!(dm.device_suspend(id, DmFlags::empty()));
 
         DM::wait_for_dm();
-        Ok(LinearDev {
-               name: name.to_owned(),
-               dev_info: dev_info,
-           })
+        Ok(LinearDev { dev_info: dev_info })
     }
 
     /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
@@ -79,7 +74,7 @@ impl LinearDev {
         blkdev_size(&f)
     }
 
-    /// path of the device
+    /// path of the device node
     pub fn devnode(&self) -> DmResult<PathBuf> {
         self.dev_info
             .device()
@@ -89,7 +84,7 @@ impl LinearDev {
 
     /// Remove the device from DM
     pub fn teardown(&self, dm: &DM) -> DmResult<()> {
-        try!(dm.device_remove(&DevId::Name(&self.name), DmFlags::empty()));
+        try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
         Ok(())
     }
 }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -2,15 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use {DM, DevId, DeviceInfo, DmFlags};
-use segment::Segment;
 use std::fmt;
 use std::fs::File;
 use std::path::PathBuf;
 
-use util::blkdev_size;
+use {DM, DevId, DeviceInfo, DmFlags};
 use result::{DmResult, DmError, InternalError};
+use segment::Segment;
 use types::{Bytes, Sectors};
+use util::blkdev_size;
 
 /// A DM construct of combined Segments
 pub struct LinearDev {

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -83,7 +83,7 @@ impl LinearDev {
     }
 
     /// Remove the device from DM
-    pub fn teardown(&self, dm: &DM) -> DmResult<()> {
+    pub fn teardown(self, dm: &DM) -> DmResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
         Ok(())
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -32,9 +32,9 @@ impl LinearDev {
     /// metadata on each DmDev.
     pub fn new(name: &str, dm: &DM, block_devs: &[&Segment]) -> DmResult<LinearDev> {
 
-        try!(dm.device_create(&name, None, DmFlags::empty()));
+        try!(dm.device_create(name, None, DmFlags::empty()));
         let table = LinearDev::dm_table(block_devs);
-        let id = &DevId::Name(&name);
+        let id = &DevId::Name(name);
         let dev_info = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
 
@@ -84,7 +84,7 @@ impl LinearDev {
 
     /// Remove the device from DM
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
-        try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
+        try!(dm.device_remove(&DevId::Name(self.name()), DmFlags::empty()));
         Ok(())
     }
 }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use {DM, DevId, DeviceInfo, DmFlags};
+use result::{DmResult, DmError, InternalError};
+use thinpooldev::ThinPoolDev;
+
+use std::fmt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use types::Sectors;
+
+/// DM construct for a thin block device
+#[derive(Clone)]
+pub struct ThinDev {
+    dev_info: DeviceInfo,
+    thin_id: u32,
+    size: Sectors,
+}
+
+impl fmt::Debug for ThinDev {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name())
+    }
+}
+
+/// support use of DM for thin provisioned devices over pools
+impl ThinDev {
+    /// Use the given ThinPoolDev as backing space for a newly constructed
+    /// thin provisioned ThinDev returned by new().
+    pub fn new(name: &str,
+               dm: &DM,
+               thin_pool: ThinPoolDev,
+               thin_id: u32,
+               length: Sectors)
+               -> DmResult<ThinDev> {
+
+        let thin_dev_path = format!("{}", try!(thin_pool.devnode()).to_string_lossy());
+        try!(thin_pool.message(dm, &format!("create_thin {}", thin_id)));
+        try!(dm.device_create(name, None, DmFlags::empty()));
+        let table = ThinDev::dm_table(&thin_dev_path, thin_id, length);
+        let id = &DevId::Name(name);
+        let di = try!(dm.table_load(id, &table));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+        DM::wait_for_dm();
+        Ok(ThinDev {
+               dev_info: di,
+               thin_id: thin_id,
+               size: length,
+           })
+    }
+
+    /// Generate a Vec<> to be passed to DM.  The format of the Vec entries are:
+    /// "<start> <length> thin </dev/mapper/poolname> <thin_id>"
+    fn dm_table(pool_dev_str: &String,
+                thin_id: u32,
+                length: Sectors)
+                -> Vec<(u64, u64, String, String)> {
+        let params = format!("{} {}", pool_dev_str, thin_id);
+        vec![(0u64, *length, "thin".to_owned(), params)]
+    }
+
+    /// name of the thin device
+    pub fn name(&self) -> &str {
+        self.dev_info.name()
+    }
+
+    /// path of the device node
+    pub fn devnode(&self) -> DmResult<PathBuf> {
+        self.dev_info
+            .device()
+            .devnode()
+            .ok_or(DmError::Dm(InternalError("No path associated with dev_info".into())))
+
+    }
+
+    /// Remove the device from DM
+    pub fn teardown(&self, dm: &DM) -> DmResult<()> {
+        try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
+        Ok(())
+    }
+}

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -78,7 +78,7 @@ impl ThinDev {
     }
 
     /// Remove the device from DM
-    pub fn teardown(&self, dm: &DM) -> DmResult<()> {
+    pub fn teardown(self, dm: &DM) -> DmResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
         Ok(())
     }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -2,14 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use {DM, DevId, DeviceInfo, DmFlags};
-use result::{DmResult, DmError, InternalError};
-use thinpooldev::ThinPoolDev;
-
 use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+
+use {DM, DevId, DeviceInfo, DmFlags};
+use result::{DmResult, DmError, InternalError};
+use thinpooldev::ThinPoolDev;
 
 use types::Sectors;
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -79,7 +79,7 @@ impl ThinDev {
 
     /// Remove the device from DM
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
-        try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
+        try!(dm.device_remove(&DevId::Name(self.name()), DmFlags::empty()));
         Ok(())
     }
 }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -42,7 +42,7 @@ impl ThinPoolDev {
                meta: LinearDev,
                data: LinearDev)
                -> DmResult<ThinPoolDev> {
-        try!(dm.device_create(&name, None, DmFlags::empty()));
+        try!(dm.device_create(name, None, DmFlags::empty()));
 
         let meta_dev_path = try!(meta.devnode());
         let data_dev_path = try!(data.devnode());
@@ -51,7 +51,7 @@ impl ThinPoolDev {
                                           low_water_mark,
                                           &meta_dev_path,
                                           &data_dev_path);
-        let id = &DevId::Name(&name);
+        let id = &DevId::Name(name);
         let di = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
 
@@ -101,7 +101,7 @@ impl ThinPoolDev {
 
     /// Remove the device from DM
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
-        try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
+        try!(dm.device_remove(&DevId::Name(self.name()), DmFlags::empty()));
         try!(self.data_dev.teardown(dm));
         try!(self.meta_dev.teardown(dm));
         Ok(())

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use {DM, DevId, DeviceInfo, DmFlags};
+
+use result::{DmResult, DmError, InternalError};
+use lineardev::LinearDev;
+
+use std::fmt;
+use std::path::Path;
+use std::path::PathBuf;
+
+use types::DataBlocks;
+use types::Sectors;
+
+/// DM construct to contain thin provisioned devices
+pub struct ThinPoolDev {
+    dev_info: DeviceInfo,
+    meta_dev: LinearDev,
+    data_dev: LinearDev,
+}
+
+impl fmt::Debug for ThinPoolDev {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name())
+    }
+}
+
+
+/// Use DM to create a "thin-pool".  A "thin-pool" is shared space for
+/// other thin provisioned devices to use.
+///
+/// See section "Setting up a fresh pool device":
+/// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
+impl ThinPoolDev {
+    /// Construct a new ThinPoolDev with the given data and meta devs.  The
+    /// ThinPoolDev is used as backing for by ThinDev.
+    pub fn new(name: &str,
+               dm: &DM,
+               length: Sectors,
+               data_block_size: Sectors,
+               low_water_mark: DataBlocks,
+               meta: LinearDev,
+               data: LinearDev)
+               -> DmResult<ThinPoolDev> {
+        try!(dm.device_create(&name, None, DmFlags::empty()));
+
+        let meta_dev_path = try!(meta.devnode());
+        let data_dev_path = try!(data.devnode());
+        let table = ThinPoolDev::dm_table(length,
+                                          data_block_size,
+                                          low_water_mark,
+                                          &meta_dev_path,
+                                          &data_dev_path);
+        let id = &DevId::Name(&name);
+        let di = try!(dm.table_load(id, &table));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        DM::wait_for_dm();
+        Ok(ThinPoolDev {
+               dev_info: di,
+               meta_dev: meta,
+               data_dev: data,
+           })
+    }
+
+    /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
+    /// <start sec> <length> "thin-pool" /dev/meta /dev/data <block size> <low water mark>
+    fn dm_table(length: Sectors,
+                data_block_size: Sectors,
+                low_water_mark: DataBlocks,
+                meta_dev: &Path,
+                data_dev: &Path)
+                -> Vec<(u64, u64, String, String)> {
+        let params = format!("{} {} {} {} 1 skip_block_zeroing",
+                             meta_dev.to_string_lossy(),
+                             data_dev.to_string_lossy(),
+                             *data_block_size,
+                             *low_water_mark);
+        vec![(0u64, *length, "thin-pool".to_owned(), params)]
+    }
+
+    /// send a message to DM thin pool
+    pub fn message(&self, dm: &DM, message: &str) -> DmResult<()> {
+        try!(dm.target_msg(&DevId::Name(self.name()), 0, message));
+        Ok(())
+    }
+
+    /// name of the thin pool device
+    pub fn name(&self) -> &str {
+        self.dev_info.name()
+    }
+
+    /// path of the device node
+    pub fn devnode(&self) -> DmResult<PathBuf> {
+        self.dev_info
+            .device()
+            .devnode()
+            .ok_or(DmError::Dm(InternalError("No path associated with dev_info".into())))
+
+    }
+
+    /// Remove the device from DM
+    pub fn teardown(&self, dm: &DM) -> DmResult<()> {
+        try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
+        try!(self.data_dev.teardown(dm));
+        try!(self.meta_dev.teardown(dm));
+        Ok(())
+    }
+}

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -2,15 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use {DM, DevId, DeviceInfo, DmFlags};
-
-use result::{DmResult, DmError, InternalError};
-use lineardev::LinearDev;
-
 use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
 
+use {DM, DevId, DeviceInfo, DmFlags};
+use lineardev::LinearDev;
+use result::{DmResult, DmError, InternalError};
 use types::DataBlocks;
 use types::Sectors;
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -100,7 +100,7 @@ impl ThinPoolDev {
     }
 
     /// Remove the device from DM
-    pub fn teardown(&self, dm: &DM) -> DmResult<()> {
+    pub fn teardown(self, dm: &DM) -> DmResult<()> {
         try!(dm.device_remove(&DevId::Name(&self.name()), DmFlags::empty()));
         try!(self.data_dev.teardown(dm));
         try!(self.meta_dev.teardown(dm));


### PR DESCRIPTION
Move thindev and thinpool from Stratis to devicemapper-rs

Minor adjustments to the use statements to match style guide
Added comments where required due to compiler warnings if not supplied
Changed fn path() to devnode() in thindev and thinpool