### PR TITLE
Clean up DM device if table load fails

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -10,7 +10,7 @@ use deviceinfo::DeviceInfo;
 use dm::{DM, DevId, DmName};
 use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
-use shared::{DmDevice, device_exists, table_load, table_reload};
+use shared::{DmDevice, device_create, device_exists, table_reload};
 use types::{Sectors, TargetLine};
 
 /// A DM construct of combined Segments
@@ -70,9 +70,8 @@ impl LinearDev {
             // TODO: Verify that kernel's model matches up with segments.
             Box::new(dm.device_status(&id)?)
         } else {
-            dm.device_create(name, None, DmFlags::empty())?;
             let table = LinearDev::dm_table(&segments);
-            Box::new(table_load(dm, &id, &table)?)
+            Box::new(device_create(dm, name, &id, &table)?)
         };
 
         DM::wait_for_dm();

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -11,7 +11,7 @@ use consts::DmFlags;
 use deviceinfo::DeviceInfo;
 use dm::{DM, DevId, DmName};
 use result::{DmError, DmResult, ErrorEnum};
-use shared::{DmDevice, device_exists, table_load, table_reload};
+use shared::{DmDevice, device_create, device_exists, table_reload};
 use thinpooldev::ThinPoolDev;
 use types::TargetLine;
 
@@ -148,9 +148,8 @@ impl ThinDev {
             // TODO: Verify that kernel's model matches arguments.
             Box::new(dm.device_status(&id)?)
         } else {
-            dm.device_create(name, None, DmFlags::empty())?;
             let table = ThinDev::dm_table(&thin_pool_dstr, thin_id, length);
-            Box::new(table_load(dm, &id, &table)?)
+            Box::new(device_create(dm, name, &id, &table)?)
         };
 
         DM::wait_for_dm();

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -12,7 +12,7 @@ use dm::{DM, DevId, DmName};
 use lineardev::LinearDev;
 use result::{DmResult, DmError, ErrorEnum};
 use segment::Segment;
-use shared::{DmDevice, device_exists, table_load, table_reload};
+use shared::{DmDevice, device_create, device_exists, table_reload};
 use types::{DataBlocks, MetaBlocks, Sectors, TargetLine};
 
 /// Values are explicitly stated in the device-mapper kernel documentation.
@@ -123,10 +123,9 @@ impl ThinPoolDev {
             // TODO: Verify that kernel table matches our table.
             Box::new(dm.device_status(&id)?)
         } else {
-            dm.device_create(name, None, DmFlags::empty())?;
             let table =
                 ThinPoolDev::dm_table(data.size(), data_block_size, low_water_mark, &meta, &data);
-            Box::new(table_load(dm, &id, &table)?)
+            Box::new(device_create(dm, name, &id, &table)?)
         };
 
         DM::wait_for_dm();


### PR DESCRIPTION
In ThinDev and ThinPoolDev::setup(), we create and load a device if it
doesn't exist. However, if table load fails (e.g. if attempting to load
a thindev whose thin_id doesn't exist) then the newly created device is
left dangling. In this case, make sure to not leave the created-but-not-
loaded table as we return with the Err.

Signed-off-by: Andy Grover <agrover@redhat.com>