### PR TITLE
Add pub use declarations for DM and Device

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,3 +84,6 @@ pub mod deviceinfo;
 pub mod device;
 ///
 pub mod dm;
+
+pub use dm::DM;
+pub use device::Device;


### PR DESCRIPTION
These put DM and Device in the toplevel namespace so they can be used more
easily.

Signed-off-by: Andy Grover <agrover@redhat.com>