### PR TITLE
Get rid of all allusions to clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MPL-2.0"
 libc = "0.2"
 nix = "0.5"
 bitflags = "0.4"
-clippy = { version = "0", optional = true }
 newtype_derive = "0.1"
 custom_derive = "0.1"
 serde = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,14 +36,7 @@
 //! Devices have "active" and "inactive" mapping tables. See function
 //! descriptions for which table they affect.
 
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(not(feature = "clippy"), allow(unknown_lints))]
-
 #![warn(missing_docs)]
-
-#![allow(used_underscore_binding)]
-#![allow(if_not_else)]
 
 #[macro_use]
 extern crate custom_derive;


### PR DESCRIPTION
It hasn't figured in CI for quite a while.

Signed-off-by: mulhern <amulhern@redhat.com>