### PR TITLE
Add ThinPoolDev::setup

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -16,7 +16,7 @@ use TargetLine;
 /// A DM construct of combined Segments
 pub struct LinearDev {
     /// Data about the device
-    dev_info: DeviceInfo,
+    pub dev_info: DeviceInfo,
 }
 
 impl fmt::Debug for LinearDev {

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -4,6 +4,7 @@
 
 use std::fmt;
 use std::path::PathBuf;
+use std::process::Command;
 
 use {DM, DevId, DeviceInfo, DmFlags};
 use lineardev::LinearDev;
@@ -95,6 +96,36 @@ impl ThinPoolDev {
                meta_dev: meta,
                data_dev: data,
            })
+    }
+
+    /// Set up an existing ThinPoolDev.
+    pub fn setup(name: &str,
+                 dm: &DM,
+                 length: Sectors,
+                 data_block_size: Sectors,
+                 low_water_mark: DataBlocks,
+                 meta: LinearDev,
+                 data: LinearDev)
+                 -> DmResult<ThinPoolDev> {
+        let meta_devnode = meta.dev_info
+            .device()
+            .devnode()
+            .expect("meta device must have a devnode");
+        if try!(Command::new("thin_check")
+                .arg("-q")
+                .arg(&meta_devnode)
+                .status())
+            .success() == false {
+            return Err(DmError::Dm(InternalError("thin_check failed, run thin_repair".into())));
+        }
+
+        ThinPoolDev::new(name,
+                         dm,
+                         length,
+                         data_block_size,
+                         low_water_mark,
+                         meta,
+                         data)
     }
 
     /// Generate a Vec<> to be passed to DM. The format of the Vec


### PR DESCRIPTION
This function re-creates a previously-existing thinpool. The primary
difference between this and ThinPoolDev::new is that it calls thin_check
to verify metadata is in a good state before proceeding.

Signed-off-by: Andy Grover <agrover@redhat.com>