### PR TITLE
Add methods to get size as sectors and the thin id from a ThinDev

### DIFF
--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -82,9 +82,19 @@ impl ThinDev {
         self.dev_info.device().dstr()
     }
 
+    /// return the total size of the linear device in sectors
+    pub fn sectors(&self) -> Sectors {
+        self.size
+    }
+
     /// return the total size of the linear device
     pub fn size(&self) -> Bytes {
         self.size.bytes()
+    }
+
+    /// return the thin id of the linear device
+    pub fn id(&self) -> u32 {
+        self.thin_id
     }
 
     /// path of the device node


### PR DESCRIPTION
stratisd also needs to get the thin device's size in sectors, since that's
how it saves it in metadata (at least for right now).

It also needs the thin id, for the same reason.

Signed-off-by: Andy Grover <agrover@redhat.com>