### PR TITLE
Tidy some mentions of Stratis in devicemapper-rs

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -32,8 +32,7 @@ impl fmt::Debug for LinearDev {
 /// linear block device of continuous sectors.
 impl LinearDev {
     /// Construct a new block device by concatenating the given segments
-    /// into linear space.  Use DM to reserve enough space for the stratis
-    /// metadata on each DmDev.
+    /// into linear space.
     /// Warning: If the segments overlap, this method will succeed. However,
     /// the behavior of the linear device in that case should be treated as
     /// undefined.

--- a/src/loopbacked.rs
+++ b/src/loopbacked.rs
@@ -110,7 +110,7 @@ fn get_devices(count: u8, dir: &TempDir) -> Vec<LoopTestDev> {
 pub fn test_with_spec<F>(count: u8, test: F) -> ()
     where F: Fn(&[&Path]) -> ()
 {
-    let tmpdir = TempDir::new("stratis").unwrap();
+    let tmpdir = TempDir::new("devicemapper").unwrap();
     let loop_devices: Vec<LoopTestDev> = get_devices(count, &tmpdir);
     let device_paths: Vec<PathBuf> = loop_devices.iter().map(|x| x.get_path()).collect();
     let device_paths: Vec<&Path> = device_paths.iter().map(|x| x.as_path()).collect();

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -202,10 +202,7 @@ impl ThinPoolDev {
     /// Get the current status of the thinpool.
     /// Returns an error if there was an error getting the status value.
     /// Panics if there is an error parsing the status value.
-    // The justification for this is that if there was no error in obtaining
-    // the status value, the data is correct and complete.
-    // Therefore, an error in parsing can only result from a change in the
-    // kernel. We assume that Stratis will know in advance about such changes.
+    // Justification: see comment above DM::parse_table_status.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
         let (_, mut status) = dm.table_status(DevId::Name(self.name()), DmFlags::empty())?;
 


### PR DESCRIPTION
Devicemapper stands on its own. There are a few harmless mentions of
Stratis in the code and test strings, but let's try to avoid these just on
principle.

Take the opportunity to describe in more detail how we can be sure the DM
kernel interface won't change under us and cause a crash.

Signed-off-by: Andy Grover <agrover@redhat.com>