### PR TITLE
Distinguish between a devicemapper device and an arbitrary device

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -3,9 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fmt;
-use std::fs::File;
-use std::io::{BufReader, BufRead};
-use std::path::PathBuf;
 
 /// A struct containing the device's major and minor numbers
 ///
@@ -16,27 +13,6 @@ pub struct Device {
     pub major: u32,
     /// Device minor number
     pub minor: u8,
-}
-
-impl Device {
-    /// Returns the path in `/dev` that corresponds with the device number/devnode.
-    pub fn devnode(&self) -> Option<PathBuf> {
-        let f = File::open("/proc/partitions").expect("Could not open /proc/partitions");
-
-        let reader = BufReader::new(f);
-
-        for line in reader.lines().skip(2) {
-            if let Ok(line) = line {
-                let spl: Vec<_> = line.split_whitespace().collect();
-
-                if spl[0].parse::<u32>().unwrap() == self.major &&
-                   spl[1].parse::<u8>().unwrap() == self.minor {
-                    return Some(["/dev", spl[3]].iter().collect::<PathBuf>());
-                }
-            }
-        }
-        None
-    }
 }
 
 /// Display format is the device number in "<major>:<minor>" format

--- a/src/device.rs
+++ b/src/device.rs
@@ -2,12 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 use std::fs::File;
-use std::io;
-use std::io::{Error, BufReader, BufRead};
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use std::io::ErrorKind::InvalidInput;
-use std::os::unix::fs::MetadataExt;
+use std::io::{BufReader, BufRead};
+use std::path::PathBuf;
 
 /// A struct containing the device's major and minor numbers
 ///
@@ -44,28 +40,6 @@ impl Device {
     /// "<major>:<minor>" format.
     pub fn dstr(&self) -> String {
         format!("{}:{}", self.major, self.minor)
-    }
-}
-
-impl FromStr for Device {
-    type Err = Error;
-    fn from_str(s: &str) -> io::Result<Device> {
-        match s.parse::<i64>() {
-            Ok(x) => Ok(Device::from(x as u64)),
-            Err(_) => {
-                match Path::new(s).metadata() {
-                    Ok(x) => {
-                        if x.mode() & 0x6000 == 0x6000 {
-                            // S_IFBLK
-                            Ok(Device::from(x.rdev()))
-                        } else {
-                            Err(Error::new(InvalidInput, format!("{} not block device", s)))
-                        }
-                    }
-                    Err(x) => Err(x),
-                }
-            }
-        }
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,6 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::fmt;
 use std::fs::File;
 use std::io::{BufReader, BufRead};
 use std::path::PathBuf;
@@ -35,11 +37,12 @@ impl Device {
         }
         None
     }
+}
 
-    /// Get a string with the Device's major and minor numbers in
-    /// "<major>:<minor>" format.
-    pub fn dstr(&self) -> String {
-        format!("{}:{}", self.major, self.minor)
+/// Display format is the device number in "<major>:<minor>" format
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.major, self.minor)
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,7 +12,7 @@ use std::os::unix::fs::MetadataExt;
 /// A struct containing the device's major and minor numbers
 ///
 /// Also allows conversion to/from a single 64bit value.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Device {
     /// Device major number
     pub major: u32,

--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -14,7 +14,7 @@ use util::slice_to_null;
 /// Contains information about the device.
 #[derive(Clone, Copy)]
 pub struct DeviceInfo {
-    /// ioclt arugument consits of a single chunk of memory, with this
+    /// ioctl argument consists of a single chunk of memory, with this
     /// structure at the start.
     hdr: dmi::Struct_dm_ioctl,
 }

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -11,7 +11,6 @@ use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::mem::{size_of, transmute};
 use std::slice;
-use std::collections::BTreeSet;
 use std::cmp;
 use std::thread;
 use std::time::Duration;
@@ -820,21 +819,6 @@ impl DM {
             } else {
                 None
             }))
-    }
-
-    /// Recursively walk DM deps to see if `dev` might be its own dependency.
-    pub fn depends_on(&self, dev: Device, dm_majors: &BTreeSet<u32>) -> DmResult<bool> {
-        if !dm_majors.contains(&dev.major) {
-            return Ok(false);
-        }
-
-        for d in self.table_deps(dev, DmFlags::empty())? {
-            if d == dev || self.depends_on(d, dm_majors)? {
-                return Ok(true);
-            }
-        }
-
-        Ok(false)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ mod util;
 mod types;
 /// shared constants
 pub mod consts;
+/// Macros shared by device mapper devices.
+#[macro_use]
+mod shared_macros;
 /// functions to create continuous linear space given device segments
 mod lineardev;
 /// allocate a device from a pool
@@ -100,6 +103,7 @@ pub use device::Device;
 pub use lineardev::LinearDev;
 pub use result::{DmResult, DmError, ErrorEnum};
 pub use segment::Segment;
+pub use shared::DmDevice;
 pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
 pub use thindev::{ThinDev, ThinDevId, ThinStatus};
 pub use types::{Bytes, DataBlocks, MetaBlocks, Sectors};

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -100,7 +100,7 @@ impl LinearDev {
             let line = (logical_start_offset,
                         length,
                         "linear".to_owned(),
-                        format!("{} {}", segment.device.dstr(), *physical_start_offset));
+                        format!("{} {}", segment.device, *physical_start_offset));
             debug!("dmtable line : {:?}", line);
             table.push(line);
             logical_start_offset += length;

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -29,7 +29,7 @@ impl fmt::Debug for LinearDev {
 }
 
 impl DmDevice for LinearDev {
-    fn devnode(&self) -> DmResult<PathBuf> {
+    fn devnode(&self) -> PathBuf {
         devnode!(self)
     }
 
@@ -161,7 +161,7 @@ impl LinearDev {
 
     /// return the total size of the linear device
     pub fn size(&self) -> DmResult<Sectors> {
-        let f = File::open(self.devnode()?)?;
+        let f = File::open(self.devnode())?;
         Ok(blkdev_size(&f)?.sectors())
     }
 }
@@ -246,7 +246,7 @@ mod tests {
                    count);
         assert_eq!(blkdev_size(&OpenOptions::new()
                                     .read(true)
-                                    .open(ld.devnode().unwrap())
+                                    .open(ld.devnode())
                                     .unwrap())
                            .unwrap()
                            .sectors(),

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fmt;
-use std::fs::File;
 use std::path::PathBuf;
 
 use consts::DmFlags;
@@ -13,7 +12,6 @@ use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
 use shared::{DmDevice, device_exists, table_load, table_reload};
 use types::{Sectors, TargetLine};
-use util::blkdev_size;
 
 /// A DM construct of combined Segments
 pub struct LinearDev {
@@ -160,9 +158,8 @@ impl LinearDev {
     }
 
     /// return the total size of the linear device
-    pub fn size(&self) -> DmResult<Sectors> {
-        let f = File::open(self.devnode())?;
-        Ok(blkdev_size(&f)?.sectors())
+    pub fn size(&self) -> Sectors {
+        self.segments.iter().map(|s| s.length).sum()
     }
 }
 
@@ -174,6 +171,7 @@ mod tests {
     use super::super::consts::DM_STATUS_TABLE;
     use super::super::device::Device;
     use super::super::loopbacked::{devnode_to_devno, test_with_spec};
+    use super::super::util::blkdev_size;
 
     use super::*;
 

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -170,8 +170,7 @@ mod tests {
 
     use super::super::consts::DM_STATUS_TABLE;
     use super::super::device::Device;
-    use super::super::loopbacked::{devnode_to_devno, test_with_spec};
-    use super::super::util::blkdev_size;
+    use super::super::loopbacked::{blkdev_size, devnode_to_devno, test_with_spec};
 
     use super::*;
 
@@ -246,7 +245,6 @@ mod tests {
                                     .read(true)
                                     .open(ld.devnode())
                                     .unwrap())
-                           .unwrap()
                            .sectors(),
                    range);
 

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -170,11 +170,10 @@ impl LinearDev {
 mod tests {
     use std::fs::OpenOptions;
     use std::path::Path;
-    use std::str::FromStr;
 
     use super::super::consts::DM_STATUS_TABLE;
     use super::super::device::Device;
-    use super::super::loopbacked::test_with_spec;
+    use super::super::loopbacked::{devnode_to_devno, test_with_spec};
 
     use super::*;
 
@@ -192,7 +191,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let mut ld = LinearDev::new(DmName::new(name).expect("valid format"),
                                     &dm,
                                     vec![Segment::new(dev, Sectors(0), Sectors(1))])
@@ -211,7 +210,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let mut ld = LinearDev::new(DmName::new(name).expect("valid format"),
                                     &dm,
                                     vec![Segment::new(dev, Sectors(0), Sectors(1))])
@@ -233,7 +232,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let segments = vec![Segment::new(dev, Sectors(0), Sectors(1)),
                             Segment::new(dev, Sectors(0), Sectors(1))];
         let range: Sectors = segments.iter().map(|s| s.length).sum();
@@ -264,7 +263,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let segments = vec![Segment::new(dev, Sectors(0), Sectors(1))];
         let table = LinearDev::dm_table(&segments);
         let ld = LinearDev::new(DmName::new(name).expect("valid format"),
@@ -289,7 +288,7 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let ld = LinearDev::new(DmName::new("name").expect("valid format"),
                                 &dm,
                                 vec![Segment::new(dev, Sectors(0), Sectors(1))])
@@ -309,7 +308,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let segments = vec![Segment::new(dev, Sectors(0), Sectors(1))];
         let table = LinearDev::dm_table(&segments);
         let ld = LinearDev::new(DmName::new(name).expect("valid format"), &dm, segments).unwrap();

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -39,6 +39,10 @@ impl DmDevice for LinearDev {
         name!(self)
     }
 
+    fn size(&self) -> Sectors {
+        self.segments.iter().map(|s| s.length).sum()
+    }
+
     fn teardown(self, dm: &DM) -> DmResult<()> {
         dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
@@ -155,11 +159,6 @@ impl LinearDev {
         dm.device_rename(self.name(), &DevId::Name(name))?;
         self.dev_info = Box::new(dm.device_status(&DevId::Name(name))?);
         Ok(())
-    }
-
-    /// return the total size of the linear device
-    pub fn size(&self) -> Sectors {
-        self.segments.iter().map(|s| s.length).sum()
     }
 }
 

--- a/src/loopbacked.rs
+++ b/src/loopbacked.rs
@@ -2,10 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fs::OpenOptions;
+use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::{Seek, SeekFrom, Write};
 use std::os::linux::fs::MetadataExt;
+use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use loopdev::{LoopControl, LoopDevice};
@@ -14,6 +15,20 @@ use tempdir::TempDir;
 
 use super::consts::{IEC, SECTOR_SIZE};
 use super::types::{Bytes, Sectors};
+
+
+/// send IOCTL via blkgetsize64
+#[allow(dead_code)]
+ioctl!(read blkgetsize64 with 0x12, 114; u64);
+
+/// get the size of a given block device file
+#[allow(dead_code)]
+pub fn blkdev_size(file: &File) -> Bytes {
+    let mut val: u64 = 0;
+
+    unsafe { blkgetsize64(file.as_raw_fd(), &mut val) }.unwrap();
+    Bytes(val)
+}
 
 /// Get a device number from a device node.
 /// Return None if the device is not a block device; devicemapper is not

--- a/src/loopbacked.rs
+++ b/src/loopbacked.rs
@@ -5,13 +5,27 @@
 use std::fs::OpenOptions;
 use std::io;
 use std::io::{Seek, SeekFrom, Write};
+use std::os::linux::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use loopdev::{LoopControl, LoopDevice};
+use nix::sys::stat::{S_IFBLK, S_IFMT};
 use tempdir::TempDir;
 
 use super::consts::{IEC, SECTOR_SIZE};
 use super::types::{Bytes, Sectors};
+
+/// Get a device number from a device node.
+/// Return None if the device is not a block device; devicemapper is not
+/// interested in other sorts of devices.
+pub fn devnode_to_devno(path: &Path) -> Option<u64> {
+    let metadata = path.metadata().unwrap();
+    if metadata.st_mode() & S_IFMT.bits() == S_IFBLK.bits() {
+        Some(metadata.st_rdev())
+    } else {
+        None
+    }
+}
 
 /// Write buf at offset length times.
 fn write_sectors<P: AsRef<Path>>(path: P,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -5,11 +5,28 @@
 /// A module to contain functionality shared among the various types of
 /// devices.
 
+use std::path::PathBuf;
+
 use super::consts::{DmFlags, DM_SUSPEND};
 use super::deviceinfo::DeviceInfo;
 use super::dm::{DevId, DM, DmName};
 use super::result::DmResult;
 use super::types::TargetLineArg;
+
+/// A trait capturing some shared properties of DM devices.
+pub trait DmDevice {
+    /// The device's device node.
+    fn devnode(&self) -> DmResult<PathBuf>;
+
+    /// The device's number, formatted as a string <maj:min>.
+    fn dstr(&self) -> String;
+
+    /// The device's name.
+    fn name(&self) -> &DmName;
+
+    /// Erase the kernel's memory of this device.
+    fn teardown(self, dm: &DM) -> DmResult<()>;
+}
 
 /// Load the table for a device.
 pub fn table_load<T1, T2>(dm: &DM,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -11,7 +11,7 @@ use super::consts::{DmFlags, DM_SUSPEND};
 use super::deviceinfo::DeviceInfo;
 use super::dm::{DevId, DM, DmName};
 use super::result::DmResult;
-use super::types::TargetLineArg;
+use super::types::{Sectors, TargetLineArg};
 
 /// A trait capturing some shared properties of DM devices.
 pub trait DmDevice {
@@ -23,6 +23,9 @@ pub trait DmDevice {
 
     /// The device's name.
     fn name(&self) -> &DmName;
+
+    /// The number of sectors available for user data.
+    fn size(&self) -> Sectors;
 
     /// Erase the kernel's memory of this device.
     fn teardown(self, dm: &DM) -> DmResult<()>;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -16,7 +16,7 @@ use super::types::TargetLineArg;
 /// A trait capturing some shared properties of DM devices.
 pub trait DmDevice {
     /// The device's device node.
-    fn devnode(&self) -> DmResult<PathBuf>;
+    fn devnode(&self) -> PathBuf;
 
     /// The device's number, formatted as a string <maj:min>.
     fn dstr(&self) -> String;

--- a/src/shared_macros.rs
+++ b/src/shared_macros.rs
@@ -13,7 +13,7 @@ macro_rules! name {
 
 macro_rules! dstr {
     ($s: ident) => {
-        $s.dev_info.device().dstr()
+        $s.dev_info.device().to_string()
     }
 }
 

--- a/src/shared_macros.rs
+++ b/src/shared_macros.rs
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// A module to contain functionality shared among the various types of
+/// devices and implemented by means of macros.
+
+macro_rules! name {
+    ($s: ident) => {
+        $s.dev_info.name()
+    }
+}
+
+macro_rules! dstr {
+    ($s: ident) => {
+        $s.dev_info.device().dstr()
+    }
+}
+
+macro_rules! devnode {
+    ($s: ident) => {
+        $s.dev_info
+          .device()
+          .devnode()
+          .ok_or_else(|| {
+                          DmError::Dm(ErrorEnum::NotFound,
+                                      "No path associated with dev_info".into())
+                      })
+
+    }
+}

--- a/src/shared_macros.rs
+++ b/src/shared_macros.rs
@@ -19,13 +19,6 @@ macro_rules! dstr {
 
 macro_rules! devnode {
     ($s: ident) => {
-        $s.dev_info
-          .device()
-          .devnode()
-          .ok_or_else(|| {
-                          DmError::Dm(ErrorEnum::NotFound,
-                                      "No path associated with dev_info".into())
-                      })
-
+        ["/dev", &format!("dm-{}", $s.dev_info.device().minor)].iter().collect()
     }
 }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -81,7 +81,7 @@ impl fmt::Debug for ThinDev {
 }
 
 impl DmDevice for ThinDev {
-    fn devnode(&self) -> DmResult<PathBuf> {
+    fn devnode(&self) -> PathBuf {
         devnode!(self)
     }
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -68,7 +68,7 @@ impl<'de> serde::Deserialize<'de> for ThinDevId {
 
 /// DM construct for a thin block device
 pub struct ThinDev {
-    dev_info: DeviceInfo,
+    dev_info: Box<DeviceInfo>,
     thin_id: ThinDevId,
     size: Sectors,
     thinpool_dstr: String,
@@ -123,11 +123,11 @@ impl ThinDev {
 
         let dev_info = if device_exists(dm, name)? {
             // TODO: Verify that kernel's model matches arguments.
-            dm.device_status(&id)?
+            Box::new(dm.device_status(&id)?)
         } else {
             dm.device_create(name, None, DmFlags::empty())?;
             let table = ThinDev::dm_table(&thin_pool_dstr, thin_id, length);
-            table_load(dm, &id, &table)?
+            Box::new(table_load(dm, &id, &table)?)
         };
 
         DM::wait_for_dm();

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -93,6 +93,10 @@ impl DmDevice for ThinDev {
         name!(self)
     }
 
+    fn size(&self) -> Sectors {
+        self.size
+    }
+
     fn teardown(self, dm: &DM) -> DmResult<()> {
         dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
@@ -167,11 +171,6 @@ impl ThinDev {
     fn dm_table(thin_pool_dstr: &str, thin_id: ThinDevId, length: Sectors) -> Vec<TargetLine> {
         let params = format!("{} {}", thin_pool_dstr, thin_id);
         vec![(Sectors::default(), length, "thin".to_owned(), params)]
-    }
-
-    /// return the total size of the linear device
-    pub fn size(&self) -> Sectors {
-        self.size
     }
 
     /// return the thin id of the linear device

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -41,7 +41,7 @@ impl fmt::Debug for ThinPoolDev {
 }
 
 impl DmDevice for ThinPoolDev {
-    fn devnode(&self) -> DmResult<PathBuf> {
+    fn devnode(&self) -> PathBuf {
         devnode!(self)
     }
 
@@ -162,7 +162,7 @@ impl ThinPoolDev {
                  -> DmResult<ThinPoolDev> {
         if !Command::new("thin_check")
                 .arg("-q")
-                .arg(&meta.devnode()?)
+                .arg(&meta.devnode())
                 .status()?
                 .success() {
             return Err(DmError::Dm(ErrorEnum::CheckFailed(meta, data),

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -53,6 +53,10 @@ impl DmDevice for ThinPoolDev {
         name!(self)
     }
 
+    fn size(&self) -> Sectors {
+        self.data_dev.size()
+    }
+
     fn teardown(self, dm: &DM) -> DmResult<()> {
         dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         self.data_dev.teardown(dm)?;

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -121,7 +121,7 @@ impl ThinPoolDev {
         } else {
             dm.device_create(name, None, DmFlags::empty())?;
             let table =
-                ThinPoolDev::dm_table(data.size()?, data_block_size, low_water_mark, &meta, &data);
+                ThinPoolDev::dm_table(data.size(), data_block_size, low_water_mark, &meta, &data);
             Box::new(table_load(dm, &id, &table)?)
         };
 
@@ -260,7 +260,7 @@ impl ThinPoolDev {
         self.meta_dev.extend(new_segs)?;
         table_reload(dm,
                      &DevId::Name(self.name()),
-                     &ThinPoolDev::dm_table(self.data_dev.size()?,
+                     &ThinPoolDev::dm_table(self.data_dev.size(),
                                             self.data_block_size,
                                             self.low_water_mark,
                                             &self.meta_dev,
@@ -273,7 +273,7 @@ impl ThinPoolDev {
         self.data_dev.extend(new_segs)?;
         table_reload(dm,
                      &DevId::Name(self.name()),
-                     &ThinPoolDev::dm_table(self.data_dev.size()?,
+                     &ThinPoolDev::dm_table(self.data_dev.size(),
                                             self.data_block_size,
                                             self.low_water_mark,
                                             &self.meta_dev,

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 use std::os::unix::prelude::AsRawFd;
 
 /// send IOCTL via blkgetsize64
+#[allow(dead_code)]
 ioctl!(read blkgetsize64 with 0x12, 114; u64);
 
 /// The smallest number divisible by `align_to` and at least `num`.
@@ -22,6 +23,7 @@ pub fn align_to(num: usize, align_to: usize) -> usize {
 }
 
 /// get the size of a given block device file
+#[allow(dead_code)]
 pub fn blkdev_size(file: &File) -> DmResult<Bytes> {
     let mut val: u64 = 0;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,15 +4,6 @@
 
 #![allow(missing_docs)]
 
-use result::{DmResult, DmError};
-use types::Bytes;
-use std::fs::File;
-use std::os::unix::prelude::AsRawFd;
-
-/// send IOCTL via blkgetsize64
-#[allow(dead_code)]
-ioctl!(read blkgetsize64 with 0x12, 114; u64);
-
 /// The smallest number divisible by `align_to` and at least `num`.
 /// Precondition: `align_to` is a power of 2.
 /// Precondition: `num` + `align_to` < usize::MAX + 1.
@@ -20,17 +11,6 @@ pub fn align_to(num: usize, align_to: usize) -> usize {
     let agn = align_to - 1;
 
     (num + agn) & !agn
-}
-
-/// get the size of a given block device file
-#[allow(dead_code)]
-pub fn blkdev_size(file: &File) -> DmResult<Bytes> {
-    let mut val: u64 = 0;
-
-    match unsafe { blkgetsize64(file.as_raw_fd(), &mut val) } {
-        Err(x) => Err(DmError::Nix(x)),
-        Ok(_) => Ok(Bytes(val)),
-    }
 }
 
 /// Return slc up to the first \0, or None


### PR DESCRIPTION
A devicemapper device implements DMDevice and delegates some actions to a transitively contained Device object.