### PR TITLE
Refactor ThinDevId impl into a separate module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,8 @@ mod shared_macros;
 mod lineardev;
 /// allocate a device from a pool
 mod thindev;
+/// the id the pool uses to track its devices
+mod thindevid;
 /// thinpooldev is shared space for  other thin provisioned devices to use
 mod thinpooldev;
 /// struct to represent a location, offset and size of a set of disk sectors
@@ -115,5 +117,6 @@ pub use result::{DmResult, DmError, ErrorEnum};
 pub use segment::Segment;
 pub use shared::{DmDevice, device_exists};
 pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
-pub use thindev::{ThinDev, ThinDevId, ThinStatus};
+pub use thindev::{ThinDev, ThinStatus};
+pub use thindevid::ThinDevId;
 pub use types::{Bytes, DataBlocks, MetaBlocks, Sectors};

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -2,67 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::fmt;
 use std::path::PathBuf;
-
-use serde;
 
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DM_SUSPEND, DevId, DmFlags, DmName};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, device_create, device_exists, device_setup, table_reload};
+use super::thindevid::ThinDevId;
 use super::thinpooldev::ThinPoolDev;
 use super::types::{Sectors, TargetLine};
-
-const THIN_DEV_ID_LIMIT: u64 = 0x1_000_000; // 2 ^ 24
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-/// A thindev id is a 24 bit number, i.e., its bit width is not a power of 2.
-pub struct ThinDevId {
-    value: u32,
-}
-
-impl ThinDevId {
-    /// Make a new ThinDevId.
-    /// Return an error if value is too large to represent in 24 bits.
-    pub fn new_u64(value: u64) -> DmResult<ThinDevId> {
-        if value < THIN_DEV_ID_LIMIT {
-            Ok(ThinDevId { value: value as u32 })
-        } else {
-            Err(DmError::Dm(ErrorEnum::Invalid,
-                            format!("argument {} unrepresentable in 24 bits", value)))
-        }
-    }
-}
-
-impl From<ThinDevId> for u32 {
-    fn from(id: ThinDevId) -> u32 {
-        id.value
-    }
-}
-
-impl fmt::Display for ThinDevId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.value, f)
-    }
-}
-
-impl serde::Serialize for ThinDevId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: serde::Serializer
-    {
-        serializer.serialize_u32(self.value)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for ThinDevId {
-    fn deserialize<D>(deserializer: D) -> Result<ThinDevId, D::Error>
-        where D: serde::de::Deserializer<'de>
-    {
-        Ok(ThinDevId { value: serde::Deserialize::deserialize(deserializer)? })
-    }
-}
 
 /// DM construct for a thin block device
 #[derive(Debug)]
@@ -280,13 +229,6 @@ mod tests {
     use super::*;
 
     const MIN_THIN_DEV_SIZE: Sectors = Sectors(1);
-
-    #[test]
-    /// Verify that new_checked_u64 discriminates.
-    fn test_new_checked_u64() {
-        assert!(ThinDevId::new_u64(2u64.pow(32)).is_err());
-        assert!(ThinDevId::new_u64(THIN_DEV_ID_LIMIT - 1).is_ok());
-    }
 
     /// Verify that specifying a size of 0 Sectors will cause a failure.
     fn test_zero_size(paths: &[&Path]) -> () {

--- a/src/thindevid.rs
+++ b/src/thindevid.rs
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::fmt;
+
+use serde;
+
+use super::result::{DmError, DmResult, ErrorEnum};
+
+const THIN_DEV_ID_LIMIT: u64 = 0x1_000_000; // 2 ^ 24
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+/// A thindev id is a 24 bit number, i.e., its bit width is not a power of 2.
+pub struct ThinDevId {
+    value: u32,
+}
+
+impl ThinDevId {
+    /// Make a new ThinDevId.
+    /// Return an error if value is too large to represent in 24 bits.
+    pub fn new_u64(value: u64) -> DmResult<ThinDevId> {
+        if value < THIN_DEV_ID_LIMIT {
+            Ok(ThinDevId { value: value as u32 })
+        } else {
+            Err(DmError::Dm(ErrorEnum::Invalid,
+                            format!("argument {} unrepresentable in 24 bits", value)))
+        }
+    }
+}
+
+impl From<ThinDevId> for u32 {
+    fn from(id: ThinDevId) -> u32 {
+        id.value
+    }
+}
+
+impl fmt::Display for ThinDevId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.value, f)
+    }
+}
+
+impl serde::Serialize for ThinDevId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer
+    {
+        serializer.serialize_u32(self.value)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ThinDevId {
+    fn deserialize<D>(deserializer: D) -> Result<ThinDevId, D::Error>
+        where D: serde::de::Deserializer<'de>
+    {
+        Ok(ThinDevId { value: serde::Deserialize::deserialize(deserializer)? })
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    /// Verify that new_checked_u64 discriminates.
+    fn test_new_checked_u64() {
+        assert!(ThinDevId::new_u64(2u64.pow(32)).is_err());
+        assert!(ThinDevId::new_u64(THIN_DEV_ID_LIMIT - 1).is_ok());
+    }
+}


### PR DESCRIPTION
For better encapsulation and testing; it should make other refactorings
easier.

Signed-off-by: mulhern <amulhern@redhat.com>