### PR TITLE
Add a testing infrastructure and some more tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ serde = "1"
 log = "0.3"
 env_logger="0.4"
 clippy = {version = "0", optional = true}
+
+[dev-dependencies]
+loopdev = "0.1.1"
+tempdir = "0.3.5"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	RUSTFLAGS='-D warnings' cargo build
 
 test:
-	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip sudo_
+	RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 cargo test -- --skip sudo_ --skip loop_
 
 sudo_test:
 	sudo env "PATH=${PATH}" RUSTFLAGS='-D warnings' RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -827,6 +827,15 @@ mod tests {
     }
 
     #[test]
+    /// Removing a device that does not exist yields an error, unfortunately.
+    fn sudo_test_remove_non_existant() {
+        assert!(DM::new()
+                    .unwrap()
+                    .device_remove(&DevId::Name("junk"), DmFlags::empty())
+                    .is_err());
+    }
+
+    #[test]
     /// A newly created device has no deps.
     fn sudo_test_empty_deps() {
         let dm = DM::new().unwrap();
@@ -895,5 +904,16 @@ mod tests {
                     .unwrap()
                     .device_status(&DevId::Name("example_dev"))
                     .is_err());
+    }
+
+    #[test]
+    /// Verify that creating a device with the same name twice fails.
+    fn sudo_test_double_creation() {
+        let dm = DM::new().unwrap();
+        let name = "example-dev";
+        dm.device_create(name, None, DmFlags::empty()).unwrap();
+        assert!(dm.device_create(name, None, DmFlags::empty()).is_err());
+        dm.device_remove(&DevId::Name(name), DmFlags::empty())
+            .unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,6 @@ mod dm;
 mod shared;
 
 #[cfg(test)]
-#[allow(dead_code)]
 mod loopbacked;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,11 @@ extern crate bitflags;
 #[macro_use]
 extern crate log;
 
+#[cfg(test)]
+extern crate loopdev;
+#[cfg(test)]
+extern crate tempdir;
+
 #[allow(dead_code, non_camel_case_types)]
 mod dm_ioctl;
 /// public utilities
@@ -85,6 +90,11 @@ mod device;
 mod dm;
 /// functionality shared between devices
 mod shared;
+
+#[cfg(test)]
+#[allow(dead_code)]
+mod loopbacked;
+
 
 pub use dm::{DM, DevId};
 pub use device::Device;

--- a/src/loopbacked.rs
+++ b/src/loopbacked.rs
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::fs::OpenOptions;
+use std::io;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use loopdev::{LoopControl, LoopDevice};
+use tempdir::TempDir;
+
+use super::consts::{IEC, SECTOR_SIZE};
+use super::types::{Bytes, Sectors};
+
+/// Write buf at offset length times.
+fn write_sectors<P: AsRef<Path>>(path: P,
+                                 offset: Sectors,
+                                 length: Sectors,
+                                 buf: &[u8; SECTOR_SIZE])
+                                 -> io::Result<()> {
+    let mut f = try!(OpenOptions::new().write(true).open(path));
+
+    try!(f.seek(SeekFrom::Start(*offset)));
+    for _ in 0..*length {
+        try!(f.write_all(buf));
+    }
+
+    try!(f.flush());
+    Ok(())
+}
+
+/// Zero sectors at the given offset for length sectors.
+fn wipe_sectors<P: AsRef<Path>>(path: P, offset: Sectors, length: Sectors) -> io::Result<()> {
+    write_sectors(path, offset, length, &[0u8; SECTOR_SIZE])
+}
+
+pub struct LoopTestDev {
+    ld: LoopDevice,
+}
+
+impl LoopTestDev {
+    pub fn new(lc: &LoopControl, path: &Path) -> LoopTestDev {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+
+        let ld = lc.next_free().unwrap();
+        ld.attach(path, 0).unwrap();
+
+        // Wipe one MiB at the start of the device. Devicemapper data may be
+        // left on the device even after a teardown.
+        wipe_sectors(&ld.get_path().unwrap(),
+                     Sectors(0),
+                     Bytes(IEC::Mi).sectors())
+                .unwrap();
+
+        LoopTestDev { ld: ld }
+    }
+
+    fn get_path(&self) -> PathBuf {
+        self.ld.get_path().unwrap()
+    }
+
+    pub fn detach(&self) {
+        self.ld.detach().unwrap()
+    }
+}
+
+impl Drop for LoopTestDev {
+    fn drop(&mut self) {
+        self.detach()
+    }
+}
+
+/// Setup count loop backed devices in dir.
+/// Make sure each loop device is backed by a 1 GiB file.
+/// Wipe the first 1 MiB of the file.
+fn get_devices(count: u8, dir: &TempDir) -> Vec<LoopTestDev> {
+    let lc = LoopControl::open().unwrap();
+    let mut loop_devices = Vec::new();
+
+    for index in 0..count {
+        let path = dir.path().join(format!("store{}", &index));
+        let mut f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .unwrap();
+
+        // the proper way to do this is fallocate, but nix doesn't implement yet.
+        // TODO: see https://github.com/nix-rust/nix/issues/596
+        f.seek(SeekFrom::Start(IEC::Gi)).unwrap();
+        f.write(&[0]).unwrap();
+        f.flush().unwrap();
+
+        let ltd = LoopTestDev::new(&lc, &path);
+
+        loop_devices.push(ltd);
+    }
+    loop_devices
+}
+
+/// Set up count loopbacked devices.
+/// Then, run the designated test.
+/// Then, take down the loop devices.
+pub fn test_with_spec<F>(count: u8, test: F) -> ()
+    where F: Fn(&[&Path]) -> ()
+{
+    let tmpdir = TempDir::new("stratis").unwrap();
+    let loop_devices: Vec<LoopTestDev> = get_devices(count, &tmpdir);
+    let device_paths: Vec<PathBuf> = loop_devices.iter().map(|x| x.get_path()).collect();
+    let device_paths: Vec<&Path> = device_paths.iter().map(|x| x.as_path()).collect();
+
+    test(&device_paths);
+}


### PR DESCRIPTION
This takes the loopbacked testing infrastructure from stratisd and puts it in the src directory. Using this arrangement, it is possible to run tests using external devices using the Rust unit test framework. The PR also add a few more dm tests that don't require the framework, and a bunch of lineardev unit tests that mostly make use of the framework.

I believe that it would be straightforward to also port the "real" testing framework from stratisd, but I have not done so.