### PR TITLE
Add extend to thinpooldev

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -487,6 +487,21 @@ impl DM {
         Ok(DeviceInfo { hdr: hdr })
     }
 
+    /// Reload the table for a device
+    pub fn table_reload<T1, T2>(&self,
+                                dm: &DM,
+                                id: &DevId,
+                                table: &[(u64, u64, T1, T2)])
+                                -> DmResult<()>
+        where T1: Borrow<str>,
+              T2: Borrow<str>
+    {
+        try!(dm.table_load(id, table));
+        try!(dm.device_suspend(id, DM_SUSPEND));
+        try!(dm.device_suspend(id, DmFlags::empty()));
+        Ok(())
+    }
+
     /// Clear the "inactive" table for a device.
     pub fn table_clear(&self, name: &DevId) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -19,6 +19,7 @@ pub struct ThinPoolDev {
     meta_dev: LinearDev,
     data_dev: LinearDev,
     data_block_size: Sectors,
+    low_water_mark: DataBlocks,
 }
 
 impl fmt::Debug for ThinPoolDev {
@@ -97,6 +98,7 @@ impl ThinPoolDev {
                meta_dev: meta,
                data_dev: data,
                data_block_size: data_block_size,
+               low_water_mark: low_water_mark,
            })
     }
 


### PR DESCRIPTION

extend() function for ThinPoolDev is needed to allow users to extend the segments allocated
to the meta and data backing devices.