### PR TITLE
Make ThinDev implementation generic on its id type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,5 +91,5 @@ pub use lineardev::LinearDev;
 pub use result::{DmResult, DmError, ErrorEnum};
 pub use segment::Segment;
 pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
-pub use thindev::{ThinDev, ThinStatus};
+pub use thindev::{ThinDev, ThinDevId, ThinStatus};
 pub use types::{Bytes, DataBlocks, Sectors};


### PR DESCRIPTION
Clients can implement the id, but it has a type that can be recognized.
This is an improvement over the uninformative type u32.

Signed-off-by: mulhern <amulhern@redhat.com>