### PR TITLE
Revert "Do not scan /proc/partitions for device node"

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,14 +1,13 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+use std::fs::File;
 use std::io;
-use std::io::Error;
+use std::io::{Error, BufReader, BufRead};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::io::ErrorKind::InvalidInput;
 use std::os::unix::fs::MetadataExt;
-
-/// A generic device-mapper device.
 
 /// A struct containing the device's major and minor numbers
 ///
@@ -22,11 +21,23 @@ pub struct Device {
 }
 
 impl Device {
-    /// The device node for this device.
-    pub fn devnode(&self) -> PathBuf {
-        vec!["/dev", &format!("dm-{}", self.minor)]
-            .iter()
-            .collect()
+    /// Returns the path in `/dev` that corresponds with the device number/devnode.
+    pub fn devnode(&self) -> Option<PathBuf> {
+        let f = File::open("/proc/partitions").expect("Could not open /proc/partitions");
+
+        let reader = BufReader::new(f);
+
+        for line in reader.lines().skip(2) {
+            if let Ok(line) = line {
+                let spl: Vec<_> = line.split_whitespace().collect();
+
+                if spl[0].parse::<u32>().unwrap() == self.major &&
+                   spl[1].parse::<u8>().unwrap() == self.minor {
+                    return Some(PathBuf::from(format!("/dev/{}", spl[3])));
+                }
+            }
+        }
+        None
     }
 
     /// Get a string with the Device's major and minor numbers in

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -138,12 +138,17 @@ impl LinearDev {
 
     /// return the total size of the linear device
     pub fn size(&self) -> DmResult<Sectors> {
-        Ok(try!(blkdev_size(&try!(File::open(self.devnode())))).sectors())
+        let f = try!(File::open(try!(self.devnode())));
+        Ok(try!(blkdev_size(&f)).sectors())
     }
 
     /// path of the device node
-    pub fn devnode(&self) -> PathBuf {
-        self.dev_info.device().devnode()
+    pub fn devnode(&self) -> DmResult<PathBuf> {
+        self.dev_info
+            .device()
+            .devnode()
+            .ok_or(DmError::Dm(ErrorEnum::NotFound,
+                               "No path associated with dev_info".into()))
     }
 
     /// Remove the device from DM

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -155,8 +155,12 @@ impl ThinDev {
     }
 
     /// path of the device node
-    pub fn devnode(&self) -> PathBuf {
-        self.dev_info.device().devnode()
+    pub fn devnode(&self) -> DmResult<PathBuf> {
+        self.dev_info
+            .device()
+            .devnode()
+            .ok_or(DmError::Dm(ErrorEnum::NotFound,
+                               "No path associated with dev_info".into()))
 
     }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -129,7 +129,7 @@ impl ThinPoolDev {
                  -> DmResult<ThinPoolDev> {
         if !try!(Command::new("thin_check")
                      .arg("-q")
-                     .arg(&meta.devnode())
+                     .arg(&try!(meta.devnode()))
                      .status())
                     .success() {
             return Err(DmError::Dm(ErrorEnum::CheckFailed(meta, data),
@@ -179,8 +179,12 @@ impl ThinPoolDev {
     }
 
     /// path of the device node
-    pub fn devnode(&self) -> PathBuf {
-        self.dev_info.device().devnode()
+    pub fn devnode(&self) -> DmResult<PathBuf> {
+        self.dev_info
+            .device()
+            .devnode()
+            .ok_or(DmError::Dm(ErrorEnum::NotFound,
+                               "No path associated with dev_info".into()))
 
     }
 


### PR DESCRIPTION
This reverts commit 5c217326dffccffe1a955d692c27111b3aab5409.

The updates to devnode() caused some troubles with Stratis.  Reverting
the commit for now until we can work through the issues.

Signed-off-by: Todd Gill <tgill@redhat.com>