### PR TITLE
implement snapshot for a thindev

### DIFF
--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -370,6 +370,32 @@ mod tests {
         tp.teardown(&dm).unwrap();
     }
 
+    /// Verify success when taking a snapshot of a ThinDev.  Check that
+    /// the size of the snapshot is the same as the source.
+    fn test_snapshot(paths: &[&Path]) -> () {
+        assert!(paths.len() >= 1);
+        let td_size = MIN_THIN_DEV_SIZE;
+        let dm = DM::new().unwrap();
+        let tp = minimal_thinpool(&dm, paths[0]);
+
+        // Create new ThinDev as source for snapshot
+        let thin_id = ThinDevId::new_u64(0).expect("is below limit");
+        let thin_name = DmName::new("name").expect("is valid DM name");
+        let td = ThinDev::new(&thin_name, &dm, &tp, thin_id, td_size).unwrap();
+
+        // Create a snapshot of the source
+        let ss_id = ThinDevId::new_u64(1).expect("is below limit");
+        let ss_name = DmName::new("snap_name").expect("is valid DM name");
+        let ss = td.snapshot(&dm, &tp, ss_name, ss_id).unwrap();
+
+        // Verify the source and the snapshot are the same size.
+        assert_eq!(td.size(), ss.size());
+
+        ss.destroy(&dm, &tp).unwrap();
+        td.destroy(&dm, &tp).unwrap();
+        tp.teardown(&dm).unwrap();
+    }
+
     #[test]
     fn loop_test_basic() {
         test_with_spec(1, test_basic);
@@ -383,5 +409,9 @@ mod tests {
     #[test]
     fn loop_test_setup_without_new() {
         test_with_spec(1, test_setup_without_new);
+    }
+    #[test]
+    fn loop_test_snapshot() {
+        test_with_spec(1, test_snapshot);
     }
 }


### PR DESCRIPTION
Taking a snapshot of a ThinDev creates a new ThinDev that is no different
than any other thin provisioned device.

Documentation for snapshots can be found at:

https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt

See section i) Creating an internal snapshot.