### PR TITLE
Remove redundant parameter from device_create

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -77,16 +77,16 @@ impl LinearDev {
                                    "linear device must have at least one segment".into()));
         }
 
-        let id = DevId::Name(name);
         let table = LinearDev::dm_table(&segments);
         let dev_info = if device_exists(dm, name)? {
+            let id = DevId::Name(name);
             if dm.table_status(&id, DM_STATUS_TABLE)?.1 != table {
                 let err_msg = "Specified data does not match kernel data";
                 return Err(DmError::Dm(ErrorEnum::Invalid, err_msg.into()));
             }
             Box::new(dm.device_status(&id)?)
         } else {
-            Box::new(device_create(dm, name, &id, &table)?)
+            Box::new(device_create(dm, name, &table)?)
         };
 
         DM::wait_for_dm();

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -35,21 +35,22 @@ pub trait DmDevice {
 /// Create a device, load a table, and resume it.
 pub fn device_create<T1, T2>(dm: &DM,
                              name: &DmName,
-                             id: &DevId,
                              table: &[TargetLineArg<T1, T2>])
                              -> DmResult<DeviceInfo>
     where T1: AsRef<str>,
           T2: AsRef<str>
 {
     dm.device_create(name, None, DmFlags::empty())?;
-    let dev_info = match dm.table_load(id, table) {
+
+    let id = DevId::Name(name);
+    let dev_info = match dm.table_load(&id, table) {
         Err(e) => {
-            dm.device_remove(id, DmFlags::empty())?;
+            dm.device_remove(&id, DmFlags::empty())?;
             return Err(e);
         }
         Ok(dev_info) => dev_info,
     };
-    dm.device_suspend(id, DmFlags::empty())?;
+    dm.device_suspend(&id, DmFlags::empty())?;
 
     Ok(dev_info)
 }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -142,15 +142,15 @@ impl ThinDev {
                  length: Sectors)
                  -> DmResult<ThinDev> {
 
-        let id = DevId::Name(name);
         let thin_pool_device = thin_pool.device();
 
         let dev_info = if device_exists(dm, name)? {
+            let id = DevId::Name(name);
             // TODO: Verify that kernel's model matches arguments.
             Box::new(dm.device_status(&id)?)
         } else {
             let table = ThinDev::dm_table(thin_pool_device, thin_id, length);
-            Box::new(device_create(dm, name, &id, &table)?)
+            Box::new(device_create(dm, name, &table)?)
         };
 
         DM::wait_for_dm();

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -124,14 +124,14 @@ impl ThinPoolDev {
                meta: LinearDev,
                data: LinearDev)
                -> DmResult<ThinPoolDev> {
-        let id = DevId::Name(name);
         let dev_info = if device_exists(dm, name)? {
+            let id = DevId::Name(name);
             // TODO: Verify that kernel table matches our table.
             Box::new(dm.device_status(&id)?)
         } else {
             let table =
                 ThinPoolDev::dm_table(data.size(), data_block_size, low_water_mark, &meta, &data);
-            Box::new(device_create(dm, name, &id, &table)?)
+            Box::new(device_create(dm, name, &table)?)
         };
 
         DM::wait_for_dm();


### PR DESCRIPTION
This was actually a bit of a bug, because it would be bad news if the
name and the id specified different devices.

Signed-off-by: mulhern <amulhern@redhat.com>