### PR TITLE
Work on devicemapper identifiers

### DIFF
--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -45,21 +45,19 @@ impl DeviceInfo {
     }
 
     /// The device's name.
-    pub fn name(&self) -> &DmName {
+    pub fn name(&self) -> DmName {
         let name: &[u8; DM_NAME_LEN] = unsafe { transmute(&self.hdr.name) };
-        // no chance not null-terminated
-        let slc = slice_to_null(name).unwrap();
-        // no chance this isn't utf8 (ascii, really)
-        from_utf8(slc).unwrap()
+        let slc = slice_to_null(name).expect("kernel ensures null-terminated");
+        let name = from_utf8(slc).expect("kernel ensures ASCII characters");
+        DmName::new(name).expect(".len() < DM_NAME_LEN")
     }
 
-    /// The device's UUID.
-    pub fn uuid(&self) -> &DmUuid {
+    /// The device's devicemapper uuid.
+    pub fn uuid(&self) -> DmUuid {
         let uuid: &[u8; DM_UUID_LEN] = unsafe { transmute(&self.hdr.uuid) };
-        // no chance not null-terminated
-        let slc = slice_to_null(uuid).unwrap();
-        // no chance this isn't utf8 (ascii, really)
-        from_utf8(slc).unwrap()
+        let slc = slice_to_null(uuid).expect("kernel ensures null-terminated");
+        let uuid = from_utf8(slc).expect("kernel ensures ASCII characters");
+        DmUuid::new(uuid).expect(".len() < DM_UUID_LEN")
     }
 
     /// The flags returned from the device.

--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -8,6 +8,7 @@ use dm_ioctl as dmi;
 
 use consts::{DM_NAME_LEN, DmFlags, DM_UUID_LEN};
 use device::Device;
+use dm::{DmName, DmUuid};
 use util::slice_to_null;
 
 /// Contains information about the device.
@@ -44,7 +45,7 @@ impl DeviceInfo {
     }
 
     /// The device's name.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &DmName {
         let name: &[u8; DM_NAME_LEN] = unsafe { transmute(&self.hdr.name) };
         // no chance not null-terminated
         let slc = slice_to_null(name).unwrap();
@@ -53,7 +54,7 @@ impl DeviceInfo {
     }
 
     /// The device's UUID.
-    pub fn uuid(&self) -> &str {
+    pub fn uuid(&self) -> &DmUuid {
         let uuid: &[u8; DM_UUID_LEN] = unsafe { transmute(&self.hdr.uuid) };
         // no chance not null-terminated
         let slc = slice_to_null(uuid).unwrap();

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -268,13 +268,13 @@ impl DM {
     /// used.
     ///
     /// Valid flags: DM_DEFERRED_REMOVE
-    pub fn device_remove(&self, name: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
+    pub fn device_remove(&self, id: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         let clean_flags = DM_DEFERRED_REMOVE & flags;
 
         Self::initialize_hdr(&mut hdr, clean_flags);
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -348,13 +348,13 @@ impl DM {
     ///
     /// dm.device_suspend(&DevId::Name("example-dev"), DM_SUSPEND).unwrap();
     /// ```
-    pub fn device_suspend(&self, name: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
+    pub fn device_suspend(&self, id: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         let clean_flags = (DM_SUSPEND | DM_NOFLUSH | DM_SKIP_LOCKFS) & flags;
 
         Self::initialize_hdr(&mut hdr, clean_flags);
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -367,12 +367,12 @@ impl DM {
     /// Get DeviceInfo for a device. This is also returned by other
     /// methods, but if just the DeviceInfo is desired then this just
     /// gets it.
-    pub fn device_status(&self, name: &DevId) -> DmResult<DeviceInfo> {
+    pub fn device_status(&self, id: &DevId) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         // No flags checked so don't pass any
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -390,7 +390,7 @@ impl DM {
     /// This interface is not very friendly to monitoring multiple devices.
     /// Events are also exported via uevents, that method may be preferable.
     pub fn device_wait(&self,
-                       name: &DevId,
+                       id: &DevId,
                        flags: DmFlags)
                        -> DmResult<(DeviceInfo, Vec<TargetLine>)> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
@@ -398,7 +398,7 @@ impl DM {
         let clean_flags = DM_QUERY_INACTIVE_TABLE & flags;
 
         Self::initialize_hdr(&mut hdr, clean_flags);
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -437,7 +437,7 @@ impl DM {
     /// dm.table_load(&DevId::Name("example-dev"), &table).unwrap();
     /// ```
     pub fn table_load<T1, T2>(&self,
-                              name: &DevId,
+                              id: &DevId,
                               targets: &[TargetLineArg<T1, T2>])
                               -> DmResult<DeviceInfo>
         where T1: AsRef<str>,
@@ -475,7 +475,7 @@ impl DM {
 
         // No flags checked so don't pass any
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -502,12 +502,12 @@ impl DM {
     }
 
     /// Clear the "inactive" table for a device.
-    pub fn table_clear(&self, name: &DevId) -> DmResult<DeviceInfo> {
+    pub fn table_clear(&self, id: &DevId) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         // No flags checked so don't pass any
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -627,7 +627,7 @@ impl DM {
     /// println!("{} {:?}", res.0.name(), res.1);
     /// ```
     pub fn table_status(&self,
-                        name: &DevId,
+                        id: &DevId,
                         flags: DmFlags)
                         -> DmResult<(DeviceInfo, Vec<TargetLine>)> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
@@ -635,7 +635,7 @@ impl DM {
         let clean_flags = (DM_NOFLUSH | DM_STATUS_TABLE | DM_QUERY_INACTIVE_TABLE) & flags;
 
         Self::initialize_hdr(&mut hdr, clean_flags);
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };
@@ -689,7 +689,7 @@ impl DM {
     /// not needed use 0.  DM-wide messages start with '@', and may
     /// return a string; targets do not.
     pub fn target_msg(&self,
-                      name: &DevId,
+                      id: &DevId,
                       sector: Sectors,
                       msg: &str)
                       -> DmResult<(DeviceInfo, Option<String>)> {
@@ -697,7 +697,7 @@ impl DM {
 
         // No flags checked so don't pass any
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *name {
+        match *id {
             DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
             DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ mod shared;
 mod loopbacked;
 
 
-pub use dm::{DM, DevId};
+pub use dm::{DM, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf};
 pub use device::Device;
 pub use lineardev::LinearDev;
 pub use result::{DmResult, DmError, ErrorEnum};

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -138,7 +138,7 @@ impl LinearDev {
 
     /// Set the name for this LinearDev.
     pub fn set_name(&mut self, dm: &DM, name: &DmName) -> DmResult<()> {
-        self.dev_info = Box::new(dm.device_rename(&DevId::Name(self.dev_info.name()), name)?);
+        self.dev_info = Box::new(dm.device_rename(self.dev_info.name(), name)?);
 
         Ok(())
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -39,7 +39,7 @@ impl LinearDev {
     /// undefined.
     /// TODO: If the linear device already exists, verify that the kernel's
     /// model matches the segments argument.
-    pub fn new(name: &DmName, dm: &DM, segments: Vec<Segment>) -> DmResult<LinearDev> {
+    pub fn new(name: DmName, dm: &DM, segments: Vec<Segment>) -> DmResult<LinearDev> {
         if segments.is_empty() {
             return Err(DmError::Dm(ErrorEnum::Invalid,
                                    "linear device must have at least one segment".into()));
@@ -48,11 +48,11 @@ impl LinearDev {
         let id = DevId::Name(name);
         let dev_info = if device_exists(dm, name)? {
             // TODO: Verify that kernel's model matches up with segments.
-            Box::new(dm.device_status(&id)?)
+            Box::new(dm.device_status(id)?)
         } else {
             dm.device_create(name, None, DmFlags::empty())?;
             let table = LinearDev::dm_table(&segments);
-            Box::new(table_load(dm, &id, &table)?)
+            Box::new(table_load(dm, id, &table)?)
         };
 
         DM::wait_for_dm();
@@ -127,22 +127,22 @@ impl LinearDev {
         }
 
         let table = LinearDev::dm_table(&self.segments);
-        table_reload(&DM::new()?, &DevId::Name(self.name()), &table)?;
+        table_reload(&DM::new()?, DevId::Name(self.name()), &table)?;
         Ok(())
     }
 
     /// DM name - from the DeviceInfo struct
-    pub fn name(&self) -> &DmName {
+    pub fn name(&self) -> DmName {
         self.dev_info.name()
     }
 
     /// Set the name for this LinearDev.
-    pub fn set_name(&mut self, dm: &DM, name: &DmName) -> DmResult<()> {
+    pub fn set_name(&mut self, dm: &DM, name: DmName) -> DmResult<()> {
         if self.name() == name {
             return Ok(());
         }
-        dm.device_rename(self.dev_info.name(), &DevId::Name(name))?;
-        self.dev_info = Box::new(dm.device_status(&DevId::Name(name))?);
+        dm.device_rename(self.name(), DevId::Name(name))?;
+        self.dev_info = Box::new(dm.device_status(DevId::Name(name))?);
         Ok(())
     }
 
@@ -170,7 +170,7 @@ impl LinearDev {
 
     /// Remove the device from DM
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
 }
@@ -189,7 +189,10 @@ mod tests {
 
     /// Verify that a new linear dev with 0 segments fails.
     fn test_empty(_paths: &[&Path]) -> () {
-        assert!(LinearDev::new("new", &DM::new().unwrap(), vec![]).is_err());
+        assert!(LinearDev::new(DmName::new("new").expect("valid format"),
+                               &DM::new().unwrap(),
+                               vec![])
+                        .is_err());
     }
 
     /// Verify that id rename succeeds.
@@ -199,11 +202,14 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
-        let mut ld = LinearDev::new(name, &dm, vec![Segment::new(dev, Sectors(0), Sectors(1))])
-            .unwrap();
+        let mut ld = LinearDev::new(DmName::new(name).expect("valid format"),
+                                    &dm,
+                                    vec![Segment::new(dev, Sectors(0), Sectors(1))])
+                .unwrap();
 
-        ld.set_name(&dm, name).unwrap();
-        assert_eq!(ld.name(), name);
+        ld.set_name(&dm, DmName::new(name).expect("valid format"))
+            .unwrap();
+        assert_eq!(ld.name(), DmName::new(name).expect("valid format"));
 
         ld.teardown(&dm).unwrap();
     }
@@ -215,12 +221,15 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
-        let mut ld = LinearDev::new(name, &dm, vec![Segment::new(dev, Sectors(0), Sectors(1))])
-            .unwrap();
+        let mut ld = LinearDev::new(DmName::new(name).expect("valid format"),
+                                    &dm,
+                                    vec![Segment::new(dev, Sectors(0), Sectors(1))])
+                .unwrap();
 
         let new_name = "new_name";
-        ld.set_name(&dm, new_name).unwrap();
-        assert_eq!(ld.name(), new_name);
+        ld.set_name(&dm, DmName::new(new_name).expect("valid format"))
+            .unwrap();
+        assert_eq!(ld.name(), DmName::new(new_name).expect("valid format"));
 
         ld.teardown(&dm).unwrap();
     }
@@ -238,8 +247,9 @@ mod tests {
                             Segment::new(dev, Sectors(0), Sectors(1))];
         let range: Sectors = segments.iter().map(|s| s.length).sum();
         let count = segments.len();
-        let ld = LinearDev::new(name, &dm, segments).unwrap();
-        assert_eq!(dm.table_status(&DevId::Name(name), DM_STATUS_TABLE)
+        let ld = LinearDev::new(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
+        assert_eq!(dm.table_status(DevId::Name(DmName::new(name).expect("valid format")),
+                                   DM_STATUS_TABLE)
                        .unwrap()
                        .1
                        .len(),
@@ -266,11 +276,17 @@ mod tests {
         let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
         let segments = vec![Segment::new(dev, Sectors(0), Sectors(1))];
         let table = LinearDev::dm_table(&segments);
-        let ld = LinearDev::new(name, &dm, vec![Segment::new(dev, Sectors(0), Sectors(1))])
-            .unwrap();
-        assert!(LinearDev::new(name, &dm, vec![Segment::new(dev, Sectors(1), Sectors(1))]).is_ok());
+        let ld = LinearDev::new(DmName::new(name).expect("valid format"),
+                                &dm,
+                                vec![Segment::new(dev, Sectors(0), Sectors(1))])
+                .unwrap();
+        assert!(LinearDev::new(DmName::new(name).expect("valid format"),
+                               &dm,
+                               vec![Segment::new(dev, Sectors(1), Sectors(1))])
+                        .is_ok());
         assert_eq!(table,
-                   dm.table_status(&DevId::Name(name), DM_STATUS_TABLE)
+                   dm.table_status(DevId::Name(DmName::new(name).expect("valid format")),
+                                   DM_STATUS_TABLE)
                        .unwrap()
                        .1);
 
@@ -283,9 +299,11 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
-        let ld = LinearDev::new("name", &dm, vec![Segment::new(dev, Sectors(0), Sectors(1))])
-            .unwrap();
-        let ld2 = LinearDev::new("ersatz",
+        let ld = LinearDev::new(DmName::new("name").expect("valid format"),
+                                &dm,
+                                vec![Segment::new(dev, Sectors(0), Sectors(1))])
+                .unwrap();
+        let ld2 = LinearDev::new(DmName::new("ersatz").expect("valid format"),
                                  &dm,
                                  vec![Segment::new(dev, Sectors(0), Sectors(1))]);
         assert!(ld2.is_ok());
@@ -303,9 +321,10 @@ mod tests {
         let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
         let segments = vec![Segment::new(dev, Sectors(0), Sectors(1))];
         let table = LinearDev::dm_table(&segments);
-        let ld = LinearDev::new(name, &dm, segments).unwrap();
+        let ld = LinearDev::new(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
         assert_eq!(table,
-                   dm.table_status(&DevId::Name(name), DM_STATUS_TABLE)
+                   dm.table_status(DevId::Name(DmName::new(name).expect("valid format")),
+                                   DM_STATUS_TABLE)
                        .unwrap()
                        .1);
         ld.teardown(&dm).unwrap();

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -138,7 +138,7 @@ impl LinearDev {
 
     /// Set the name for this LinearDev.
     pub fn set_name(&mut self, dm: &DM, name: &DmName) -> DmResult<()> {
-        self.dev_info = Box::new(dm.device_rename(self.dev_info.name(), name, DmFlags::empty())?);
+        self.dev_info = Box::new(dm.device_rename(&DevId::Name(self.dev_info.name()), name)?);
 
         Ok(())
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -141,7 +141,7 @@ impl LinearDev {
         if self.name() == name {
             return Ok(());
         }
-        dm.device_rename(self.dev_info.name(), name)?;
+        dm.device_rename(self.dev_info.name(), &DevId::Name(name))?;
         self.dev_info = Box::new(dm.device_status(&DevId::Name(name))?);
         Ok(())
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 use consts::DmFlags;
 use deviceinfo::DeviceInfo;
-use dm::{DM, DevId};
+use dm::{DM, DevId, DmName};
 use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
 use shared::{device_exists, table_load, table_reload};
@@ -39,7 +39,7 @@ impl LinearDev {
     /// undefined.
     /// TODO: If the linear device already exists, verify that the kernel's
     /// model matches the segments argument.
-    pub fn new(name: &str, dm: &DM, segments: Vec<Segment>) -> DmResult<LinearDev> {
+    pub fn new(name: &DmName, dm: &DM, segments: Vec<Segment>) -> DmResult<LinearDev> {
         if segments.is_empty() {
             return Err(DmError::Dm(ErrorEnum::Invalid,
                                    "linear device must have at least one segment".into()));
@@ -132,12 +132,12 @@ impl LinearDev {
     }
 
     /// DM name - from the DeviceInfo struct
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &DmName {
         self.dev_info.name()
     }
 
     /// Set the name for this LinearDev.
-    pub fn set_name(&mut self, dm: &DM, name: &str) -> DmResult<()> {
+    pub fn set_name(&mut self, dm: &DM, name: &DmName) -> DmResult<()> {
         self.dev_info = Box::new(dm.device_rename(self.dev_info.name(), name, DmFlags::empty())?);
 
         Ok(())

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -138,6 +138,9 @@ impl LinearDev {
 
     /// Set the name for this LinearDev.
     pub fn set_name(&mut self, dm: &DM, name: &DmName) -> DmResult<()> {
+        if self.name() == name {
+            return Ok(());
+        }
         dm.device_rename(self.dev_info.name(), name)?;
         self.dev_info = Box::new(dm.device_status(&DevId::Name(name))?);
         Ok(())
@@ -187,6 +190,22 @@ mod tests {
     /// Verify that a new linear dev with 0 segments fails.
     fn test_empty(_paths: &[&Path]) -> () {
         assert!(LinearDev::new("new", &DM::new().unwrap(), vec![]).is_err());
+    }
+
+    /// Verify that id rename succeeds.
+    fn test_rename_id(paths: &[&Path]) -> () {
+        assert!(paths.len() >= 1);
+
+        let dm = DM::new().unwrap();
+        let name = "name";
+        let dev = Device::from_str(&paths[0].to_string_lossy()).unwrap();
+        let mut ld = LinearDev::new(name, &dm, vec![Segment::new(dev, Sectors(0), Sectors(1))])
+            .unwrap();
+
+        ld.set_name(&dm, name).unwrap();
+        assert_eq!(ld.name(), name);
+
+        ld.teardown(&dm).unwrap();
     }
 
     /// Verify that after a rename, the device has the new name.
@@ -305,6 +324,11 @@ mod tests {
     #[test]
     fn loop_test_rename() {
         test_with_spec(1, test_rename);
+    }
+
+    #[test]
+    fn loop_test_rename_id() {
+        test_with_spec(1, test_rename_id);
     }
 
     #[test]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -7,7 +7,7 @@
 
 use super::consts::{DmFlags, DM_SUSPEND};
 use super::deviceinfo::DeviceInfo;
-use super::dm::{DevId, DM};
+use super::dm::{DevId, DM, DmName};
 use super::result::DmResult;
 use super::types::TargetLineArg;
 
@@ -40,7 +40,7 @@ pub fn table_reload<T1, T2>(dm: &DM,
 }
 
 /// Check if a device of the given name exists.
-pub fn device_exists(dm: &DM, name: &str) -> DmResult<bool> {
+pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
     Ok(dm.list_devices()
            .map(|l| l.iter().any(|&(ref n, _)| n == name))?)
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -13,7 +13,7 @@ use super::types::TargetLineArg;
 
 /// Load the table for a device.
 pub fn table_load<T1, T2>(dm: &DM,
-                          id: &DevId,
+                          id: DevId,
                           table: &[TargetLineArg<T1, T2>])
                           -> DmResult<DeviceInfo>
     where T1: AsRef<str>,
@@ -27,7 +27,7 @@ pub fn table_load<T1, T2>(dm: &DM,
 
 /// Reload the table for a device
 pub fn table_reload<T1, T2>(dm: &DM,
-                            id: &DevId,
+                            id: DevId,
                             table: &[TargetLineArg<T1, T2>])
                             -> DmResult<DeviceInfo>
     where T1: AsRef<str>,
@@ -40,7 +40,7 @@ pub fn table_reload<T1, T2>(dm: &DM,
 }
 
 /// Check if a device of the given name exists.
-pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
+pub fn device_exists(dm: &DM, name: DmName) -> DmResult<bool> {
     Ok(dm.list_devices()
-           .map(|l| l.iter().any(|&(ref n, _)| n == name))?)
+           .map(|l| l.iter().any(|&(ref n, _)| n.as_ref() == name))?)
 }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -9,8 +9,8 @@ use serde;
 
 use consts::DmFlags;
 use deviceinfo::DeviceInfo;
-use dm::{DM, DevId};
-use result::{DmResult, DmError, ErrorEnum};
+use dm::{DM, DevId, DmName};
+use result::{DmError, DmResult, ErrorEnum};
 use shared::{device_exists, table_load, table_reload};
 use thinpooldev::ThinPoolDev;
 use types::TargetLine;
@@ -94,7 +94,7 @@ pub enum ThinStatus {
 impl ThinDev {
     /// Use the given ThinPoolDev as backing space for a newly constructed
     /// thin provisioned ThinDev returned by new().
-    pub fn new(name: &str,
+    pub fn new(name: &DmName,
                dm: &DM,
                thin_pool: &ThinPoolDev,
                thin_id: ThinDevId,
@@ -111,7 +111,7 @@ impl ThinDev {
     /// on the metadata device for its thin pool.
     /// TODO: If the device is already known to the kernel, verify that kernel
     /// model matches arguments.
-    pub fn setup(name: &str,
+    pub fn setup(name: &DmName,
                  dm: &DM,
                  thin_pool: &ThinPoolDev,
                  thin_id: ThinDevId,
@@ -151,7 +151,7 @@ impl ThinDev {
     }
 
     /// name of the thin device
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &DmName {
         self.dev_info.name()
     }
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -94,7 +94,7 @@ pub enum ThinStatus {
 impl ThinDev {
     /// Use the given ThinPoolDev as backing space for a newly constructed
     /// thin provisioned ThinDev returned by new().
-    pub fn new(name: &DmName,
+    pub fn new(name: DmName,
                dm: &DM,
                thin_pool: &ThinPoolDev,
                thin_id: ThinDevId,
@@ -111,7 +111,7 @@ impl ThinDev {
     /// on the metadata device for its thin pool.
     /// TODO: If the device is already known to the kernel, verify that kernel
     /// model matches arguments.
-    pub fn setup(name: &DmName,
+    pub fn setup(name: DmName,
                  dm: &DM,
                  thin_pool: &ThinPoolDev,
                  thin_id: ThinDevId,
@@ -123,11 +123,11 @@ impl ThinDev {
 
         let dev_info = if device_exists(dm, name)? {
             // TODO: Verify that kernel's model matches arguments.
-            dm.device_status(&id)?
+            dm.device_status(id)?
         } else {
             dm.device_create(name, None, DmFlags::empty())?;
             let table = ThinDev::dm_table(&thin_pool_dstr, thin_id, length);
-            table_load(dm, &id, &table)?
+            table_load(dm, id, &table)?
         };
 
         DM::wait_for_dm();
@@ -151,7 +151,7 @@ impl ThinDev {
     }
 
     /// name of the thin device
-    pub fn name(&self) -> &DmName {
+    pub fn name(&self) -> DmName {
         self.dev_info.name()
     }
 
@@ -184,8 +184,7 @@ impl ThinDev {
 
     /// Get the current status of the thin device.
     pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
-        let (_, mut status) =
-            dm.table_status(&DevId::Name(self.dev_info.name()), DmFlags::empty())?;
+        let (_, mut status) = dm.table_status(DevId::Name(self.name()), DmFlags::empty())?;
 
         assert_eq!(status.len(),
                    1,
@@ -214,7 +213,7 @@ impl ThinDev {
         self.size += sectors;
 
         table_reload(dm,
-                     &DevId::Name(self.dev_info.name()),
+                     DevId::Name(self.name()),
                      &ThinDev::dm_table(&self.thinpool_dstr, self.thin_id, self.size))?;
 
         Ok(())
@@ -232,7 +231,7 @@ impl ThinDev {
 
     /// Tear down the DM device.
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
 }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 
 use consts::{DmFlags, IEC};
 use deviceinfo::DeviceInfo;
-use dm::{DM, DevId};
+use dm::{DM, DevId, DmName};
 use lineardev::LinearDev;
 use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
@@ -86,7 +86,7 @@ impl ThinPoolDev {
     /// Construct a new ThinPoolDev with the given data and meta devs.
     /// TODO: If the device already exists, verify that kernel's model
     /// matches arguments.
-    pub fn new(name: &str,
+    pub fn new(name: &DmName,
                dm: &DM,
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
@@ -132,7 +132,7 @@ impl ThinPoolDev {
     /// Set up an existing ThinPoolDev.
     /// By "existing" is here meant that metadata for the thinpool already
     /// exists on the thinpool's metadata device.
-    pub fn setup(name: &str,
+    pub fn setup(name: &DmName,
                  dm: &DM,
                  data_block_size: Sectors,
                  low_water_mark: DataBlocks,
@@ -178,7 +178,7 @@ impl ThinPoolDev {
     }
 
     /// name of the thin pool device
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &DmName {
         self.dev_info.name()
     }
 


### PR DESCRIPTION
This PR is supposed to help clarify the use of various things for identifying devices.

* It rewrites DevId substantially.
* It documents that a devicemapper uuid is not an ISO standard UUID.
* It changes a confusing parameter name, "name", to "id", which is a bit better.
* ```DM::device_rename()``` does not allow specifying the device by uuid either when renaming or when setting a uuid.
* Has LinearDev::set_name() return the DeviceInfo from device_status() call.
* Makes LinearDev::set_name() idempotent.
* Adds a bunch of tests.

Resolves #90.
Resolves #92.