### PR TITLE
No longer specify trusty distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 os: linux
-dist: trusty
 group: edge
 
 addons:


### PR DESCRIPTION
It is now the default on Travis.

Signed-off-by: mulhern <amulhern@redhat.com>