### PR TITLE
Change DmName/DmUuid to be unsized

### DIFF
--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -45,7 +45,7 @@ impl DeviceInfo {
     }
 
     /// The device's name.
-    pub fn name(&self) -> DmName {
+    pub fn name(&self) -> &DmName {
         let name: &[u8; DM_NAME_LEN] = unsafe { transmute(&self.hdr.name) };
         let slc = slice_to_null(name).expect("kernel ensures null-terminated");
         let name = from_utf8(slc).expect("kernel ensures ASCII characters");
@@ -53,7 +53,7 @@ impl DeviceInfo {
     }
 
     /// The device's devicemapper uuid.
-    pub fn uuid(&self) -> DmUuid {
+    pub fn uuid(&self) -> &DmUuid {
         let uuid: &[u8; DM_UUID_LEN] = unsafe { transmute(&self.hdr.uuid) };
         let slc = slice_to_null(uuid).expect("kernel ensures null-terminated");
         let uuid = from_utf8(slc).expect("kernel ensures ASCII characters");

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -38,7 +38,7 @@ impl LinearDev {
     /// undefined.
     /// TODO: If the linear device already exists, verify that the kernel's
     /// model matches the segments argument.
-    pub fn new(name: DmName, dm: &DM, segments: Vec<Segment>) -> DmResult<LinearDev> {
+    pub fn new(name: &DmName, dm: &DM, segments: Vec<Segment>) -> DmResult<LinearDev> {
         if segments.is_empty() {
             return Err(DmError::Dm(ErrorEnum::Invalid,
                                    "linear device must have at least one segment".into()));
@@ -47,11 +47,11 @@ impl LinearDev {
         let id = DevId::Name(name);
         let dev_info = if device_exists(dm, name)? {
             // TODO: Verify that kernel's model matches up with segments.
-            Box::new(dm.device_status(id)?)
+            Box::new(dm.device_status(&id)?)
         } else {
             dm.device_create(name, None, DmFlags::empty())?;
             let table = LinearDev::dm_table(&segments);
-            Box::new(table_load(dm, id, &table)?)
+            Box::new(table_load(dm, &id, &table)?)
         };
 
         DM::wait_for_dm();
@@ -126,22 +126,22 @@ impl LinearDev {
         }
 
         let table = LinearDev::dm_table(&self.segments);
-        table_reload(&DM::new()?, DevId::Name(self.name()), &table)?;
+        table_reload(&DM::new()?, &DevId::Name(self.name()), &table)?;
         Ok(())
     }
 
     /// DM name - from the DeviceInfo struct
-    pub fn name(&self) -> DmName {
+    pub fn name(&self) -> &DmName {
         self.dev_info.name()
     }
 
     /// Set the name for this LinearDev.
-    pub fn set_name(&mut self, dm: &DM, name: DmName) -> DmResult<()> {
+    pub fn set_name(&mut self, dm: &DM, name: &DmName) -> DmResult<()> {
         if self.name() == name {
             return Ok(());
         }
-        dm.device_rename(self.name(), DevId::Name(name))?;
-        self.dev_info = Box::new(dm.device_status(DevId::Name(name))?);
+        dm.device_rename(self.name(), &DevId::Name(name))?;
+        self.dev_info = Box::new(dm.device_status(&DevId::Name(name))?);
         Ok(())
     }
 
@@ -169,7 +169,7 @@ impl LinearDev {
 
     /// Remove the device from DM
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
 }
@@ -247,7 +247,7 @@ mod tests {
         let range: Sectors = segments.iter().map(|s| s.length).sum();
         let count = segments.len();
         let ld = LinearDev::new(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
-        assert_eq!(dm.table_status(DevId::Name(DmName::new(name).expect("valid format")),
+        assert_eq!(dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)
                        .unwrap()
                        .1
@@ -284,7 +284,7 @@ mod tests {
                                vec![Segment::new(dev, Sectors(1), Sectors(1))])
                         .is_ok());
         assert_eq!(table,
-                   dm.table_status(DevId::Name(DmName::new(name).expect("valid format")),
+                   dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)
                        .unwrap()
                        .1);
@@ -322,7 +322,7 @@ mod tests {
         let table = LinearDev::dm_table(&segments);
         let ld = LinearDev::new(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
         assert_eq!(table,
-                   dm.table_status(DevId::Name(DmName::new(name).expect("valid format")),
+                   dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)
                        .unwrap()
                        .1);

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -13,7 +13,7 @@ use super::types::TargetLineArg;
 
 /// Load the table for a device.
 pub fn table_load<T1, T2>(dm: &DM,
-                          id: DevId,
+                          id: &DevId,
                           table: &[TargetLineArg<T1, T2>])
                           -> DmResult<DeviceInfo>
     where T1: AsRef<str>,
@@ -27,7 +27,7 @@ pub fn table_load<T1, T2>(dm: &DM,
 
 /// Reload the table for a device
 pub fn table_reload<T1, T2>(dm: &DM,
-                            id: DevId,
+                            id: &DevId,
                             table: &[TargetLineArg<T1, T2>])
                             -> DmResult<DeviceInfo>
     where T1: AsRef<str>,
@@ -40,7 +40,9 @@ pub fn table_reload<T1, T2>(dm: &DM,
 }
 
 /// Check if a device of the given name exists.
-pub fn device_exists(dm: &DM, name: DmName) -> DmResult<bool> {
+pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
+    // TODO: Why do we have to call .as_ref() here instead of relying on deref
+    // coercion?
     Ok(dm.list_devices()
            .map(|l| l.iter().any(|&(ref n, _)| n.as_ref() == name))?)
 }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -94,7 +94,7 @@ pub enum ThinStatus {
 impl ThinDev {
     /// Use the given ThinPoolDev as backing space for a newly constructed
     /// thin provisioned ThinDev returned by new().
-    pub fn new(name: DmName,
+    pub fn new(name: &DmName,
                dm: &DM,
                thin_pool: &ThinPoolDev,
                thin_id: ThinDevId,
@@ -111,7 +111,7 @@ impl ThinDev {
     /// on the metadata device for its thin pool.
     /// TODO: If the device is already known to the kernel, verify that kernel
     /// model matches arguments.
-    pub fn setup(name: DmName,
+    pub fn setup(name: &DmName,
                  dm: &DM,
                  thin_pool: &ThinPoolDev,
                  thin_id: ThinDevId,
@@ -123,11 +123,11 @@ impl ThinDev {
 
         let dev_info = if device_exists(dm, name)? {
             // TODO: Verify that kernel's model matches arguments.
-            dm.device_status(id)?
+            dm.device_status(&id)?
         } else {
             dm.device_create(name, None, DmFlags::empty())?;
             let table = ThinDev::dm_table(&thin_pool_dstr, thin_id, length);
-            table_load(dm, id, &table)?
+            table_load(dm, &id, &table)?
         };
 
         DM::wait_for_dm();
@@ -151,7 +151,7 @@ impl ThinDev {
     }
 
     /// name of the thin device
-    pub fn name(&self) -> DmName {
+    pub fn name(&self) -> &DmName {
         self.dev_info.name()
     }
 
@@ -184,7 +184,7 @@ impl ThinDev {
 
     /// Get the current status of the thin device.
     pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
-        let (_, mut status) = dm.table_status(DevId::Name(self.name()), DmFlags::empty())?;
+        let (_, mut status) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
 
         assert_eq!(status.len(),
                    1,
@@ -213,7 +213,7 @@ impl ThinDev {
         self.size += sectors;
 
         table_reload(dm,
-                     DevId::Name(self.name()),
+                     &DevId::Name(self.name()),
                      &ThinDev::dm_table(&self.thinpool_dstr, self.thin_id, self.size))?;
 
         Ok(())
@@ -231,7 +231,7 @@ impl ThinDev {
 
     /// Tear down the DM device.
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
 }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -86,7 +86,7 @@ impl ThinPoolDev {
     /// Construct a new ThinPoolDev with the given data and meta devs.
     /// TODO: If the device already exists, verify that kernel's model
     /// matches arguments.
-    pub fn new(name: DmName,
+    pub fn new(name: &DmName,
                dm: &DM,
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
@@ -96,12 +96,12 @@ impl ThinPoolDev {
         let id = DevId::Name(name);
         let dev_info = if device_exists(dm, name)? {
             // TODO: Verify that kernel table matches our table.
-            dm.device_status(id)?
+            dm.device_status(&id)?
         } else {
             dm.device_create(name, None, DmFlags::empty())?;
             let table =
                 ThinPoolDev::dm_table(data.size()?, data_block_size, low_water_mark, &meta, &data);
-            table_load(dm, id, &table)?
+            table_load(dm, &id, &table)?
         };
 
         DM::wait_for_dm();
@@ -132,7 +132,7 @@ impl ThinPoolDev {
     /// Set up an existing ThinPoolDev.
     /// By "existing" is here meant that metadata for the thinpool already
     /// exists on the thinpool's metadata device.
-    pub fn setup(name: DmName,
+    pub fn setup(name: &DmName,
                  dm: &DM,
                  data_block_size: Sectors,
                  low_water_mark: DataBlocks,
@@ -173,12 +173,12 @@ impl ThinPoolDev {
 
     /// send a message to DM thin pool
     pub fn message(&self, dm: &DM, message: &str) -> DmResult<()> {
-        dm.target_msg(DevId::Name(self.name()), Sectors(0), message)?;
+        dm.target_msg(&DevId::Name(self.name()), Sectors(0), message)?;
         Ok(())
     }
 
     /// name of the thin pool device
-    pub fn name(&self) -> DmName {
+    pub fn name(&self) -> &DmName {
         self.dev_info.name()
     }
 
@@ -204,7 +204,7 @@ impl ThinPoolDev {
     /// Panics if there is an error parsing the status value.
     // Justification: see comment above DM::parse_table_status.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
-        let (_, mut status) = dm.table_status(DevId::Name(self.name()), DmFlags::empty())?;
+        let (_, mut status) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
 
         assert_eq!(status.len(),
                    1,
@@ -260,7 +260,7 @@ impl ThinPoolDev {
     pub fn extend_meta(&mut self, dm: &DM, new_segs: Vec<Segment>) -> DmResult<()> {
         self.meta_dev.extend(new_segs)?;
         table_reload(dm,
-                     DevId::Name(self.name()),
+                     &DevId::Name(self.name()),
                      &ThinPoolDev::dm_table(self.data_dev.size()?,
                                             self.data_block_size,
                                             self.low_water_mark,
@@ -273,7 +273,7 @@ impl ThinPoolDev {
     pub fn extend_data(&mut self, dm: &DM, new_segs: Vec<Segment>) -> DmResult<()> {
         self.data_dev.extend(new_segs)?;
         table_reload(dm,
-                     DevId::Name(self.name()),
+                     &DevId::Name(self.name()),
                      &ThinPoolDev::dm_table(self.data_dev.size()?,
                                             self.data_block_size,
                                             self.low_water_mark,
@@ -284,7 +284,7 @@ impl ThinPoolDev {
 
     /// Remove the device from DM
     pub fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         self.data_dev.teardown(dm)?;
         self.meta_dev.teardown(dm)?;
         Ok(())


### PR DESCRIPTION
A little poking around to see if we could implement ToOwned for DmName has led me to the conclusion that DmName should be an unsized type, wrapping `str` not `&str`.

This PR undoes some changes in #141. In looking at the code more I gained some insights that would have been REALLY good to bring up in the earlier PR's review. I'm sorry for not doing so earlier and noticing before it was merged (and tagged).