### PR TITLE
Make new() and setup() methods approach idempotency

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -489,21 +489,6 @@ impl DM {
         Ok(DeviceInfo::new(hdr))
     }
 
-    /// Reload the table for a device
-    pub fn table_reload<T1, T2>(&self,
-                                dm: &DM,
-                                id: &DevId,
-                                table: &[TargetLineArg<T1, T2>])
-                                -> DmResult<()>
-        where T1: AsRef<str>,
-              T2: AsRef<str>
-    {
-        try!(dm.table_load(id, table));
-        try!(dm.device_suspend(id, DM_SUSPEND));
-        try!(dm.device_suspend(id, DmFlags::empty()));
-        Ok(())
-    }
-
     /// Clear the "inactive" table for a device.
     pub fn table_clear(&self, name: &DevId) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,8 @@ mod deviceinfo;
 mod device;
 /// core lower level API
 mod dm;
+/// functionality shared between devices
+mod shared;
 
 pub use dm::{DM, DevId};
 pub use device::Device;

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -11,7 +11,7 @@ use deviceinfo::DeviceInfo;
 use dm::{DM, DevId};
 use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
-use shared::{table_load, table_reload};
+use shared::{device_exists, table_load, table_reload};
 use types::{Sectors, TargetLine};
 use util::blkdev_size;
 
@@ -34,16 +34,23 @@ impl LinearDev {
     /// Construct a new block device by concatenating the given segments
     /// into linear space.  Use DM to reserve enough space for the stratis
     /// metadata on each DmDev.
+    /// TODO: If the linear device already exists, verify that the kernel's
+    /// model matches the segments argument.
     pub fn new(name: &str, dm: &DM, segments: Vec<Segment>) -> DmResult<LinearDev> {
         if segments.is_empty() {
             return Err(DmError::Dm(ErrorEnum::Invalid,
                                    "linear device must have at least one segment".into()));
         }
 
-        try!(dm.device_create(name, None, DmFlags::empty()));
-        let table = LinearDev::dm_table(&segments);
-        let id = &DevId::Name(name);
-        let dev_info = Box::new(try!(table_load(&dm, id, &table)));
+        let id = DevId::Name(name);
+        let dev_info = if try!(device_exists(dm, name)) {
+            // TODO: Verify that kernel's model matches up with segments.
+            Box::new(try!(dm.device_status(&id)))
+        } else {
+            try!(dm.device_create(name, None, DmFlags::empty()));
+            let table = LinearDev::dm_table(&segments);
+            Box::new(try!(table_load(dm, &id, &table)))
+        };
 
         DM::wait_for_dm();
         Ok(LinearDev {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -40,7 +40,6 @@ pub fn table_reload<T1, T2>(dm: &DM,
 }
 
 /// Check if a device of the given name exists.
-#[allow(dead_code)]
 pub fn device_exists(dm: &DM, name: &str) -> DmResult<bool> {
     Ok(try!(dm.list_devices()
                 .map(|l| l.iter().any(|&(ref n, _)| n == name))))

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// A module to contain functionality shared among the various types of
+/// devices.
+
+use super::consts::{DmFlags, DM_SUSPEND};
+use super::deviceinfo::DeviceInfo;
+use super::dm::{DevId, DM};
+use super::result::DmResult;
+use super::types::TargetLineArg;
+
+/// Load the table for a device.
+pub fn table_load<T1, T2>(dm: &DM,
+                          id: &DevId,
+                          table: &[TargetLineArg<T1, T2>])
+                          -> DmResult<DeviceInfo>
+    where T1: AsRef<str>,
+          T2: AsRef<str>
+{
+    let dev_info = try!(dm.table_load(id, table));
+    try!(dm.device_suspend(id, DmFlags::empty()));
+    Ok(dev_info)
+
+}
+
+/// Reload the table for a device
+pub fn table_reload<T1, T2>(dm: &DM,
+                            id: &DevId,
+                            table: &[TargetLineArg<T1, T2>])
+                            -> DmResult<DeviceInfo>
+    where T1: AsRef<str>,
+          T2: AsRef<str>
+{
+    let dev_info = try!(dm.table_load(id, table));
+    try!(dm.device_suspend(id, DM_SUSPEND));
+    try!(dm.device_suspend(id, DmFlags::empty()));
+    Ok(dev_info)
+}
+
+/// Check if a device of the given name exists.
+#[allow(dead_code)]
+pub fn device_exists(dm: &DM, name: &str) -> DmResult<bool> {
+    Ok(try!(dm.list_devices()
+                .map(|l| l.iter().any(|&(ref n, _)| n == name))))
+}

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -12,7 +12,7 @@ use dm::{DM, DevId};
 use lineardev::LinearDev;
 use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
-use shared::{table_load, table_reload};
+use shared::{device_exists, table_load, table_reload};
 use types::{DataBlocks, MetaBlocks, Sectors, TargetLine};
 
 /// DM construct to contain thin provisioned devices
@@ -74,6 +74,8 @@ pub enum ThinPoolWorkingStatus {
 /// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
 impl ThinPoolDev {
     /// Construct a new ThinPoolDev with the given data and meta devs.
+    /// TODO: If the device already exists, verify that kernel's model
+    /// matches arguments.
     pub fn new(name: &str,
                dm: &DM,
                length: Sectors,
@@ -82,20 +84,20 @@ impl ThinPoolDev {
                meta: LinearDev,
                data: LinearDev)
                -> DmResult<ThinPoolDev> {
-        try!(dm.device_create(name, None, DmFlags::empty()));
-
-        let id = &DevId::Name(name);
-        let di = try!(table_load(&dm,
-                                 id,
-                                 &ThinPoolDev::dm_table(length,
-                                                        data_block_size,
-                                                        low_water_mark,
-                                                        &meta,
-                                                        &data)));
+        let id = DevId::Name(name);
+        let dev_info = if try!(device_exists(dm, name)) {
+            // TODO: Verify that kernel table matches our table.
+            try!(dm.device_status(&id))
+        } else {
+            try!(dm.device_create(name, None, DmFlags::empty()));
+            let table =
+                ThinPoolDev::dm_table(length, data_block_size, low_water_mark, &meta, &data);
+            try!(table_load(dm, &id, &table))
+        };
 
         DM::wait_for_dm();
         Ok(ThinPoolDev {
-               dev_info: di,
+               dev_info: dev_info,
                meta_dev: meta,
                data_dev: data,
                data_block_size: data_block_size,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -12,6 +12,7 @@ use dm::{DM, DevId};
 use lineardev::LinearDev;
 use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
+use shared::{table_load, table_reload};
 use types::{DataBlocks, MetaBlocks, Sectors, TargetLine};
 
 /// DM construct to contain thin provisioned devices
@@ -84,13 +85,13 @@ impl ThinPoolDev {
         try!(dm.device_create(name, None, DmFlags::empty()));
 
         let id = &DevId::Name(name);
-        let di = try!(dm.table_load(id,
-                                    &ThinPoolDev::dm_table(length,
-                                                           data_block_size,
-                                                           low_water_mark,
-                                                           &meta,
-                                                           &data)));
-        try!(dm.device_suspend(id, DmFlags::empty()));
+        let di = try!(table_load(&dm,
+                                 id,
+                                 &ThinPoolDev::dm_table(length,
+                                                        data_block_size,
+                                                        low_water_mark,
+                                                        &meta,
+                                                        &data)));
 
         DM::wait_for_dm();
         Ok(ThinPoolDev {
@@ -246,13 +247,13 @@ impl ThinPoolDev {
 
     /// Reload the device mapper table.
     fn table_reload(&self, dm: &DM) -> DmResult<()> {
-        try!(dm.table_reload(dm,
-                             &DevId::Name(self.name()),
-                             &ThinPoolDev::dm_table(try!(self.data_dev.size()),
-                                                    self.data_block_size,
-                                                    self.low_water_mark,
-                                                    &self.meta_dev,
-                                                    &self.data_dev)));
+        try!(table_reload(dm,
+                          &DevId::Name(self.name()),
+                          &ThinPoolDev::dm_table(try!(self.data_dev.size()),
+                                                 self.data_block_size,
+                                                 self.low_water_mark,
+                                                 &self.meta_dev,
+                                                 &self.data_dev)));
         Ok(())
     }
 


### PR DESCRIPTION
Do not fail, if when setting up or creating a DM device, it is already registered with the kernel.