### PR TITLE
Transfer a test from stratisd to devicemapper

### DIFF
--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -304,7 +304,7 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
                                 &[Segment::new(dev, Sectors(0), MIN_RECOMMENDED_METADATA_SIZE)])
             .unwrap();
 
-    // 8 * MIN_DATA_BLOCK_SIZE should be enough to mount an xfs filesystem
+    // 512 * MIN_DATA_BLOCK_SIZE (32 MiB) should be enough for an xfs filesystem
     let data = LinearDev::setup(dm,
                                 DmName::new("data").expect("valid format"),
                                 None,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -304,12 +304,14 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
                                 &[Segment::new(dev, Sectors(0), MIN_RECOMMENDED_METADATA_SIZE)])
             .unwrap();
 
-    let data =
-        LinearDev::setup(dm,
-                         DmName::new("data").expect("valid format"),
-                         None,
-                         &[Segment::new(dev, MIN_RECOMMENDED_METADATA_SIZE, MIN_DATA_BLOCK_SIZE)])
-                .unwrap();
+    // 8 * MIN_DATA_BLOCK_SIZE should be enough to mount an xfs filesystem
+    let data = LinearDev::setup(dm,
+                                DmName::new("data").expect("valid format"),
+                                None,
+                                &[Segment::new(dev,
+                                               MIN_RECOMMENDED_METADATA_SIZE,
+                                               512u64 * MIN_DATA_BLOCK_SIZE)])
+            .unwrap();
 
     ThinPoolDev::new(dm,
                      DmName::new("pool").expect("valid format"),


### PR DESCRIPTION
The test is really more appropriate in devicemapper than stratisd, as it tests
only devicemapper functionality.

The minimal thinpool has to be made slightly larger, so that an xfs filesystem can be made on a thindevice in the pool.