### PR TITLE
Add optional UUID parameter to setup() and new() methods

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -1122,10 +1122,13 @@ mod tests {
     /// The table should have an entry for a newly created device.
     /// The device has no segments, so the second part of the info should
     /// be empty.
+    /// The UUID of the returned info should be the device's UUID.
     fn sudo_test_table_status() {
         let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
-        dm.device_create(name, None, DmFlags::empty()).unwrap();
+        let uuid = DmUuid::new("uuid").expect("is valid DM UUID");
+        dm.device_create(name, Some(uuid), DmFlags::empty())
+            .unwrap();
 
         let status;
         loop {
@@ -1136,6 +1139,7 @@ mod tests {
         }
 
         assert!(status.1.is_empty());
+        assert_eq!(status.0.uuid(), Some(uuid));
         dm.device_remove(&DevId::Name(name), DmFlags::empty())
             .unwrap();
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -71,7 +71,7 @@ impl LinearDev {
         }
 
         let table = LinearDev::dm_table(segments);
-        let dev_info = device_setup(dm, name, &table)?;
+        let dev_info = device_setup(dm, name, None, &table)?;
 
         DM::wait_for_dm();
         Ok(LinearDev {

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -64,7 +64,7 @@ impl LinearDev {
     /// the existence of the requested device". Of course, a linear device
     /// is usually expected to hold data, so it is important to get the
     /// mapping just right.
-    pub fn setup(name: &DmName, dm: &DM, segments: &[Segment]) -> DmResult<LinearDev> {
+    pub fn setup(dm: &DM, name: &DmName, segments: &[Segment]) -> DmResult<LinearDev> {
         if segments.is_empty() {
             return Err(DmError::Dm(ErrorEnum::Invalid,
                                    "linear device must have at least one segment".into()));
@@ -173,8 +173,8 @@ mod tests {
 
     /// Verify that a new linear dev with 0 segments fails.
     fn test_empty(_paths: &[&Path]) -> () {
-        assert!(LinearDev::setup(DmName::new("new").expect("valid format"),
-                                 &DM::new().unwrap(),
+        assert!(LinearDev::setup(&DM::new().unwrap(),
+                                 DmName::new("new").expect("valid format"),
                                  &[])
                         .is_err());
     }
@@ -186,8 +186,8 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
-        let mut ld = LinearDev::setup(DmName::new(name).expect("valid format"),
-                                      &dm,
+        let mut ld = LinearDev::setup(&dm,
+                                      DmName::new(name).expect("valid format"),
                                       &[Segment::new(dev, Sectors(0), Sectors(1))])
                 .unwrap();
 
@@ -205,8 +205,8 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
-        let mut ld = LinearDev::setup(DmName::new(name).expect("valid format"),
-                                      &dm,
+        let mut ld = LinearDev::setup(&dm,
+                                      DmName::new(name).expect("valid format"),
                                       &[Segment::new(dev, Sectors(0), Sectors(1))])
                 .unwrap();
 
@@ -231,7 +231,7 @@ mod tests {
                          Segment::new(dev, Sectors(0), Sectors(1))];
         let range: Sectors = segments.iter().map(|s| s.length).sum();
         let count = segments.len();
-        let ld = LinearDev::setup(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
+        let ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), segments).unwrap();
         assert_eq!(dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)
                        .unwrap()
@@ -258,12 +258,12 @@ mod tests {
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
         let table = LinearDev::dm_table(segments);
-        let ld = LinearDev::setup(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
-        assert!(LinearDev::setup(DmName::new(name).expect("valid format"),
-                                 &dm,
+        let ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), segments).unwrap();
+        assert!(LinearDev::setup(&dm,
+                                 DmName::new(name).expect("valid format"),
                                  &[Segment::new(dev, Sectors(1), Sectors(1))])
                         .is_err());
-        assert!(LinearDev::setup(DmName::new(name).expect("valid format"), &dm, segments).is_ok());
+        assert!(LinearDev::setup(&dm, DmName::new(name).expect("valid format"), segments).is_ok());
         assert_eq!(table,
                    dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)
@@ -280,9 +280,9 @@ mod tests {
         let dm = DM::new().unwrap();
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
-        let ld = LinearDev::setup(DmName::new("name").expect("valid format"), &dm, segments)
+        let ld = LinearDev::setup(&dm, DmName::new("name").expect("valid format"), segments)
             .unwrap();
-        let ld2 = LinearDev::setup(DmName::new("ersatz").expect("valid format"), &dm, segments);
+        let ld2 = LinearDev::setup(&dm, DmName::new("ersatz").expect("valid format"), segments);
         assert!(ld2.is_ok());
 
         ld2.unwrap().teardown(&dm).unwrap();
@@ -299,7 +299,7 @@ mod tests {
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1)),
                          Segment::new(dev, Sectors(1), Sectors(1))];
         let table = LinearDev::dm_table(segments);
-        let ld = LinearDev::setup(DmName::new(name).expect("valid format"), &dm, segments).unwrap();
+        let ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), segments).unwrap();
         assert_eq!(table,
                    dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::{DM, DevId, DmFlags, DmName};
+use super::dm::{DM, DevId, DmFlags, DmName, DmUuid};
 use super::result::{DmResult, DmError, ErrorEnum};
 use super::segment::Segment;
 use super::shared::{DmDevice, device_setup, table_reload};
@@ -64,14 +64,18 @@ impl LinearDev {
     /// the existence of the requested device". Of course, a linear device
     /// is usually expected to hold data, so it is important to get the
     /// mapping just right.
-    pub fn setup(dm: &DM, name: &DmName, segments: &[Segment]) -> DmResult<LinearDev> {
+    pub fn setup(dm: &DM,
+                 name: &DmName,
+                 uuid: Option<&DmUuid>,
+                 segments: &[Segment])
+                 -> DmResult<LinearDev> {
         if segments.is_empty() {
             return Err(DmError::Dm(ErrorEnum::Invalid,
                                    "linear device must have at least one segment".into()));
         }
 
         let table = LinearDev::dm_table(segments);
-        let dev_info = device_setup(dm, name, None, &table)?;
+        let dev_info = device_setup(dm, name, uuid, &table)?;
 
         DM::wait_for_dm();
         Ok(LinearDev {
@@ -175,6 +179,7 @@ mod tests {
     fn test_empty(_paths: &[&Path]) -> () {
         assert!(LinearDev::setup(&DM::new().unwrap(),
                                  DmName::new("new").expect("valid format"),
+                                 None,
                                  &[])
                         .is_err());
     }
@@ -188,6 +193,7 @@ mod tests {
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let mut ld = LinearDev::setup(&dm,
                                       DmName::new(name).expect("valid format"),
+                                      None,
                                       &[Segment::new(dev, Sectors(0), Sectors(1))])
                 .unwrap();
 
@@ -207,6 +213,7 @@ mod tests {
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let mut ld = LinearDev::setup(&dm,
                                       DmName::new(name).expect("valid format"),
+                                      None,
                                       &[Segment::new(dev, Sectors(0), Sectors(1))])
                 .unwrap();
 
@@ -231,7 +238,11 @@ mod tests {
                          Segment::new(dev, Sectors(0), Sectors(1))];
         let range: Sectors = segments.iter().map(|s| s.length).sum();
         let count = segments.len();
-        let ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), segments).unwrap();
+        let ld = LinearDev::setup(&dm,
+                                  DmName::new(name).expect("valid format"),
+                                  None,
+                                  segments)
+                .unwrap();
         assert_eq!(dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)
                        .unwrap()
@@ -258,12 +269,21 @@ mod tests {
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
         let table = LinearDev::dm_table(segments);
-        let ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), segments).unwrap();
+        let ld = LinearDev::setup(&dm,
+                                  DmName::new(name).expect("valid format"),
+                                  None,
+                                  segments)
+                .unwrap();
         assert!(LinearDev::setup(&dm,
                                  DmName::new(name).expect("valid format"),
+                                 None,
                                  &[Segment::new(dev, Sectors(1), Sectors(1))])
                         .is_err());
-        assert!(LinearDev::setup(&dm, DmName::new(name).expect("valid format"), segments).is_ok());
+        assert!(LinearDev::setup(&dm,
+                                 DmName::new(name).expect("valid format"),
+                                 None,
+                                 segments)
+                        .is_ok());
         assert_eq!(table,
                    dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)
@@ -280,9 +300,15 @@ mod tests {
         let dm = DM::new().unwrap();
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
-        let ld = LinearDev::setup(&dm, DmName::new("name").expect("valid format"), segments)
-            .unwrap();
-        let ld2 = LinearDev::setup(&dm, DmName::new("ersatz").expect("valid format"), segments);
+        let ld = LinearDev::setup(&dm,
+                                  DmName::new("name").expect("valid format"),
+                                  None,
+                                  segments)
+                .unwrap();
+        let ld2 = LinearDev::setup(&dm,
+                                   DmName::new("ersatz").expect("valid format"),
+                                   None,
+                                   segments);
         assert!(ld2.is_ok());
 
         ld2.unwrap().teardown(&dm).unwrap();
@@ -299,7 +325,11 @@ mod tests {
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1)),
                          Segment::new(dev, Sectors(1), Sectors(1))];
         let table = LinearDev::dm_table(segments);
-        let ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), segments).unwrap();
+        let ld = LinearDev::setup(&dm,
+                                  DmName::new(name).expect("valid format"),
+                                  None,
+                                  segments)
+                .unwrap();
         assert_eq!(table,
                    dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
                                    DM_STATUS_TABLE)

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -87,12 +87,13 @@ fn device_match(dm: &DM,
 /// just load the table.
 pub fn device_setup(dm: &DM,
                     name: &DmName,
+                    uuid: Option<&DmUuid>,
                     table: &[TargetLineArg<String, String>])
                     -> DmResult<DeviceInfo> {
     if device_exists(dm, name)? {
-        device_match(dm, name, None, table)
+        device_match(dm, name, uuid, table)
     } else {
-        device_create(dm, name, None, table)
+        device_create(dm, name, uuid, table)
     }
 }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -69,7 +69,7 @@ fn device_match(dm: &DM,
 
         return Err(DmError::Dm(ErrorEnum::Invalid, err_msg.into()));
     }
-    Ok(dm.device_status(id)?)
+    Ok(table_status.0)
 }
 
 /// Setup a device.

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::{DevId, DM, DM_STATUS_TABLE, DM_SUSPEND, DmFlags, DmName};
+use super::dm::{DevId, DM, DM_STATUS_TABLE, DM_SUSPEND, DmFlags, DmName, DmUuid};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::types::{Sectors, TargetLineArg};
 
@@ -34,12 +34,13 @@ pub trait DmDevice {
 /// Create a device, load a table, and resume it.
 pub fn device_create<T1, T2>(dm: &DM,
                              name: &DmName,
+                             uuid: Option<&DmUuid>,
                              table: &[TargetLineArg<T1, T2>])
                              -> DmResult<DeviceInfo>
     where T1: AsRef<str>,
           T2: AsRef<str>
 {
-    dm.device_create(name, None, DmFlags::empty())?;
+    dm.device_create(name, uuid, DmFlags::empty())?;
 
     let id = DevId::Name(name);
     let dev_info = match dm.table_load(&id, table) {
@@ -82,7 +83,7 @@ pub fn device_setup(dm: &DM,
     if device_exists(dm, name)? {
         device_match(dm, &DevId::Name(name), table)
     } else {
-        device_create(dm, name, table)
+        device_create(dm, name, None, table)
     }
 }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -58,10 +58,10 @@ pub fn device_create<T1, T2>(dm: &DM,
 /// Verify that kernel data matches arguments passed.
 /// Return the status of the device.
 fn device_match(dm: &DM,
-                id: &DevId,
+                name: &DmName,
                 table: &[TargetLineArg<String, String>])
                 -> DmResult<DeviceInfo> {
-    let table_status = dm.table_status(id, DM_STATUS_TABLE)?;
+    let table_status = dm.table_status(&DevId::Name(name), DM_STATUS_TABLE)?;
     if table_status.1 != table {
         let err_msg = format!("Specified new table \"{:?}\" does not match kernel table \"{:?}\"",
                               table,
@@ -81,7 +81,7 @@ pub fn device_setup(dm: &DM,
                     table: &[TargetLineArg<String, String>])
                     -> DmResult<DeviceInfo> {
     if device_exists(dm, name)? {
-        device_match(dm, &DevId::Name(name), table)
+        device_match(dm, name, table)
     } else {
         device_create(dm, name, None, table)
     }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -152,6 +152,7 @@ impl ThinDev {
     /// an error is returned.
     pub fn setup(dm: &DM,
                  name: &DmName,
+                 uuid: Option<&DmUuid>,
                  thin_pool: &ThinPoolDev,
                  thin_id: ThinDevId,
                  length: Sectors)
@@ -159,7 +160,7 @@ impl ThinDev {
 
         let thin_pool_device = thin_pool.device();
         let table = ThinDev::dm_table(thin_pool_device, thin_id, length);
-        let dev_info = device_setup(dm, name, None, &table)?;
+        let dev_info = device_setup(dm, name, uuid, &table)?;
 
         DM::wait_for_dm();
         Ok(ThinDev {
@@ -318,6 +319,7 @@ mod tests {
         let td_size = MIN_THIN_DEV_SIZE;
         assert!(ThinDev::setup(&dm,
                                &DmName::new("name").expect("is valid DM name"),
+                               None,
                                &tp,
                                ThinDevId::new_u64(0).expect("is below limit"),
                                td_size)
@@ -359,14 +361,14 @@ mod tests {
         assert!(ThinDev::new(&dm, &id, None, &tp, thin_id, td_size).is_err());
 
         // Setting up the just created thin dev succeeds.
-        assert!(ThinDev::setup(&dm, &id, &tp, thin_id, td_size).is_ok());
+        assert!(ThinDev::setup(&dm, &id, None, &tp, thin_id, td_size).is_ok());
 
         // Setting up the just created thin dev once more succeeds.
-        assert!(ThinDev::setup(&dm, &id, &tp, thin_id, td_size).is_ok());
+        assert!(ThinDev::setup(&dm, &id, None, &tp, thin_id, td_size).is_ok());
 
         // Teardown the thindev, then set it back up.
         td.teardown(&dm).unwrap();
-        let td = ThinDev::setup(&dm, &id, &tp, thin_id, td_size);
+        let td = ThinDev::setup(&dm, &id, None, &tp, thin_id, td_size);
         assert!(td.is_ok());
 
         td.unwrap().destroy(&dm, &tp).unwrap();

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -159,7 +159,7 @@ impl ThinDev {
 
         let thin_pool_device = thin_pool.device();
         let table = ThinDev::dm_table(thin_pool_device, thin_id, length);
-        let dev_info = device_setup(dm, name, &table)?;
+        let dev_info = device_setup(dm, name, None, &table)?;
 
         DM::wait_for_dm();
         Ok(ThinDev {

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -129,7 +129,7 @@ impl ThinDev {
 
         let thin_pool_device = thin_pool.device();
         let table = ThinDev::dm_table(thin_pool_device, thin_id, length);
-        let dev_info = device_create(dm, name, &table)?;
+        let dev_info = device_create(dm, name, None, &table)?;
 
         DM::wait_for_dm();
         Ok(ThinDev {
@@ -187,6 +187,7 @@ impl ThinDev {
         dm.device_suspend(&source_id, DmFlags::empty())?;
         let dev_info = Box::new(device_create(dm,
                                               snapshot_name,
+                                              None,
                                               &ThinDev::dm_table(thin_pool.device(),
                                                                  snapshot_thin_id,
                                                                  self.size()))?);

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -112,8 +112,8 @@ impl ThinDev {
     /// If the specified thin_id is already in use by the thin pool an error
     /// is returned. If the device is already among the list of devices that
     /// dm is aware of, return an error.
-    pub fn new(name: &DmName,
-               dm: &DM,
+    pub fn new(dm: &DM,
+               name: &DmName,
                thin_pool: &ThinPoolDev,
                thin_id: ThinDevId,
                length: Sectors)
@@ -149,8 +149,8 @@ impl ThinDev {
     ///
     /// If the device has no thin id already registered with the thin pool
     /// an error is returned.
-    pub fn setup(name: &DmName,
-                 dm: &DM,
+    pub fn setup(dm: &DM,
+                 name: &DmName,
                  thin_pool: &ThinPoolDev,
                  thin_id: ThinDevId,
                  length: Sectors)
@@ -295,8 +295,8 @@ mod tests {
         let dm = DM::new().unwrap();
         let tp = minimal_thinpool(&dm, paths[0]);
 
-        assert!(ThinDev::new(&DmName::new("name").expect("is valid DM name"),
-                             &dm,
+        assert!(ThinDev::new(&dm,
+                             &DmName::new("name").expect("is valid DM name"),
                              &tp,
                              ThinDevId::new_u64(0).expect("is below limit"),
                              Sectors(0))
@@ -313,8 +313,8 @@ mod tests {
         let tp = minimal_thinpool(&dm, paths[0]);
 
         let td_size = MIN_THIN_DEV_SIZE;
-        assert!(ThinDev::setup(&DmName::new("name").expect("is valid DM name"),
-                               &dm,
+        assert!(ThinDev::setup(&dm,
+                               &DmName::new("name").expect("is valid DM name"),
                                &tp,
                                ThinDevId::new_u64(0).expect("is below limit"),
                                td_size)
@@ -339,7 +339,7 @@ mod tests {
         let id = DmName::new("name").expect("is valid DM name");
 
         let td_size = MIN_THIN_DEV_SIZE;
-        let td = ThinDev::new(&id, &dm, &tp, thin_id, td_size).unwrap();
+        let td = ThinDev::new(&dm, &id, &tp, thin_id, td_size).unwrap();
 
         assert!(match td.status(&dm).unwrap() {
                     ThinStatus::Fail => false,
@@ -353,17 +353,17 @@ mod tests {
                    td_size.bytes());
 
         // New thindev w/ same id fails.
-        assert!(ThinDev::new(&id, &dm, &tp, thin_id, td_size).is_err());
+        assert!(ThinDev::new(&dm, &id, &tp, thin_id, td_size).is_err());
 
         // Setting up the just created thin dev succeeds.
-        assert!(ThinDev::setup(&id, &dm, &tp, thin_id, td_size).is_ok());
+        assert!(ThinDev::setup(&dm, &id, &tp, thin_id, td_size).is_ok());
 
         // Setting up the just created thin dev once more succeeds.
-        assert!(ThinDev::setup(&id, &dm, &tp, thin_id, td_size).is_ok());
+        assert!(ThinDev::setup(&dm, &id, &tp, thin_id, td_size).is_ok());
 
         // Teardown the thindev, then set it back up.
         td.teardown(&dm).unwrap();
-        let td = ThinDev::setup(&id, &dm, &tp, thin_id, td_size);
+        let td = ThinDev::setup(&dm, &id, &tp, thin_id, td_size);
         assert!(td.is_ok());
 
         td.unwrap().destroy(&dm, &tp).unwrap();
@@ -381,7 +381,7 @@ mod tests {
         // Create new ThinDev as source for snapshot
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
         let thin_name = DmName::new("name").expect("is valid DM name");
-        let td = ThinDev::new(&thin_name, &dm, &tp, thin_id, td_size).unwrap();
+        let td = ThinDev::new(&dm, &thin_name, &tp, thin_id, td_size).unwrap();
 
         // Create a snapshot of the source
         let ss_id = ThinDevId::new_u64(1).expect("is below limit");

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use super::consts::IEC;
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::{DM, DevId, DmFlags, DmName};
+use super::dm::{DM, DevId, DmFlags, DmName, DmUuid};
 use super::lineardev::LinearDev;
 use super::result::{DmResult, DmError, ErrorEnum};
 use super::segment::Segment;
@@ -112,6 +112,7 @@ impl ThinPoolDev {
     /// Precondition: the metadata device does not contain any pool metadata.
     pub fn new(dm: &DM,
                name: &DmName,
+               uuid: Option<&DmUuid>,
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
                meta: LinearDev,
@@ -124,7 +125,7 @@ impl ThinPoolDev {
 
         let table =
             ThinPoolDev::dm_table(data.size(), data_block_size, low_water_mark, &meta, &data);
-        let dev_info = device_create(dm, name, None, &table)?;
+        let dev_info = device_create(dm, name, uuid, &table)?;
 
         DM::wait_for_dm();
         Ok(ThinPoolDev {
@@ -303,6 +304,7 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
 
     ThinPoolDev::new(dm,
                      DmName::new("pool").expect("valid format"),
+                     None,
                      MIN_DATA_BLOCK_SIZE,
                      DataBlocks(1),
                      meta,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -124,7 +124,7 @@ impl ThinPoolDev {
 
         let table =
             ThinPoolDev::dm_table(data.size(), data_block_size, low_water_mark, &meta, &data);
-        let dev_info = device_create(dm, name, &table)?;
+        let dev_info = device_create(dm, name, None, &table)?;
 
         DM::wait_for_dm();
         Ok(ThinPoolDev {

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -159,6 +159,7 @@ impl ThinPoolDev {
     /// well-formed and consistent with the data on the data device.
     pub fn setup(dm: &DM,
                  name: &DmName,
+                 uuid: Option<&DmUuid>,
                  data_block_size: Sectors,
                  low_water_mark: DataBlocks,
                  meta: LinearDev,
@@ -166,7 +167,7 @@ impl ThinPoolDev {
                  -> DmResult<ThinPoolDev> {
         let table =
             ThinPoolDev::dm_table(data.size(), data_block_size, low_water_mark, &meta, &data);
-        let dev_info = device_setup(dm, name, None, &table)?;
+        let dev_info = device_setup(dm, name, uuid, &table)?;
 
         DM::wait_for_dm();
         Ok(ThinPoolDev {
@@ -293,12 +294,14 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
     let dev = Device::from(devnode_to_devno(path).unwrap());
     let meta = LinearDev::setup(dm,
                                 DmName::new("meta").expect("valid format"),
+                                None,
                                 &[Segment::new(dev, Sectors(0), MIN_RECOMMENDED_METADATA_SIZE)])
             .unwrap();
 
     let data =
         LinearDev::setup(dm,
                          DmName::new("data").expect("valid format"),
+                         None,
                          &[Segment::new(dev, MIN_RECOMMENDED_METADATA_SIZE, MIN_DATA_BLOCK_SIZE)])
                 .unwrap();
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -166,7 +166,7 @@ impl ThinPoolDev {
                  -> DmResult<ThinPoolDev> {
         let table =
             ThinPoolDev::dm_table(data.size(), data_block_size, low_water_mark, &meta, &data);
-        let dev_info = device_setup(dm, name, &table)?;
+        let dev_info = device_setup(dm, name, None, &table)?;
 
         DM::wait_for_dm();
         Ok(ThinPoolDev {

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -110,8 +110,8 @@ impl ThinPoolDev {
     /// Construct a new ThinPoolDev with the given data and meta devs.
     /// Returns an error if the device is already known to the kernel.
     /// Precondition: the metadata device does not contain any pool metadata.
-    pub fn new(name: &DmName,
-               dm: &DM,
+    pub fn new(dm: &DM,
+               name: &DmName,
                data_block_size: Sectors,
                low_water_mark: DataBlocks,
                meta: LinearDev,
@@ -156,8 +156,8 @@ impl ThinPoolDev {
     /// on the metadata device. If the metadata is corrupted, subsequent
     /// errors will result, so it is expected that the metadata is
     /// well-formed and consistent with the data on the data device.
-    pub fn setup(name: &DmName,
-                 dm: &DM,
+    pub fn setup(dm: &DM,
+                 name: &DmName,
                  data_block_size: Sectors,
                  low_water_mark: DataBlocks,
                  meta: LinearDev,
@@ -290,19 +290,19 @@ impl ThinPoolDev {
 #[cfg(test)]
 pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
     let dev = Device::from(devnode_to_devno(path).unwrap());
-    let meta = LinearDev::setup(DmName::new("meta").expect("valid format"),
-                                dm,
+    let meta = LinearDev::setup(dm,
+                                DmName::new("meta").expect("valid format"),
                                 &[Segment::new(dev, Sectors(0), MIN_RECOMMENDED_METADATA_SIZE)])
             .unwrap();
 
     let data =
-        LinearDev::setup(DmName::new("data").expect("valid format"),
-                         dm,
+        LinearDev::setup(dm,
+                         DmName::new("data").expect("valid format"),
                          &[Segment::new(dev, MIN_RECOMMENDED_METADATA_SIZE, MIN_DATA_BLOCK_SIZE)])
                 .unwrap();
 
-    ThinPoolDev::new(DmName::new("pool").expect("valid format"),
-                     dm,
+    ThinPoolDev::new(dm,
+                     DmName::new("pool").expect("valid format"),
                      MIN_DATA_BLOCK_SIZE,
                      DataBlocks(1),
                      meta,


### PR DESCRIPTION
Add ability to set optional UUID parameter in ```new()``` and ```setup()``` methods.

Makes placement of DM parameter consistent in these methods with other methods.
Fixes a minor bug in ```device_match()```.

Supercedes #161 .