### PR TITLE
ThinDev::new should take a reference to the ThinPoolDev

### DIFF
--- a/src/segment.rs
+++ b/src/segment.rs
@@ -17,11 +17,11 @@ pub struct Segment {
 
 impl Segment {
     /// Create a new Segment with given attributes
-    pub fn new(device: Device, start: u64, length: u64) -> Segment {
+    pub fn new(device: Device, start: Sectors, length: Sectors) -> Segment {
         Segment {
             device: device,
-            start: Sectors(start),
-            length: Sectors(length),
+            start: start,
+            length: length,
         }
     }
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -33,7 +33,7 @@ impl ThinDev {
     /// thin provisioned ThinDev returned by new().
     pub fn new(name: &str,
                dm: &DM,
-               thin_pool: ThinPoolDev,
+               thin_pool: &ThinPoolDev,
                thin_id: u32,
                length: Sectors)
                -> DmResult<ThinDev> {


### PR DESCRIPTION
ThinDev::new should take a reference to the ThinPoolDev
Change Segment::new() to take Sectors rather than u64