### PR TITLE
Use DevId a bit more and document it a bit more

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -32,7 +32,9 @@ use util::slice_to_null;
 pub enum DevId<'a> {
     /// The parameter is the device's name
     Name(&'a str),
-    /// The parameter is the device's UUID
+    /// The parameter is the device's "DM UUID"
+    /// Note that this UUID is not a canonical UUID, but rather a
+    /// devicemapper-specific format that is supposed to be unique.
     Uuid(&'a str),
 }
 
@@ -69,6 +71,8 @@ impl DM {
         name_dest[..len].clone_from_slice(name.as_bytes());
     }
 
+    /// Set the devicemapper "UUID".
+    /// Note that this is a devicemapper specific id value, not a UUID.
     fn hdr_set_uuid(hdr: &mut dmi::Struct_dm_ioctl, uuid: &str) -> () {
         let uuid_dest: &mut [u8; DM_UUID_LEN] = unsafe { transmute(&mut hdr.uuid) };
         let len = uuid.as_bytes().len();
@@ -225,7 +229,7 @@ impl DM {
     /// use devicemapper::consts::DmFlags;
     /// let dm = DM::new().unwrap();
     ///
-    /// // Setting a uuid is optional
+    /// // Setting a devicemapper uuid is optional
     /// let dev = dm.device_create("example-dev", None, DmFlags::empty()).unwrap();
     /// ```
     pub fn device_create(&self,
@@ -272,40 +276,40 @@ impl DM {
         Ok(DeviceInfo::new(hdr))
     }
 
-    /// Change a DM device's name.
+    /// Reset a device's name, or set, for the first and only time its
+    /// devicemapper uuid.
     ///
-    /// If DM_UUID is set, change the UUID instead.
-    ///
-    /// Valid flags: DM_UUID
-    ///
-    /// Prerequisite: old_name != new_name
-    /// Note: Possibly surprisingly, returned DeviceInfo's name field
-    /// contains the previous name, not the new name.
-    pub fn device_rename(&self,
-                         old_name: &str,
-                         new_name: &str,
-                         flags: DmFlags)
-                         -> DmResult<DeviceInfo> {
+    /// Prerequisite: if new == DevId::Name(new_name), old_name != new_name
+    /// Note: Possibly surprisingly, returned DeviceInfo contains the old
+    /// data for name or uuid, not the newly set value.
+    pub fn device_rename(&self, old_name: &str, new: DevId) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
-        let clean_flags = DM_UUID & flags;
+        let mut data_in = match new {
+            DevId::Name(new_name) => {
+                Self::initialize_hdr(&mut hdr, DmFlags::empty());
+                Self::hdr_set_name(&mut hdr, old_name);
 
-        Self::initialize_hdr(&mut hdr, clean_flags);
+                let data_in = new_name.as_bytes();
+                if data_in.len() > DM_NAME_LEN - 1 {
+                    let err_msg = format!("New value {} too long", new_name);
+                    return Err(DmError::Dm(ErrorEnum::Invalid, err_msg.into()));
+                }
+                data_in.to_vec()
+            }
+            DevId::Uuid(new_uuid) => {
+                Self::initialize_hdr(&mut hdr, DM_UUID);
+                Self::hdr_set_name(&mut hdr, old_name);
 
-        let max_len = if clean_flags.contains(DM_UUID) {
-            Self::hdr_set_uuid(&mut hdr, old_name);
-            DM_UUID_LEN - 1
-        } else {
-            Self::hdr_set_name(&mut hdr, old_name);
-            DM_NAME_LEN - 1
+                let data_in = new_uuid.as_bytes();
+                if data_in.len() > DM_UUID_LEN - 1 {
+                    let err_msg = format!("New value {} too long", new_uuid);
+                    return Err(DmError::Dm(ErrorEnum::Invalid, err_msg.into()));
+                }
+                data_in.to_vec()
+            }
         };
 
-        if new_name.as_bytes().len() > max_len {
-            return Err(DmError::Dm(ErrorEnum::Invalid,
-                                   format!("New name {} too long", new_name).into()));
-        }
-
-        let mut data_in = new_name.as_bytes().to_vec();
         data_in.push(b'\0');
 
         self.do_ioctl(dmi::DM_DEV_RENAME_CMD as u8, &mut hdr, Some(&data_in))?;
@@ -728,7 +732,6 @@ impl DM {
 
 #[cfg(test)]
 mod tests {
-
     use {DevId, DM};
     use consts::{DmFlags, DM_STATUS_TABLE};
 
@@ -791,7 +794,7 @@ mod tests {
         let name = "example-dev";
         dm.device_create(name, None, DmFlags::empty()).unwrap();
         DM::wait_for_dm();
-        assert!(dm.device_rename(name, name, DmFlags::empty()).is_err());
+        assert!(dm.device_rename(name, DevId::Name(name)).is_err());
         dm.device_remove(&DevId::Name(name), DmFlags::empty())
             .unwrap();
     }
@@ -807,8 +810,7 @@ mod tests {
 
         let new_name = "example-dev-2";
         loop {
-            if dm.device_rename(name, new_name, DmFlags::empty())
-                   .is_ok() {
+            if dm.device_rename(name, DevId::Name(new_name)).is_ok() {
                 break;
             }
         }
@@ -829,7 +831,7 @@ mod tests {
     fn sudo_test_rename_non_existant() {
         assert!(DM::new()
                     .unwrap()
-                    .device_rename("old_name", "new_name", DmFlags::empty())
+                    .device_rename("old_name", DevId::Name("new_name"))
                     .is_err());
     }
 

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -260,13 +260,13 @@ impl DM {
     /// used.
     ///
     /// Valid flags: DM_DEFERRED_REMOVE
-    pub fn device_remove(&self, name: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
+    pub fn device_remove(&self, id: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         let clean_flags = DM_DEFERRED_REMOVE & flags;
 
         Self::initialize_hdr(&mut hdr, clean_flags);
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -340,13 +340,13 @@ impl DM {
     ///
     /// dm.device_suspend(&DevId::Name("example-dev"), DM_SUSPEND).unwrap();
     /// ```
-    pub fn device_suspend(&self, name: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
+    pub fn device_suspend(&self, id: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         let clean_flags = (DM_SUSPEND | DM_NOFLUSH | DM_SKIP_LOCKFS) & flags;
 
         Self::initialize_hdr(&mut hdr, clean_flags);
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -359,12 +359,12 @@ impl DM {
     /// Get DeviceInfo for a device. This is also returned by other
     /// methods, but if just the DeviceInfo is desired then this just
     /// gets it.
-    pub fn device_status(&self, name: &DevId) -> DmResult<DeviceInfo> {
+    pub fn device_status(&self, id: &DevId) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         // No flags checked so don't pass any
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -382,7 +382,7 @@ impl DM {
     /// This interface is not very friendly to monitoring multiple devices.
     /// Events are also exported via uevents, that method may be preferable.
     pub fn device_wait(&self,
-                       name: &DevId,
+                       id: &DevId,
                        flags: DmFlags)
                        -> DmResult<(DeviceInfo, Vec<TargetLine>)> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
@@ -390,7 +390,7 @@ impl DM {
         let clean_flags = DM_QUERY_INACTIVE_TABLE & flags;
 
         Self::initialize_hdr(&mut hdr, clean_flags);
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -429,7 +429,7 @@ impl DM {
     /// dm.table_load(&DevId::Name("example-dev"), &table).unwrap();
     /// ```
     pub fn table_load<T1, T2>(&self,
-                              name: &DevId,
+                              id: &DevId,
                               targets: &[TargetLineArg<T1, T2>])
                               -> DmResult<DeviceInfo>
         where T1: AsRef<str>,
@@ -467,7 +467,7 @@ impl DM {
 
         // No flags checked so don't pass any
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -494,12 +494,12 @@ impl DM {
     }
 
     /// Clear the "inactive" table for a device.
-    pub fn table_clear(&self, name: &DevId) -> DmResult<DeviceInfo> {
+    pub fn table_clear(&self, id: &DevId) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         // No flags checked so don't pass any
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -619,7 +619,7 @@ impl DM {
     /// println!("{} {:?}", res.0.name(), res.1);
     /// ```
     pub fn table_status(&self,
-                        name: &DevId,
+                        id: &DevId,
                         flags: DmFlags)
                         -> DmResult<(DeviceInfo, Vec<TargetLine>)> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
@@ -627,7 +627,7 @@ impl DM {
         let clean_flags = (DM_NOFLUSH | DM_STATUS_TABLE | DM_QUERY_INACTIVE_TABLE) & flags;
 
         Self::initialize_hdr(&mut hdr, clean_flags);
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -681,7 +681,7 @@ impl DM {
     /// not needed use 0.  DM-wide messages start with '@', and may
     /// return a string; targets do not.
     pub fn target_msg(&self,
-                      name: &DevId,
+                      id: &DevId,
                       sector: Sectors,
                       msg: &str)
                       -> DmResult<(DeviceInfo, Option<String>)> {
@@ -689,7 +689,7 @@ impl DM {
 
         // No flags checked so don't pass any
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -138,7 +138,7 @@ impl LinearDev {
 
     /// Set the name for this LinearDev.
     pub fn set_name(&mut self, dm: &DM, name: &str) -> DmResult<()> {
-        self.dev_info = Box::new(dm.device_rename(self.dev_info.name(), name, DmFlags::empty())?);
+        self.dev_info = Box::new(dm.device_rename(self.dev_info.name(), DevId::Name(name))?);
 
         Ok(())
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -138,8 +138,8 @@ impl LinearDev {
 
     /// Set the name for this LinearDev.
     pub fn set_name(&mut self, dm: &DM, name: &str) -> DmResult<()> {
-        self.dev_info = Box::new(dm.device_rename(self.dev_info.name(), DevId::Name(name))?);
-
+        dm.device_rename(self.dev_info.name(), DevId::Name(name))?;
+        self.dev_info = Box::new(dm.device_status(&DevId::Name(name))?);
         Ok(())
     }
 
@@ -187,6 +187,23 @@ mod tests {
     /// Verify that a new linear dev with 0 segments fails.
     fn test_empty(_paths: &[&Path]) -> () {
         assert!(LinearDev::new("new", &DM::new().unwrap(), vec![]).is_err());
+    }
+
+    /// Verify that after a rename, the device has the new name.
+    fn test_rename(paths: &[&Path]) -> () {
+        assert!(paths.len() >= 1);
+
+        let dm = DM::new().unwrap();
+        let name = "name";
+        let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
+        let mut ld = LinearDev::new(name, &dm, vec![Segment::new(dev, Sectors(0), Sectors(1))])
+            .unwrap();
+
+        let new_name = "new_name";
+        ld.set_name(&dm, new_name).unwrap();
+        assert_eq!(ld.name(), new_name);
+
+        ld.teardown(&dm).unwrap();
     }
 
     /// Verify that passing the same segments two times gets two segments.
@@ -283,6 +300,11 @@ mod tests {
     #[test]
     fn loop_test_empty() {
         test_with_spec(0, test_empty);
+    }
+
+    #[test]
+    fn loop_test_rename() {
+        test_with_spec(1, test_rename);
     }
 
     #[test]


### PR DESCRIPTION
* Documents the reason why DevId's Uuid constructor does not take a Uuid argument.
* Rewrite ```device_rename()``` to use DevId parameter. Fixes a bug since it is impossible to reset a uuid according to kernel docs in ioctl.h.
* Changes a confusing parameter name, "name", to "id", which is a bit better.
* Adds some tests to verify basic operation on devicemapper "uuids".
* Has ```LinearDev::set_name()``` return the DeviceInfo from ```device_status()``` call.
* Makes ```LinearDev::set_name()``` idempotent.

Resolves #90.
Resolves #92.