### PR TITLE
Avoid redundannt methods

### DIFF
--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -12,7 +12,7 @@ use result::{DmResult, DmError, InternalError};
 use thinpooldev::ThinPoolDev;
 use types::TargetLine;
 
-use types::{Bytes, Sectors};
+use types::Sectors;
 
 /// DM construct for a thin block device
 pub struct ThinDev {
@@ -82,14 +82,9 @@ impl ThinDev {
         self.dev_info.device().dstr()
     }
 
-    /// return the total size of the linear device in sectors
-    pub fn sectors(&self) -> Sectors {
-        self.size
-    }
-
     /// return the total size of the linear device
-    pub fn size(&self) -> Bytes {
-        self.size.bytes()
+    pub fn size(&self) -> Sectors {
+        self.size
     }
 
     /// return the thin id of the linear device


### PR DESCRIPTION
Sectors and Bytes are differently interconvertible by means of the
methods bytes() and sectors(). sectors() has been carefully defined
to do something sensible when the value is not a whole number of sectors.

If thindev size will always be in granularity of sectors, then it is
reasonable for the unique size() method to return Sectors.

On the other hand, if thindev size will not always be in granularity of
sectors, then it would be best to have the unique size() method return
Bytes.

This commit assumes that the thindev size will always in granularity of
sectors.

Signed-off-by: mulhern <amulhern@redhat.com>