### PR TITLE
Small fixes having to do with DeviceInfo

### DIFF
--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -15,10 +15,14 @@ use util::slice_to_null;
 pub struct DeviceInfo {
     /// ioclt arugument consits of a single chunk of memory, with this
     /// structure at the start.
-    pub hdr: dmi::Struct_dm_ioctl,
+    hdr: dmi::Struct_dm_ioctl,
 }
 
 impl DeviceInfo {
+    pub fn new(hdr: dmi::Struct_dm_ioctl) -> DeviceInfo {
+        DeviceInfo { hdr }
+    }
+
     /// The major, minor, and patchlevel versions of devicemapper.
     pub fn version(&self) -> (u32, u32, u32) {
         (self.hdr.version[0], self.hdr.version[1], self.hdr.version[2])

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -246,7 +246,7 @@ impl DM {
 
         try!(self.do_ioctl(dmi::DM_DEV_CREATE_CMD as u8, &mut hdr, None));
 
-        Ok(DeviceInfo { hdr: hdr })
+        Ok(DeviceInfo::new(hdr))
     }
 
     /// Remove a DM device and its mapping tables.
@@ -269,7 +269,7 @@ impl DM {
 
         try!(self.do_ioctl(dmi::DM_DEV_REMOVE_CMD as u8, &mut hdr, None));
 
-        Ok(DeviceInfo { hdr: hdr })
+        Ok(DeviceInfo::new(hdr))
     }
 
     /// Change a DM device's name.
@@ -306,7 +306,7 @@ impl DM {
 
         try!(self.do_ioctl(dmi::DM_DEV_RENAME_CMD as u8, &mut hdr, Some(&data_in)));
 
-        Ok(DeviceInfo { hdr: hdr })
+        Ok(DeviceInfo::new(hdr))
     }
 
     /// Suspend or resume a DM device, depending on if DM_SUSPEND flag
@@ -345,7 +345,7 @@ impl DM {
 
         try!(self.do_ioctl(dmi::DM_DEV_SUSPEND_CMD as u8, &mut hdr, None));
 
-        Ok(DeviceInfo { hdr: hdr })
+        Ok(DeviceInfo::new(hdr))
     }
 
     /// Get DeviceInfo for a device. This is also returned by other
@@ -363,7 +363,7 @@ impl DM {
 
         try!(self.do_ioctl(dmi::DM_DEV_STATUS_CMD as u8, &mut hdr, None));
 
-        Ok(DeviceInfo { hdr: hdr })
+        Ok(DeviceInfo::new(hdr))
     }
 
     /// Wait for a device to report an event.
@@ -391,7 +391,7 @@ impl DM {
 
         let status = try!(Self::parse_table_status(hdr.target_count, &data_out));
 
-        Ok((DeviceInfo { hdr: hdr }, status))
+        Ok((DeviceInfo::new(hdr), status))
 
     }
 
@@ -482,7 +482,7 @@ impl DM {
 
         try!(self.do_ioctl(dmi::DM_TABLE_LOAD_CMD as u8, &mut hdr, Some(&data_in)));
 
-        Ok(DeviceInfo { hdr: hdr })
+        Ok(DeviceInfo::new(hdr))
     }
 
     /// Reload the table for a device
@@ -513,7 +513,7 @@ impl DM {
 
         try!(self.do_ioctl(dmi::DM_TABLE_CLEAR_CMD as u8, &mut hdr, None));
 
-        Ok(DeviceInfo { hdr: hdr })
+        Ok(DeviceInfo::new(hdr))
     }
 
     /// Query DM for which devices are referenced by the "active"
@@ -639,7 +639,7 @@ impl DM {
 
         let status = try!(Self::parse_table_status(hdr.target_count, &data_out));
 
-        Ok((DeviceInfo { hdr: hdr }, status))
+        Ok((DeviceInfo::new(hdr), status))
     }
 
     /// Returns a list of each loaded target type with its name, and
@@ -710,7 +710,7 @@ impl DM {
 
         let data_out = try!(self.do_ioctl(dmi::DM_TARGET_MSG_CMD as u8, &mut hdr, Some(&data_in)));
 
-        Ok((DeviceInfo { hdr: hdr },
+        Ok((DeviceInfo::new(hdr),
             if (hdr.flags & DM_DATA_OUT.bits()) > 0 {
                 Some(String::from_utf8_lossy(&data_out[..data_out.len() - 1]).into_owned())
             } else {

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -17,7 +17,7 @@ use util::blkdev_size;
 /// A DM construct of combined Segments
 pub struct LinearDev {
     /// Data about the device
-    dev_info: DeviceInfo,
+    dev_info: Box<DeviceInfo>,
     segments: Vec<Segment>,
 }
 
@@ -42,7 +42,7 @@ impl LinearDev {
         try!(dm.device_create(name, None, DmFlags::empty()));
         let table = LinearDev::dm_table(&segments);
         let id = &DevId::Name(name);
-        let dev_info = try!(dm.table_load(id, &table));
+        let dev_info = Box::new(try!(dm.table_load(id, &table)));
         try!(dm.device_suspend(id, DmFlags::empty()));
 
         DM::wait_for_dm();
@@ -125,7 +125,8 @@ impl LinearDev {
 
     /// Set the name for this LinearDev.
     pub fn set_name(&mut self, dm: &DM, name: &str) -> DmResult<()> {
-        self.dev_info = try!(dm.device_rename(self.dev_info.name(), name, DmFlags::empty()));
+        self.dev_info =
+            Box::new(try!(dm.device_rename(self.dev_info.name(), name, DmFlags::empty())));
 
         Ok(())
     }


### PR DESCRIPTION
Give it a constructor and make hdr private.
Box it in LinearDev to make LinearDev cost less to move.