### PR TITLE
Pass Vec<Segment> as &[Segment]

### DIFF
--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -70,13 +70,13 @@ impl LinearDev {
     /// the existence of the requested device". Of course, a linear device
     /// is usually expected to hold data, so it is important to get the
     /// mapping just right.
-    pub fn setup(name: &DmName, dm: &DM, segments: Vec<Segment>) -> DmResult<LinearDev> {
+    pub fn setup(name: &DmName, dm: &DM, segments: &[Segment]) -> DmResult<LinearDev> {
         if segments.is_empty() {
             return Err(DmError::Dm(ErrorEnum::Invalid,
                                    "linear device must have at least one segment".into()));
         }
 
-        let table = LinearDev::dm_table(&segments);
+        let table = LinearDev::dm_table(segments);
         let dev_info = if device_exists(dm, name)? {
             let id = DevId::Name(name);
             if dm.table_status(&id, DM_STATUS_TABLE)?.1 != table {
@@ -91,7 +91,7 @@ impl LinearDev {
         DM::wait_for_dm();
         Ok(LinearDev {
                dev_info: dev_info,
-               segments: segments,
+               segments: segments.to_vec(),
            })
     }
 
@@ -132,7 +132,7 @@ impl LinearDev {
     /// segments already in the device, this method will succeed. However,
     /// the behavior of the linear device in that case should be treated as
     /// undefined.
-    pub fn extend(&mut self, dm: &DM, new_segs: Vec<Segment>) -> DmResult<()> {
+    pub fn extend(&mut self, dm: &DM, new_segs: &[Segment]) -> DmResult<()> {
         if new_segs.is_empty() {
             return Ok(());
         }
@@ -154,9 +154,9 @@ impl LinearDev {
         };
 
         if coalesced_new_first {
-            self.segments.extend(new_segs.into_iter().skip(1));
+            self.segments.extend(new_segs.iter().skip(1).cloned());
         } else {
-            self.segments.extend(new_segs);
+            self.segments.extend(new_segs.iter().cloned());
         }
 
         let table = LinearDev::dm_table(&self.segments);
@@ -189,7 +189,7 @@ mod tests {
     fn test_empty(_paths: &[&Path]) -> () {
         assert!(LinearDev::setup(DmName::new("new").expect("valid format"),
                                  &DM::new().unwrap(),
-                                 vec![])
+                                 &[])
                         .is_err());
     }
 
@@ -202,7 +202,7 @@ mod tests {
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let mut ld = LinearDev::setup(DmName::new(name).expect("valid format"),
                                       &dm,
-                                      vec![Segment::new(dev, Sectors(0), Sectors(1))])
+                                      &[Segment::new(dev, Sectors(0), Sectors(1))])
                 .unwrap();
 
         ld.set_name(&dm, DmName::new(name).expect("valid format"))
@@ -221,7 +221,7 @@ mod tests {
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let mut ld = LinearDev::setup(DmName::new(name).expect("valid format"),
                                       &dm,
-                                      vec![Segment::new(dev, Sectors(0), Sectors(1))])
+                                      &[Segment::new(dev, Sectors(0), Sectors(1))])
                 .unwrap();
 
         let new_name = "new_name";
@@ -241,8 +241,8 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
-        let segments = vec![Segment::new(dev, Sectors(0), Sectors(1)),
-                            Segment::new(dev, Sectors(0), Sectors(1))];
+        let segments = &[Segment::new(dev, Sectors(0), Sectors(1)),
+                         Segment::new(dev, Sectors(0), Sectors(1))];
         let range: Sectors = segments.iter().map(|s| s.length).sum();
         let count = segments.len();
         let ld = LinearDev::setup(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
@@ -270,15 +270,12 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
-        let segments = vec![Segment::new(dev, Sectors(0), Sectors(1))];
-        let table = LinearDev::dm_table(&segments);
-        let ld = LinearDev::setup(DmName::new(name).expect("valid format"),
-                                  &dm,
-                                  segments.iter().cloned().collect())
-                .unwrap();
+        let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
+        let table = LinearDev::dm_table(segments);
+        let ld = LinearDev::setup(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
         assert!(LinearDev::setup(DmName::new(name).expect("valid format"),
                                  &dm,
-                                 vec![Segment::new(dev, Sectors(1), Sectors(1))])
+                                 &[Segment::new(dev, Sectors(1), Sectors(1))])
                         .is_err());
         assert!(LinearDev::setup(DmName::new(name).expect("valid format"), &dm, segments).is_ok());
         assert_eq!(table,
@@ -296,11 +293,9 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
-        let segments = vec![Segment::new(dev, Sectors(0), Sectors(1))];
-        let ld = LinearDev::setup(DmName::new("name").expect("valid format"),
-                                  &dm,
-                                  segments.iter().cloned().collect())
-                .unwrap();
+        let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
+        let ld = LinearDev::setup(DmName::new("name").expect("valid format"), &dm, segments)
+            .unwrap();
         let ld2 = LinearDev::setup(DmName::new("ersatz").expect("valid format"), &dm, segments);
         assert!(ld2.is_ok());
 
@@ -315,8 +310,8 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
-        let segments = vec![Segment::new(dev, Sectors(0), Sectors(1))];
-        let table = LinearDev::dm_table(&segments);
+        let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
+        let table = LinearDev::dm_table(segments);
         let ld = LinearDev::setup(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
         assert_eq!(table,
                    dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -271,7 +271,7 @@ impl ThinPoolDev {
     }
 
     /// Extend an existing meta device with additional new segments.
-    pub fn extend_meta(&mut self, dm: &DM, new_segs: Vec<Segment>) -> DmResult<()> {
+    pub fn extend_meta(&mut self, dm: &DM, new_segs: &[Segment]) -> DmResult<()> {
         self.meta_dev.extend(dm, new_segs)?;
         table_reload(dm,
                      &DevId::Name(self.name()),
@@ -284,7 +284,7 @@ impl ThinPoolDev {
     }
 
     /// Extend an existing data device with additional new segments.
-    pub fn extend_data(&mut self, dm: &DM, new_segs: Vec<Segment>) -> DmResult<()> {
+    pub fn extend_data(&mut self, dm: &DM, new_segs: &[Segment]) -> DmResult<()> {
         self.data_dev.extend(dm, new_segs)?;
         table_reload(dm,
                      &DevId::Name(self.name()),
@@ -302,15 +302,14 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
     let dev = Device::from(devnode_to_devno(path).unwrap());
     let meta = LinearDev::setup(DmName::new("meta").expect("valid format"),
                                 dm,
-                                vec![Segment::new(dev, Sectors(0), MIN_RECOMMENDED_METADATA_SIZE)])
+                                &[Segment::new(dev, Sectors(0), MIN_RECOMMENDED_METADATA_SIZE)])
             .unwrap();
 
-    let data = LinearDev::setup(DmName::new("data").expect("valid format"),
-                                dm,
-                                vec![Segment::new(dev,
-                                                  MIN_RECOMMENDED_METADATA_SIZE,
-                                                  MIN_DATA_BLOCK_SIZE)])
-            .unwrap();
+    let data =
+        LinearDev::setup(DmName::new("data").expect("valid format"),
+                         dm,
+                         &[Segment::new(dev, MIN_RECOMMENDED_METADATA_SIZE, MIN_DATA_BLOCK_SIZE)])
+                .unwrap();
 
     ThinPoolDev::new(DmName::new("pool").expect("valid format"),
                      dm,


### PR DESCRIPTION
These are really just representations of data, not things that should be
claimed. The segments are all cloneable.

Also, it should make error-chain easier, since the segments no longer
need to be moved in the same way.

Signed-off-by: mulhern <amulhern@redhat.com>