### PR TITLE
Do not scan /proc/partitions for device node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ before_install:
 language: rust
 
 matrix:
-    allow_failures:
-        - env: TASK=clippy
-    include:        
+    include:
         - rust: stable
           env: TASK=fmt
         - rust: stable

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,13 +1,14 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-use std::fs::File;
 use std::io;
-use std::io::{Error, BufReader, BufRead};
+use std::io::Error;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::io::ErrorKind::InvalidInput;
 use std::os::unix::fs::MetadataExt;
+
+/// A generic device-mapper device.
 
 /// A struct containing the device's major and minor numbers
 ///
@@ -21,23 +22,11 @@ pub struct Device {
 }
 
 impl Device {
-    /// Returns the path in `/dev` that corresponds with the device number/devnode.
-    pub fn devnode(&self) -> Option<PathBuf> {
-        let f = File::open("/proc/partitions").expect("Could not open /proc/partitions");
-
-        let reader = BufReader::new(f);
-
-        for line in reader.lines().skip(2) {
-            if let Ok(line) = line {
-                let spl: Vec<_> = line.split_whitespace().collect();
-
-                if spl[0].parse::<u32>().unwrap() == self.major &&
-                   spl[1].parse::<u8>().unwrap() == self.minor {
-                    return Some(PathBuf::from(format!("/dev/{}", spl[3])));
-                }
-            }
-        }
-        None
+    /// The device node for this device.
+    pub fn devnode(&self) -> PathBuf {
+        vec!["/dev", &format!("dm-{}", self.minor)]
+            .iter()
+            .collect()
     }
 
     /// Get a string with the Device's major and minor numbers in

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -97,7 +97,7 @@ impl DM {
 
         let hdr_slc = unsafe {
             let len = hdr.data_start as usize;
-            let ptr: *mut u8 = transmute(hdr);
+            let ptr = hdr as *mut dmi::Struct_dm_ioctl as *mut u8;
             slice::from_raw_parts_mut(ptr, len)
         };
 
@@ -479,7 +479,7 @@ impl DM {
 
         for (targ, param) in targs {
             unsafe {
-                let ptr: *mut u8 = transmute(&targ);
+                let ptr = &targ as *const dmi::Struct_dm_target_spec as *mut u8;
                 let slc = slice::from_raw_parts(ptr, size_of::<dmi::Struct_dm_target_spec>());
                 data_in.extend_from_slice(slc);
             }
@@ -704,9 +704,8 @@ impl DM {
         let mut msg_struct: dmi::Struct_dm_target_msg = Default::default();
         msg_struct.sector = sector;
         let mut data_in = unsafe {
-            let ptr: *mut u8 = transmute(&msg_struct);
-            let slc = slice::from_raw_parts(ptr, size_of::<dmi::Struct_dm_target_msg>());
-            slc.to_vec()
+            let ptr = &msg_struct as *const dmi::Struct_dm_target_msg as *mut u8;
+            slice::from_raw_parts(ptr, size_of::<dmi::Struct_dm_target_msg>()).to_vec()
         };
 
         data_in.extend(msg.as_bytes());

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -138,17 +138,12 @@ impl LinearDev {
 
     /// return the total size of the linear device
     pub fn size(&self) -> DmResult<Sectors> {
-        let f = try!(File::open(try!(self.devnode())));
-        Ok(try!(blkdev_size(&f)).sectors())
+        Ok(try!(blkdev_size(&try!(File::open(self.devnode())))).sectors())
     }
 
     /// path of the device node
-    pub fn devnode(&self) -> DmResult<PathBuf> {
-        self.dev_info
-            .device()
-            .devnode()
-            .ok_or(DmError::Dm(ErrorEnum::NotFound,
-                               "No path associated with dev_info".into()))
+    pub fn devnode(&self) -> PathBuf {
+        self.dev_info.device().devnode()
     }
 
     /// Remove the device from DM

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -155,12 +155,8 @@ impl ThinDev {
     }
 
     /// path of the device node
-    pub fn devnode(&self) -> DmResult<PathBuf> {
-        self.dev_info
-            .device()
-            .devnode()
-            .ok_or(DmError::Dm(ErrorEnum::NotFound,
-                               "No path associated with dev_info".into()))
+    pub fn devnode(&self) -> PathBuf {
+        self.dev_info.device().devnode()
 
     }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -239,7 +239,7 @@ impl ThinPoolDev {
         }
     }
 
-    /// Reload the devie mapper table.
+    /// Reload the device mapper table.
     fn table_reload(&self, dm: &DM) -> DmResult<()> {
         try!(dm.table_reload(dm,
                              &DevId::Name(self.name()),

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -129,7 +129,7 @@ impl ThinPoolDev {
                  -> DmResult<ThinPoolDev> {
         if !try!(Command::new("thin_check")
                      .arg("-q")
-                     .arg(&try!(meta.devnode()))
+                     .arg(&meta.devnode())
                      .status())
                     .success() {
             return Err(DmError::Dm(ErrorEnum::CheckFailed(meta, data),
@@ -179,12 +179,8 @@ impl ThinPoolDev {
     }
 
     /// path of the device node
-    pub fn devnode(&self) -> DmResult<PathBuf> {
-        self.dev_info
-            .device()
-            .devnode()
-            .ok_or(DmError::Dm(ErrorEnum::NotFound,
-                               "No path associated with dev_info".into()))
+    pub fn devnode(&self) -> PathBuf {
+        self.dev_info.device().devnode()
 
     }
 


### PR DESCRIPTION
This change eliminates the majority of the outstanding clippy errors as a side-effect.

So this PR follows up the devnode changes by eliminating all clippy errors and making clippy mandatory.