### PR TITLE
Revert "Make device_rename idempotent"

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -278,6 +278,7 @@ impl DM {
     ///
     /// Valid flags: DM_UUID
     ///
+    /// Prerequisite: old_name != new_name
     /// Note: Possibly surprisingly, returned DeviceInfo's name field
     /// contains the previous name, not the new name.
     pub fn device_rename(&self,
@@ -285,10 +286,6 @@ impl DM {
                          new_name: &str,
                          flags: DmFlags)
                          -> DmResult<DeviceInfo> {
-        if old_name == new_name {
-            return self.device_status(&DevId::Name(old_name));
-        }
-
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         let clean_flags = DM_UUID & flags;
@@ -803,13 +800,14 @@ mod tests {
     }
 
     #[test]
-    /// Test that device rename to same name succeeds.
+    /// Test that device rename to same name fails.
+    /// This is unfortunate, but appears to be true.
     fn sudo_test_rename_id() {
         let dm = DM::new().unwrap();
         let name = "example-dev";
         dm.device_create(name, None, DmFlags::empty()).unwrap();
         DM::wait_for_dm();
-        assert!(dm.device_rename(name, name, DmFlags::empty()).is_ok());
+        assert!(dm.device_rename(name, name, DmFlags::empty()).is_err());
         dm.device_remove(&DevId::Name(name), DmFlags::empty())
             .unwrap();
     }


### PR DESCRIPTION
This reverts commit b54dcd1caa353b5510a980034761425a11926aae.

It only works properly for a name, but "name" might be a UUID.

Signed-off-by: mulhern <amulhern@redhat.com>