### PR TITLE
device: Convert to/from dev_t and kdev_t

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["Linux", "device", "mapper", "libdm", "storage"]
 license = "MPL-2.0"
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.31"
 nix = "0.9"
 bitflags = "0.9"
 newtype_derive = "0.1"

--- a/src/device.rs
+++ b/src/device.rs
@@ -3,16 +3,17 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fmt;
+use libc::{dev_t, major, makedev, minor};
 
 /// A struct containing the device's major and minor numbers
 ///
-/// Also allows conversion to/from a single 64bit value.
+/// Also allows conversion to/from a single 64bit dev_t value.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Device {
     /// Device major number
     pub major: u32,
     /// Device minor number
-    pub minor: u8,
+    pub minor: u32,
 }
 
 /// Display format is the device number in "<major>:<minor>" format
@@ -22,17 +23,77 @@ impl fmt::Display for Device {
     }
 }
 
-impl From<u64> for Device {
-    fn from(val: u64) -> Device {
+impl From<dev_t> for Device {
+    fn from(val: dev_t) -> Device {
         Device {
-            major: (val >> 8) as u32,
-            minor: (val & 0xff) as u8,
+            major: unsafe { major(val) },
+            minor: unsafe { minor(val) },
         }
     }
 }
 
-impl From<Device> for u64 {
-    fn from(dev: Device) -> u64 {
-        u64::from((dev.major << 8) ^ (u32::from(dev.minor) & 0xff))
+impl From<Device> for dev_t {
+    fn from(dev: Device) -> dev_t {
+        unsafe { makedev(dev.major, dev.minor) }
+    }
+}
+
+/// The Linux kernel's kdev_t encodes major/minor values as mmmM MMmm.
+impl Device {
+    /// Make a Device from a kdev_t.
+    pub fn from_kdev_t(val: u32) -> Device {
+        Device {
+            major: (val & 0xf_ff00) >> 8,
+            minor: (val & 0xff) | ((val >> 12) & 0xf_ff00),
+        }
+    }
+
+    /// Convert to a kdev_t. Return None if values are not expressible as a
+    /// kdev_t.
+    pub fn to_kdev_t(&self) -> Option<u32> {
+        if self.major > 0xfff || self.minor > 0xf_ffff {
+            return None;
+        }
+
+        Some((self.minor & 0xff) | (self.major << 8) | ((self.minor & !0xff) << 12))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    /// Verify conversion is correct both ways
+    pub fn test_dev_t_conversion() {
+        let test_devt_1: dev_t = 0xabcdef1234567890;
+
+        let dev1 = Device::from(test_devt_1);
+        // Default glibc dev_t encoding is MMMM Mmmm mmmM MMmm. I guess if
+        // we're on a platform where non-default is used, we'll fail.
+        assert_eq!(dev1.major, 0xabcde678);
+        assert_eq!(dev1.minor, 0xf1234590);
+
+        let test_devt_2: dev_t = dev_t::from(dev1);
+        assert_eq!(test_devt_1, test_devt_2);
+    }
+
+    #[test]
+    /// Verify conversion is correct both ways
+    pub fn test_kdev_t_conversion() {
+        let test_devt_1: u32 = 0x12345678;
+
+        let dev1 = Device::from_kdev_t(test_devt_1);
+        // Default kernel kdev_t "huge" encoding is mmmM MMmm.
+        assert_eq!(dev1.major, 0x456);
+        assert_eq!(dev1.minor, 0x12378);
+
+        let test_devt_2: u32 = dev1.to_kdev_t().unwrap();
+        assert_eq!(test_devt_1, test_devt_2);
+
+        // a Device inexpressible as a kdev_t
+        let dev2 = Device::from(0xabcdef1234567890);
+        assert_eq!(dev2.to_kdev_t(), None);
     }
 }

--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -51,7 +51,9 @@ impl DeviceInfo {
 
     /// The device's major and minor device numbers, as a Device.
     pub fn device(&self) -> Device {
-        self.hdr.dev.into()
+        // dm_ioctl struct reserves 64 bits for device but kernel "huge"
+        // encoding is only 32 bits.
+        Device::from_kdev_t(self.hdr.dev as u32)
     }
 
     /// The device's name.

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -753,7 +753,12 @@ impl DM {
                                       target_deps.count as usize)
             };
 
-            Ok(dev_slc.iter().map(|d| Device::from(*d)).collect())
+            // Note: The DM target_deps struct reserves 64 bits for each entry
+            // but only 32 bits is used by kernel "huge" dev_t encoding.
+            Ok(dev_slc
+                   .iter()
+                   .map(|d| Device::from_kdev_t(*d as u32))
+                   .collect())
         }
     }
 


### PR DESCRIPTION
We can't assume which bits in a libc::dev_t are major and which are minor.
This is especially true since the default is to use an intermingled
pattern that allows for >256 major and minor, but keeps the layout the same
as the old 16 bit dev_t if both values are less than 256.

Also properly convert to/from the kernel's dev_t encoding. Even though
DM's ioctl struct has a 64 bit field for this, it uses the kernel's
"huge" encoding, which is only 32 bits. Therefore it's possible to have
a valid Device that cannot be expressed to the kernel. But, this field
isn't currently ever set right now. If we ever want to specify DM devices
by maj:min then we'd need to use to_kdev_t().

fixes #147

Signed-off-by: Andy Grover <agrover@redhat.com>