### PR TITLE
Make Segment implement Serialize and Deserialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ clippy = { version = "0", optional = true }
 newtype_derive = "0.1"
 custom_derive = "0.1"
 serde = "1"
+serde_derive = "1"
 log = "0.3"
 env_logger="0.3.5"

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,7 +12,7 @@ use std::os::unix::fs::MetadataExt;
 /// A struct containing the device's major and minor numbers
 ///
 /// Also allows conversion to/from a single 64bit value.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Serialize, Deserialize)]
 pub struct Device {
     /// Device major number
     pub major: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ extern crate libc;
 extern crate nix;
 extern crate serde;
 #[macro_use]
+extern crate serde_derive;
+#[macro_use]
 extern crate bitflags;
 
 #[macro_use]

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -7,7 +7,7 @@ use types::Sectors;
 use device::Device;
 
 /// struct to represent a continuous set of sectors on a disk
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Segment {
     /// The offset into the device where this segment starts.
     pub start: Sectors,


### PR DESCRIPTION
Stratis would like to store and retrieve information encoded
as Segments. Do the same for Device, since Segment uses it.

Signed-off-by: mulhern <amulhern@redhat.com>