### PR TITLE
Add CheckFailed to Error enum

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -16,6 +16,8 @@ pub enum ErrorEnum {
     Invalid,
     /// something not found
     NotFound,
+    /// Check failed
+    CheckFailed,
 }
 
 impl fmt::Display for ErrorEnum {

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -112,7 +112,7 @@ impl ThinPoolDev {
                     .arg(&try!(meta.devnode()))
                     .status())
                    .success() == false {
-            return Err(DmError::Dm(ErrorEnum::Error,
+            return Err(DmError::Dm(ErrorEnum::CheckFailed,
                                    "thin_check failed, run thin_repair".into()));
         }
 


### PR DESCRIPTION
Clients need to distinguish if thin_check is the cause of the failure, so
that they may handle it, such as by running thin_repair.

Signed-off-by: Andy Grover <agrover@redhat.com>