### PR TITLE
Updates for rustfmt 0.8.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-check: build test
+check: fmt build test
+
+${HOME}/.cargo/bin/cargo-fmt:
+	cargo install rustfmt --vers 0.8.3
+
+fmt: ${HOME}/.cargo/bin/cargo-fmt
+	PATH=${HOME}/.cargo/bin:${PATH} cargo fmt -- --write-mode=diff
 
 build:
 	RUSTFLAGS='-D warnings' cargo build --verbose
@@ -7,6 +13,7 @@ test:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test --verbose
 
 .PHONY:
-	build
 	check
+	fmt
+	build
 	test

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -115,8 +115,8 @@ impl DM {
         let op = iorw!(DM_IOCTL, ioctl, size_of::<dmi::Struct_dm_ioctl>()) as c_ulong;
         loop {
             if let Err(_) = unsafe {
-                convert_ioctl_res!(nix_ioctl(self.file.as_raw_fd(), op, v.as_mut_ptr()))
-            } {
+                   convert_ioctl_res!(nix_ioctl(self.file.as_raw_fd(), op, v.as_mut_ptr()))
+               } {
                 return Err((DmError::Io(Error::last_os_error())));
             }
 
@@ -300,7 +300,7 @@ impl DM {
 
         if new_name.as_bytes().len() > max_len {
             return Err(DmError::Dm(InternalError(format!("New name {} too long", new_name)
-                .into())));
+                                                     .into())));
         }
 
         let mut data_in = new_name.as_bytes().to_vec();
@@ -401,7 +401,10 @@ impl DM {
     ///
     /// `targets` is an array of (sector_start, sector_length, type, params).
     ///
-    /// `params` are target-specific, please see [Linux kernel documentation](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/device-mapper) for more.
+    /// `params` are target-specific, please see [Linux kernel documentation]
+    /// https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/ ->
+    /// Documentation/device-mapper
+    /// for more.
     ///
     /// # Example
     ///
@@ -643,8 +646,8 @@ impl DM {
                         .unwrap()
                 };
 
-                let name_slc =
-                    slice_to_null(&result[size_of::<dmi::Struct_dm_target_versions>()..])
+                let name_slc = slice_to_null(&result
+                                                  [size_of::<dmi::Struct_dm_target_versions>()..])
                         .expect("bad data from ioctl");
                 let name = String::from_utf8_lossy(name_slc).into_owned();
                 targets.push((name, tver.version[0], tver.version[1], tver.version[2]));
@@ -758,7 +761,8 @@ mod tests {
         println!("{:?}", deps);
 
         println!("Calling table_status() INFO");
-        let status_info = dmi.table_status(&DevId::Name(&name), DmFlags::empty()).unwrap();
+        let status_info = dmi.table_status(&DevId::Name(&name), DmFlags::empty())
+            .unwrap();
         println!("{:?}", status_info.1);
 
         println!("Calling table_status() TABLE");
@@ -766,7 +770,8 @@ mod tests {
             .unwrap();
         println!("{:?}", status.1);
 
-        dmi.device_remove(&DevId::Name(&name), DmFlags::empty()).unwrap();
+        dmi.device_remove(&DevId::Name(&name), DmFlags::empty())
+            .unwrap();
 
     }
 }

--- a/src/dm_ioctl.rs
+++ b/src/dm_ioctl.rs
@@ -14,11 +14,12 @@ pub struct Struct_Unnamed1 {
     pub fds_bits: [::libc::c_ulong; 16usize],
 }
 impl ::std::default::Default for Struct_Unnamed1 {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 pub type __kernel_fd_set = Struct_Unnamed1;
-pub type __kernel_sighandler_t =
-    ::std::option::Option<extern "C" fn(arg1: ::libc::c_int) -> ()>;
+pub type __kernel_sighandler_t = ::std::option::Option<extern "C" fn(arg1: ::libc::c_int) -> ()>;
 pub type __kernel_key_t = ::libc::c_int;
 pub type __kernel_mqd_t = ::libc::c_int;
 pub type __kernel_old_uid_t = ::libc::c_ushort;
@@ -45,7 +46,9 @@ pub struct Struct_Unnamed2 {
     pub val: [::libc::c_int; 2usize],
 }
 impl ::std::default::Default for Struct_Unnamed2 {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 pub type __kernel_fsid_t = Struct_Unnamed2;
 pub type __kernel_off_t = __kernel_long_t;
@@ -82,10 +85,14 @@ pub struct Struct_dm_ioctl {
     pub data: [::libc::c_char; 7usize],
 }
 impl ::std::clone::Clone for Struct_dm_ioctl {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 impl ::std::default::Default for Struct_dm_ioctl {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -97,7 +104,9 @@ pub struct Struct_dm_target_spec {
     pub target_type: [::libc::c_char; 16usize],
 }
 impl ::std::default::Default for Struct_dm_target_spec {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -107,7 +116,9 @@ pub struct Struct_dm_target_deps {
     pub dev: [__u64; 0usize],
 }
 impl ::std::default::Default for Struct_dm_target_deps {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -117,7 +128,9 @@ pub struct Struct_dm_name_list {
     pub name: [::libc::c_char; 0usize],
 }
 impl ::std::default::Default for Struct_dm_name_list {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -127,7 +140,9 @@ pub struct Struct_dm_target_versions {
     pub name: [::libc::c_char; 0usize],
 }
 impl ::std::default::Default for Struct_dm_target_versions {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -136,7 +151,9 @@ pub struct Struct_dm_target_msg {
     pub message: [::libc::c_char; 0usize],
 }
 impl ::std::default::Default for Struct_dm_target_msg {
-    fn default() -> Self { unsafe { ::std::mem::zeroed() } }
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
 }
 pub type Enum_Unnamed3 = ::libc::c_uint;
 pub const DM_VERSION_CMD: ::libc::c_uint = 0;

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -57,10 +57,10 @@ impl ThinDev {
         try!(dm.device_suspend(id, DmFlags::empty()));
         DM::wait_for_dm();
         Ok(ThinDev {
-            dev_info: di,
-            thin_id: thin_id,
-            size: length,
-        })
+               dev_info: di,
+               thin_id: thin_id,
+               size: length,
+           })
     }
 
     /// Generate a Vec<> to be passed to DM. The format of the Vec

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -92,10 +92,10 @@ impl ThinPoolDev {
 
         DM::wait_for_dm();
         Ok(ThinPoolDev {
-            dev_info: di,
-            meta_dev: meta,
-            data_dev: data,
-        })
+               dev_info: di,
+               meta_dev: meta,
+               data_dev: data,
+           })
     }
 
     /// Set up an existing ThinPoolDev.
@@ -112,10 +112,10 @@ impl ThinPoolDev {
             .devnode()
             .expect("meta device must have a devnode");
         if try!(Command::new("thin_check")
-                .arg("-q")
-                .arg(&meta_devnode)
-                .status())
-            .success() == false {
+                    .arg("-q")
+                    .arg(&meta_devnode)
+                    .status())
+                   .success() == false {
             return Err(DmError::Dm(InternalError("thin_check failed, run thin_repair".into())));
         }
 


### PR DESCRIPTION

Update the code using rustfmt 0.8.3 as needed
Update the Makefile to include a format check as part of CI
Allow for 110 character line length.  The default is 100.  The code had a pointer to a long
URL.  I think allowing 110 is better than removing the comment.