### PR TITLE
Omit debug! in LinearDev::dm_table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ bitflags = "1"
 newtype_derive = "0.1"
 macro-attr = "0.2.0"
 serde = "1"
-log = "0.3"
-env_logger="0.4"
 clippy = {version = "0", optional = true}
 error-chain = "0.11"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,6 @@ extern crate bitflags;
 #[macro_use]
 extern crate error_chain;
 
-#[macro_use]
-extern crate log;
-
 #[cfg(test)]
 extern crate loopdev;
 #[cfg(test)]

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -174,7 +174,6 @@ impl LinearDev {
                 target_type: TargetTypeBuf::new("linear".into()).expect("< length limit"),
                 params: LinearDevTargetParams::new(segment.device, physical_start_offset),
             };
-            debug!("dmtable line : {:?}", line);
             table.push(line);
             logical_start_offset += length;
         }


### PR DESCRIPTION
I believe that it has served its purpose as a development aid, and it
would be unlikely to be all that helpful for customer debugging.

When there is a failure, we would be better served by packaging that
information up in the error returned.

Get rid of log, env_logger requirements. They can be re-added w/ a small
amount of effort as necessary.

Resolves: #16.

Signed-off-by: mulhern <amulhern@redhat.com>