### PR TITLE
Require device() instead of dstr() in DmDevice

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use consts::DmFlags;
+use device::Device;
 use deviceinfo::DeviceInfo;
 use dm::{DM, DevId, DmName};
 use result::{DmResult, DmError, ErrorEnum};
@@ -27,12 +28,12 @@ impl fmt::Debug for LinearDev {
 }
 
 impl DmDevice for LinearDev {
-    fn devnode(&self) -> PathBuf {
-        devnode!(self)
+    fn device(&self) -> Device {
+        device!(self)
     }
 
-    fn dstr(&self) -> String {
-        dstr!(self)
+    fn devnode(&self) -> PathBuf {
+        devnode!(self)
     }
 
     fn name(&self) -> &DmName {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -8,6 +8,7 @@
 use std::path::PathBuf;
 
 use super::consts::{DmFlags, DM_SUSPEND};
+use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::{DevId, DM, DmName};
 use super::result::DmResult;
@@ -18,8 +19,8 @@ pub trait DmDevice {
     /// The device's device node.
     fn devnode(&self) -> PathBuf;
 
-    /// The device's number, formatted as a string <maj:min>.
-    fn dstr(&self) -> String;
+    /// The device.
+    fn device(&self) -> Device;
 
     /// The device's name.
     fn name(&self) -> &DmName;

--- a/src/shared_macros.rs
+++ b/src/shared_macros.rs
@@ -5,15 +5,15 @@
 /// A module to contain functionality shared among the various types of
 /// devices and implemented by means of macros.
 
-macro_rules! name {
+macro_rules! device {
     ($s: ident) => {
-        $s.dev_info.name()
+        $s.dev_info.device()
     }
 }
 
-macro_rules! dstr {
+macro_rules! name {
     ($s: ident) => {
-        $s.dev_info.device().to_string()
+        $s.dev_info.name()
     }
 }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use consts::{DmFlags, IEC};
+use device::Device;
 use deviceinfo::DeviceInfo;
 use dm::{DM, DevId, DmName};
 use lineardev::LinearDev;
@@ -41,12 +42,12 @@ impl fmt::Debug for ThinPoolDev {
 }
 
 impl DmDevice for ThinPoolDev {
-    fn devnode(&self) -> PathBuf {
-        devnode!(self)
+    fn device(&self) -> Device {
+        device!(self)
     }
 
-    fn dstr(&self) -> String {
-        dstr!(self)
+    fn devnode(&self) -> PathBuf {
+        devnode!(self)
     }
 
     fn name(&self) -> &DmName {
@@ -188,8 +189,8 @@ impl ThinPoolDev {
                 data: &LinearDev)
                 -> Vec<TargetLine> {
         let params = format!("{} {} {} {} 1 skip_block_zeroing",
-                             meta.dstr(),
-                             data.dstr(),
+                             meta.device(),
+                             data.device(),
                              *data_block_size,
                              *low_water_mark);
         vec![(Sectors::default(), length, "thin-pool".to_owned(), params)]


### PR DESCRIPTION
Device is copy, and a better choice as an identifier when not passing the
entire DmDevice as an argument.

ThinDev now stores its thinpooldev as a Device, not a String.
The need for a special type for Dstr goes away entirely, since Device
implements Display in the necessary format.

Signed-off-by: mulhern <amulhern@redhat.com>