### PR TITLE
Pass devicemapper context to LinearDev::extend()

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -132,7 +132,7 @@ impl LinearDev {
     /// segments already in the device, this method will succeed. However,
     /// the behavior of the linear device in that case should be treated as
     /// undefined.
-    pub fn extend(&mut self, new_segs: Vec<Segment>) -> DmResult<()> {
+    pub fn extend(&mut self, dm: &DM, new_segs: Vec<Segment>) -> DmResult<()> {
         if new_segs.is_empty() {
             return Ok(());
         }
@@ -160,7 +160,7 @@ impl LinearDev {
         }
 
         let table = LinearDev::dm_table(&self.segments);
-        table_reload(&DM::new()?, &DevId::Name(self.name()), &table)?;
+        table_reload(dm, &DevId::Name(self.name()), &table)?;
         Ok(())
     }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -272,7 +272,7 @@ impl ThinPoolDev {
 
     /// Extend an existing meta device with additional new segments.
     pub fn extend_meta(&mut self, dm: &DM, new_segs: Vec<Segment>) -> DmResult<()> {
-        self.meta_dev.extend(new_segs)?;
+        self.meta_dev.extend(dm, new_segs)?;
         table_reload(dm,
                      &DevId::Name(self.name()),
                      &ThinPoolDev::dm_table(self.data_dev.size(),
@@ -285,7 +285,7 @@ impl ThinPoolDev {
 
     /// Extend an existing data device with additional new segments.
     pub fn extend_data(&mut self, dm: &DM, new_segs: Vec<Segment>) -> DmResult<()> {
-        self.data_dev.extend(new_segs)?;
+        self.data_dev.extend(dm, new_segs)?;
         table_reload(dm,
                      &DevId::Name(self.name()),
                      &ThinPoolDev::dm_table(self.data_dev.size(),


### PR DESCRIPTION
There is no other method in LinearDev, ThinDev, ThinPoolDev where the
context is instantiated within the method. If the context is required,
it is always passed as a parameter. This makes it the same for this method.

Signed-off-by: mulhern <amulhern@redhat.com>