### PR TITLE
Since thindev ids are inconveniently special, give them a type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,5 +91,5 @@ pub use lineardev::LinearDev;
 pub use result::{DmResult, DmError, ErrorEnum};
 pub use segment::Segment;
 pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
-pub use thindev::{ThinDev, ThinStatus};
+pub use thindev::{ThinDev, ThinDevId, ThinStatus};
 pub use types::{Bytes, DataBlocks, Sectors};


### PR DESCRIPTION
The type can be amended or improved later, but at least it gives something
close to the maximally random number now.

Signed-off-by: mulhern <amulhern@redhat.com>