### PR TITLE
Change LinearDev::new block_devs arg to take &[Segment]

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -32,7 +32,7 @@ impl LinearDev {
     /// Construct a new block device by concatenating the given block_devs
     /// into linear space.  Use DM to reserve enough space for the stratis
     /// metadata on each DmDev.
-    pub fn new(name: &str, dm: &DM, block_devs: &[&Segment]) -> DmResult<LinearDev> {
+    pub fn new(name: &str, dm: &DM, block_devs: &[Segment]) -> DmResult<LinearDev> {
 
         try!(dm.device_create(name, None, DmFlags::empty()));
         let table = LinearDev::dm_table(block_devs);
@@ -46,7 +46,7 @@ impl LinearDev {
 
     /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
     /// <logical start sec> <length> "linear" /dev/xxx <start offset>
-    fn dm_table(block_devs: &[&Segment]) -> Vec<TargetLine> {
+    fn dm_table(block_devs: &[Segment]) -> Vec<TargetLine> {
         let mut table = Vec::new();
         let mut logical_start_sector = Sectors(0);
         for block_dev in block_devs {


### PR DESCRIPTION
This saves clients needing to convert a [Segment] into a [&Segment].

Signed-off-by: Andy Grover <agrover@redhat.com>