### PR TITLE
Be nice to vi users by ignoring .swp files as well as .swo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .settings
 
 *.swo
+*.swp


### PR DESCRIPTION
So they don't get accidentally included in commits.

Signed-off-by: mulhern <amulhern@redhat.com>