### PR TITLE
Travis: Use container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-sudo: required
 os: linux
 dist: trusty
 group: edge
 
-before_install:
-    - sudo apt-get -qq update
-    - sudo apt-get install -y libdevmapper-dev
+addons:
+  apt:
+    packages:
+    - libdevmapper-dev
 
 language: rust
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
         - rust: stable
           env: TASK=build
         - rust: stable
+          sudo: required
           env: TASK=sudo_test
         - rust: nightly
           env: TASK=clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ addons:
 
 language: rust
 
+cache: cargo
+
 matrix:
     allow_failures:
         - env: TASK=clippy


### PR DESCRIPTION
This removes the `sudo: required` from all builds except the `sudo_test` one, which should improve the CI boot time. See https://docs.travis-ci.com/user/reference/precise/#Virtualization-environments for more information.