### PR TITLE
Run cargo-tree from Makefile using "make tree"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 ${HOME}/.cargo/bin/cargo-fmt:
 	cargo install rustfmt --vers 0.8.3
 
+${HOME}/.cargo/bin/cargo-tree:
+	cargo install cargo-tree
+
+tree: ${HOME}/.cargo/bin/cargo-tree
+	PATH=${HOME}/.cargo/bin:${PATH} cargo tree
+
 fmt: ${HOME}/.cargo/bin/cargo-fmt
 	PATH=${HOME}/.cargo/bin:${PATH} cargo fmt -- --write-mode=diff
 
@@ -22,3 +28,4 @@ clippy:
 	test
 	sudo_test
 	clippy
+	tree


### PR DESCRIPTION
This assumes that cargo-tree has been installed in the same way as
cargo-fmt.

Signed-off-by: mulhern <amulhern@redhat.com>