### PR TITLE
Improve CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,21 @@ before_install:
     - sudo apt-get install -y libdevmapper-dev
 
 language: rust
-rust: stable
+
+matrix:
+    allow_failures:
+        - env: TASK=clippy
+    include:        
+        - rust: stable
+          env: TASK=fmt
+        - rust: stable
+          env: TASK=build
+        - rust: stable
+          env: TASK=sudo_test
+        - rust: nightly
+          env: TASK=clippy
 
 branches:
     only: master
 
-script: make check
+script: make -f Makefile $TASK 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ custom_derive = "0.1"
 serde = "1"
 log = "0.3"
 env_logger="0.3.5"
+clippy = {version = "*", optional = true}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-check: fmt build sudo_test
-
 ${HOME}/.cargo/bin/cargo-fmt:
 	cargo install rustfmt --vers 0.8.3
 
@@ -7,17 +5,20 @@ fmt: ${HOME}/.cargo/bin/cargo-fmt
 	PATH=${HOME}/.cargo/bin:${PATH} cargo fmt -- --write-mode=diff
 
 build:
-	RUSTFLAGS='-D warnings' cargo build --verbose
+	RUSTFLAGS='-D warnings' cargo build
 
 test:
-	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test --verbose -- --skip test_basics
+	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip test_basics
 
 sudo_test:
-	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test --verbose
+	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test
+
+clippy:
+	RUSTFLAGS='-D warnings' cargo build --features "clippy" --verbose
 
 .PHONY:
-	check
 	fmt
 	build
 	test
 	sudo_test
+	clippy

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -50,6 +50,7 @@ bitflags!(
     flags DmFlags: dmi::__u32 {
         /// In: Device should be read-only.
         /// Out: Device is read-only.
+        #[allow(identity_op)]
         const DM_READONLY             = (1 << 0),
         /// In: Device should be suspended.
         /// Out: Device is suspended.

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -41,7 +41,7 @@ pub const DM_VERSION_PATCHLEVEL: u32 = 0;
 pub const DM_NAME_LEN: usize = 128;
 /// UUID max length
 pub const DM_UUID_LEN: usize = 129;
-/// Start with a large buffer to make BUFFER_FULL rare. Libdm does this too.s
+/// Start with a large buffer to make BUFFER_FULL rare. Libdm does this too.
 pub const MIN_BUF_SIZE: usize = 16 * 1024;
 
 

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -114,10 +114,9 @@ impl DM {
 
         let op = iorw!(DM_IOCTL, ioctl, size_of::<dmi::Struct_dm_ioctl>()) as c_ulong;
         loop {
-            if let Err(_) = unsafe {
-                   convert_ioctl_res!(nix_ioctl(self.file.as_raw_fd(), op, v.as_mut_ptr()))
-               } {
-                return Err((DmError::Io(Error::last_os_error())));
+            if unsafe { convert_ioctl_res!(nix_ioctl(self.file.as_raw_fd(), op, v.as_mut_ptr())) }
+                   .is_err() {
+                return Err(DmError::Io(Error::last_os_error()));
             }
 
             let hdr = unsafe {
@@ -562,7 +561,7 @@ impl DM {
     // unify table status parsing.
     fn parse_table_status(count: u32, buf: &[u8]) -> DmResult<Vec<TargetLine>> {
         let mut targets = Vec::new();
-        if buf.len() > 0 {
+        if !buf.is_empty() {
             let mut next_off = 0;
             let mut result = &buf[..];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(not(features = "clippy"), allow(unknown_lints))]
 
+#![allow(doc_markdown)]
+
 #![warn(missing_docs)]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,10 @@
 //! Devices have "active" and "inactive" mapping tables. See function
 //! descriptions for which table they affect.
 
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
+#![cfg_attr(not(features = "clippy"), allow(unknown_lints))]
+
 #![warn(missing_docs)]
 
 #[macro_use]

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -72,7 +72,7 @@ impl LinearDev {
                         format!("{} {}", block_dev.device.dstr(), *start));
             debug!("dmtable line : {:?}", line);
             table.push(line);
-            logical_start_sector = logical_start_sector + length;
+            logical_start_sector += length;
         }
 
         table
@@ -93,7 +93,7 @@ impl LinearDev {
             let new_first = new_segs.first().expect("new_segs must not be empty");
             if old_last.device == new_first.device &&
                (old_last.start + old_last.length == new_first.start) {
-                old_last.length = old_last.length + new_first.length;
+                old_last.length += new_first.length;
                 true
             } else {
                 false

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -115,7 +115,7 @@ impl ThinDev {
         try!(dm.device_create(name, None, DmFlags::empty()));
         let id = &DevId::Name(name);
         let thin_pool_dstr = thin_pool.dstr();
-        let di = try!(dm.table_load(&id, &ThinDev::dm_table(&thin_pool_dstr, thin_id, length)));
+        let di = try!(dm.table_load(id, &ThinDev::dm_table(&thin_pool_dstr, thin_id, length)));
         try!(dm.device_suspend(id, DmFlags::empty()));
         DM::wait_for_dm();
         Ok(ThinDev {
@@ -166,11 +166,12 @@ impl ThinDev {
 
     /// Get the current status of the thin device.
     pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
-        let (_, mut status) = try!(dm.table_status(&DevId::Name(&self.dev_info.name()),
+        let (_, mut status) = try!(dm.table_status(&DevId::Name(self.dev_info.name()),
                                                    DmFlags::empty()));
 
-        assert!(status.len() == 1,
-                "Kernel must return 1 line from thin status");
+        assert_eq!(status.len(),
+                   1,
+                   "Kernel must return 1 line from thin status");
 
         let status_line = status.pop().expect("assertion above holds").3;
         if status_line.starts_with("Fail") {
@@ -193,9 +194,9 @@ impl ThinDev {
     /// sectors given.
     pub fn extend(&mut self, dm: &DM, sectors: Sectors) -> DmResult<()> {
 
-        self.size = self.size + sectors;
+        self.size += sectors;
 
-        let id = &DevId::Name(&self.dev_info.name());
+        let id = &DevId::Name(self.dev_info.name());
 
         try!(dm.table_load(id,
                            &ThinDev::dm_table(&self.thinpool_dstr, self.thin_id, self.size)));

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -127,11 +127,11 @@ impl ThinPoolDev {
                  meta: LinearDev,
                  data: LinearDev)
                  -> DmResult<ThinPoolDev> {
-        if try!(Command::new("thin_check")
-                    .arg("-q")
-                    .arg(&try!(meta.devnode()))
-                    .status())
-                   .success() == false {
+        if !try!(Command::new("thin_check")
+                     .arg("-q")
+                     .arg(&try!(meta.devnode()))
+                     .status())
+                    .success() {
             return Err(DmError::Dm(ErrorEnum::CheckFailed(meta, data),
                                    "thin_check failed, run thin_repair".into()));
         }
@@ -245,7 +245,7 @@ impl ThinPoolDev {
 
     /// Reload the devie mapper table.
     fn table_reload(&self, dm: &DM) -> DmResult<()> {
-        try!(dm.table_reload(&dm,
+        try!(dm.table_reload(dm,
                              &DevId::Name(self.name()),
                              &ThinPoolDev::dm_table(try!(self.data_dev.size()),
                                                     self.data_block_size,


### PR DESCRIPTION
Break out the various targets into separate runs and add clippy target
back in as an allowed failure.

Signed-off-by: mulhern <amulhern@redhat.com>