### PR TITLE
Update ThinDev to track the ThinPool name

### DIFF
--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -163,8 +163,8 @@ impl ThinPoolDev {
     }
 
     /// send a message to DM thin pool
-    pub fn message(&self, dm: &DM, message: &str) -> DmResult<()> {
-        try!(dm.target_msg(&DevId::Name(self.name()), 0, message));
+    pub fn message(dm: &DM, name: &str, message: &str) -> DmResult<()> {
+        try!(dm.target_msg(&DevId::Name(name), 0, message));
         Ok(())
     }
 


### PR DESCRIPTION

This allows destroy to  message the ThinPool to release associated blocks.