### PR TITLE
Add a Makefile target that runs only non-root tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-check: fmt build test
+check: fmt build sudo_test
 
 ${HOME}/.cargo/bin/cargo-fmt:
 	cargo install rustfmt --vers 0.8.3
@@ -10,6 +10,9 @@ build:
 	RUSTFLAGS='-D warnings' cargo build --verbose
 
 test:
+	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test --verbose -- --skip test_basics
+
+sudo_test:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test --verbose
 
 .PHONY:
@@ -17,3 +20,4 @@ test:
 	fmt
 	build
 	test
+	sudo_test


### PR DESCRIPTION
It is convenient to run basic unit tests and non-running doc tests
on one's own system.

On the CI, continue to run all tests as root.

This is a somewhat temporary expedient. If more tests that require root
are added, it may pay to better distinguish between the different types of
tests.

Signed-off-by: mulhern <amulhern@redhat.com>