### PR TITLE
Add ThinDev::extend()

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::fs::File;
 use std::path::PathBuf;
 
-use consts::DmFlags;
+use consts::{DmFlags, DM_SUSPEND};
 use deviceinfo::DeviceInfo;
 use dm::{DM, DevId};
 use result::{DmResult, DmError, InternalError};
@@ -18,6 +18,7 @@ use util::blkdev_size;
 pub struct LinearDev {
     /// Data about the device
     pub dev_info: DeviceInfo,
+    segments: Vec<Segment>,
 }
 
 impl fmt::Debug for LinearDev {
@@ -32,21 +33,27 @@ impl LinearDev {
     /// Construct a new block device by concatenating the given block_devs
     /// into linear space.  Use DM to reserve enough space for the stratis
     /// metadata on each DmDev.
-    pub fn new(name: &str, dm: &DM, block_devs: &[Segment]) -> DmResult<LinearDev> {
+    pub fn new(name: &str, dm: &DM, block_devs: Vec<Segment>) -> DmResult<LinearDev> {
+        assert_ne!(block_devs.len(), 0);
 
         try!(dm.device_create(name, None, DmFlags::empty()));
-        let table = LinearDev::dm_table(block_devs);
+        let table = LinearDev::dm_table(&block_devs);
         let id = &DevId::Name(name);
         let dev_info = try!(dm.table_load(id, &table));
         try!(dm.device_suspend(id, DmFlags::empty()));
 
         DM::wait_for_dm();
-        Ok(LinearDev { dev_info: dev_info })
+        Ok(LinearDev {
+               dev_info: dev_info,
+               segments: block_devs,
+           })
     }
 
     /// Generate a Vec<> to be passed to DM.  The format of the Vec entries is:
     /// <logical start sec> <length> "linear" /dev/xxx <start offset>
     fn dm_table(block_devs: &[Segment]) -> Vec<TargetLine> {
+        assert_ne!(block_devs.len(), 0);
+
         let mut table = Vec::new();
         let mut logical_start_sector = Sectors(0);
         for block_dev in block_devs {
@@ -61,6 +68,42 @@ impl LinearDev {
         }
 
         table
+    }
+
+    /// Extend an existing LinearDev with additional new segments.
+    pub fn extend(&mut self, new_segs: Vec<Segment>) -> DmResult<()> {
+        // Last existing and first new may be contiguous. Coalesce into
+        // a single Segment if so.
+        let coalesced_new_first = {
+            let mut old_last = self.segments
+                .last_mut()
+                .expect("Existing segment list must not be empty");
+            let new_first = new_segs.first().expect("new_segs must not be empty");
+            if old_last.device == new_first.device &&
+               (old_last.start + old_last.length == new_first.start) {
+                old_last.length = old_last.length + new_first.length;
+                true
+            } else {
+                false
+            }
+        };
+
+        if coalesced_new_first {
+            self.segments.extend(new_segs.into_iter().skip(1));
+        } else {
+            self.segments.extend(new_segs);
+        }
+
+        let table = LinearDev::dm_table(&self.segments);
+
+        let dm = try!(DM::new());
+        let id = &DevId::Name(self.name());
+
+        try!(dm.table_load(id, &table));
+        try!(dm.device_suspend(id, DM_SUSPEND));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+
+        Ok(())
     }
 
     /// DM name - from the DeviceInfo struct

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -9,9 +9,12 @@ use device::Device;
 /// struct to represent a continuous set of sectors on a disk
 #[derive(Debug)]
 pub struct Segment {
-    start: Sectors,
-    length: Sectors,
-    device: Device,
+    /// The offset into the device where this segment starts.
+    pub start: Sectors,
+    /// The length of the segment.
+    pub length: Sectors,
+    /// The device the segment is within.
+    pub device: Device,
 }
 
 


### PR DESCRIPTION
This method extends the thin volume's logical size by the number of
sectors given.

Since this involves reloading the device's table after initialization, it
was necessary to remember the associated thinpool's dstr so we could
properly reload its table. Modifying ThinDev::dm_table args was also
needed.

Signed-off-by: Andy Grover <agrover@redhat.com>