### PR TITLE
Drop an unimplemented method

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -721,11 +721,6 @@ impl DM {
             }))
     }
 
-    /// Unimplemented.
-    pub fn device_set_geometry(&self, _flags: DmFlags) {
-        unimplemented!()
-    }
-
     /// Recursively walk DM deps to see if `dev` might be its own dependency.
     pub fn depends_on(&self, dev: Device, dm_majors: &BTreeSet<u32>) -> bool {
         if !dm_majors.contains(&dev.major) {


### PR DESCRIPTION
It has remained unimplemented since Aug, 2015, when it was first introduced
along with a bunch of other unimplemented methods, all of which have since
been implemented.

Signed-off-by: mulhern <amulhern@redhat.com>