### PR TITLE
Adapt for change in 4.12+ kernels

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -145,7 +145,8 @@ impl DM {
         hdr_slc.clone_from_slice(&v[..hdr.data_start as usize]);
 
         // Maybe we got some add'l data back?
-        Ok(v[hdr.data_start as usize..hdr.data_size as usize].to_vec())
+        let new_data_off = cmp::max(hdr.data_start, hdr.data_size);
+        Ok(v[hdr.data_start as usize..new_data_off as usize].to_vec())
     }
 
     /// Devicemapper version information: Major, Minor, and patchlevel versions.


### PR DESCRIPTION
See https://www.spinics.net/lists/stable/msg170390.html and 4617f564c in
the Linux kernel repo.

We were assuming hdr.data_size was always greater or equal to
hdr.data_start, but this is no longer the case.

This kernel change is also widely backported to previous kernel versions'
stable branches.

fixes #50

Signed-off-by: Andy Grover <agrover@redhat.com>