### PR TITLE
Thindev setup & destroy

### DIFF
--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -41,8 +41,8 @@ pub enum ThinStatus {
 
 /// support use of DM for thin provisioned devices over pools
 impl ThinDev {
-    /// Use the given ThinPoolDev as backing space for a newly constructed
-    /// thin provisioned ThinDev returned by new().
+    /// Use the given ThinPoolDev as backing space for a newly
+    /// constructed thin provisioned ThinDev.
     pub fn new(name: &str,
                dm: &DM,
                thin_pool: &ThinPoolDev,
@@ -51,16 +51,26 @@ impl ThinDev {
                -> DmResult<ThinDev> {
 
         try!(thin_pool.message(dm, &format!("create_thin {}", thin_id)));
+        ThinDev::setup(name, dm, thin_pool, thin_id, length)
+    }
+
+    /// Create the device for an existing thin volume.
+    pub fn setup(name: &str,
+                 dm: &DM,
+                 thin_pool: &ThinPoolDev,
+                 thin_id: u32,
+                 length: Sectors)
+                 -> DmResult<ThinDev> {
         try!(dm.device_create(name, None, DmFlags::empty()));
         let id = &DevId::Name(name);
         let di = try!(dm.table_load(&id, &ThinDev::dm_table(&thin_pool, thin_id, length)));
         try!(dm.device_suspend(id, DmFlags::empty()));
         DM::wait_for_dm();
         Ok(ThinDev {
-            dev_info: di,
-            thin_id: thin_id,
-            size: length,
-        })
+               dev_info: di,
+               thin_id: thin_id,
+               size: length,
+           })
     }
 
     /// Generate a Vec<> to be passed to DM. The format of the Vec

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -125,7 +125,16 @@ impl ThinDev {
                                          .expect("highest mapped sector value must be valid")))))
     }
 
-    /// Remove the device from DM
+    /// Remove the thin device.
+    pub fn destroy(self, dm: &DM, thin_pool: &ThinPoolDev) -> DmResult<()> {
+        let id = self.thin_id;
+        try!(self.teardown(dm));
+        try!(thin_pool.message(dm, &format!("delete {}", id)));
+
+        Ok(())
+    }
+
+    /// Tear down the DM device.
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
         try!(dm.device_remove(&DevId::Name(self.name()), DmFlags::empty()));
         Ok(())


### PR DESCRIPTION
Please especially look at the second commit -- it needs a `&ThinPoolDev` to send the message, but it's not clear how to acquire this in the likely caller, `StratFilesystem::destroy()`.

This suggests we should consider refactoring something on either the dm-rs or stratisd sides to make this work better. Thoughts? Maybe we don't need destroy in the Filesystem trait, just have Pool::destroy_filesystems do it directly?

