### PR TITLE
define a type for MetaBlocks to be used for tracking thin-meta use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,4 +91,4 @@ pub use result::{DmResult, DmError, ErrorEnum};
 pub use segment::Segment;
 pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
 pub use thindev::{ThinDev, ThinDevId, ThinStatus};
-pub use types::{Bytes, DataBlocks, Sectors};
+pub use types::{Bytes, DataBlocks, MetaBlocks, Sectors};

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -12,7 +12,7 @@ use dm::{DM, DevId};
 use lineardev::LinearDev;
 use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
-use types::{DataBlocks, Sectors, TargetLine};
+use types::{DataBlocks, MetaBlocks, Sectors, TargetLine};
 
 /// DM construct to contain thin provisioned devices
 pub struct ThinPoolDev {
@@ -34,9 +34,9 @@ impl fmt::Debug for ThinPoolDev {
 /// allocations for metadata and data blocks.
 pub struct ThinPoolBlockUsage {
     /// The number of metadata blocks that are in use.
-    pub used_meta: u64,
+    pub used_meta: MetaBlocks,
     /// The total number of metadata blocks available to the thinpool.
-    pub total_meta: u64,
+    pub total_meta: MetaBlocks,
     /// The number of data blocks that are in use.
     pub used_data: DataBlocks,
     /// The total number of data blocks available to the thinpool.
@@ -210,12 +210,12 @@ impl ThinPoolDev {
             let meta_vals = status_vals[1].split('/').collect::<Vec<_>>();
             let data_vals = status_vals[2].split('/').collect::<Vec<_>>();
             ThinPoolBlockUsage {
-                used_meta: meta_vals[0]
-                    .parse::<u64>()
-                    .expect("used_meta value must be valid"),
-                total_meta: meta_vals[1]
-                    .parse::<u64>()
-                    .expect("total_meta value must be valid"),
+                used_meta: MetaBlocks(meta_vals[0]
+                                          .parse::<u64>()
+                                          .expect("used_meta value must be valid")),
+                total_meta: MetaBlocks(meta_vals[1]
+                                           .parse::<u64>()
+                                           .expect("total_meta value must be valid")),
                 used_data: DataBlocks(data_vals[0]
                                           .parse::<u64>()
                                           .expect("used_data value must be valid")),

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,10 @@ use std::ops::{Div, Mul, Rem, Add};
 
 use serde;
 
+/// a kernel defined block size constant for a DM meta device
+/// defined in drivers/md/persistent-data/dm-space-map-metadata.h line 12
+const META_BLOCK_SIZE: Sectors = Sectors(8);
+
 // macros for implementing serialize and deserialize on all types
 macro_rules! serde {
     ($T: ident) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -113,6 +113,24 @@ custom_derive! {
     #[derive(NewtypeAdd, NewtypeAddAssign,
              NewtypeDeref,
              NewtypeFrom,
+             NewtypeSub,
+             Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+    /// A type for Meta Data blocks as used by the thin pool.
+    /// MetaBlocks have a kernel defined constant size of META_BLOCK_SIZE
+    pub struct MetaBlocks(pub u64);
+}
+
+impl MetaBlocks {
+    /// Return the number of Sectors in the MetaBlocks.
+    pub fn sectors(self) -> Sectors {
+        self.0 * META_BLOCK_SIZE
+    }
+}
+
+custom_derive! {
+    #[derive(NewtypeAdd, NewtypeAddAssign,
+             NewtypeDeref,
+             NewtypeFrom,
              NewtypeSub, NewtypeSubAssign,
              Debug, Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
     /// Structure to represent bytes


### PR DESCRIPTION
Use a MetaBlocks type for tracking the meta data device utilization.

dm.table_status() for a thin pool returns the meta device usage in blocks. The
block size for a meta is a constant 8 sectors.  The MetaBlocks type
wraps these sizes.

Signed-off-by: Todd Gill <tgill@redhat.com>