### PR TITLE
Use a dedicated type for targets

### DIFF
--- a/src/deviceinfo.rs
+++ b/src/deviceinfo.rs
@@ -6,8 +6,9 @@ use std::mem::transmute;
 use std::str::from_utf8;
 
 use super::device::Device;
-use super::dm::{DmFlags, DmName, DmUuid};
+use super::dm::DmFlags;
 use super::dm_ioctl as dmi;
+use super::types::{DmName, DmUuid};
 use super::util::slice_to_null;
 
 /// Name max length

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -17,8 +17,7 @@ use super::device::Device;
 use super::deviceinfo::{DM_NAME_LEN, DM_UUID_LEN, DeviceInfo};
 use super::dm_ioctl as dmi;
 use super::result::DmResult;
-use super::types::{DevId, DmName, DmNameBuf, DmUuid, Sectors, TargetLine, TargetLineArg,
-                   TargetTypeBuf};
+use super::types::{DevId, DmName, DmNameBuf, DmUuid, Sectors, TargetLine, TargetTypeBuf};
 use super::util::{align_to, slice_to_null};
 
 /// Indicator to send IOCTL to DM
@@ -503,15 +502,13 @@ impl DM {
     /// let table = vec![(Sectors(0),
     ///                   Sectors(32768),
     ///                   TargetTypeBuf::new("linear".into()).expect("< length limit"),
-    ///                   "/dev/sdb1 2048")];
+    ///                   "/dev/sdb1 2048".into())];
     ///
     /// let name = DmName::new("example-dev").expect("is valid DM name");
     /// let id = DevId::Name(name);
     /// dm.table_load(&id, &table).unwrap();
     /// ```
-    pub fn table_load<T>(&self, id: &DevId, targets: &[TargetLineArg<T>]) -> DmResult<DeviceInfo>
-        where T: AsRef<str>
-    {
+    pub fn table_load(&self, id: &DevId, targets: &[TargetLine]) -> DmResult<DeviceInfo> {
         let mut targs = Vec::new();
 
         // Construct targets first, since we need to know how many & size
@@ -528,7 +525,7 @@ impl DM {
                     "TargetType max length = targ.target_type.len()");
             dst[..ttyp.len()].clone_from_slice(ttyp.as_bytes());
 
-            let mut params = t.3.as_ref().to_owned();
+            let mut params = t.3.to_owned();
             let params_len = params.len();
             let pad_bytes = align_to(params_len + 1usize, 8usize) - params_len;
             params.extend(vec!["\0"; pad_bytes]);

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -108,8 +108,8 @@ fn dev_id_check(value: &str, max_allowed_chars: usize) -> DmResult<()> {
 /// conformance to DM restrictions, such as maximum length.
 // This implementation follows the example of Path/PathBuf as closely as
 // possible.
-macro_rules! dev_id {
-    ($B: ident, $O: ident, $MAX: ident) => {
+macro_rules! str_id {
+    ($B: ident, $O: ident, $MAX: ident, $check: ident) => {
         /// The borrowed version of the DM identifier.
         #[derive(Debug, PartialEq, Eq, Hash)]
         pub struct $B {
@@ -125,7 +125,7 @@ macro_rules! dev_id {
         impl $B {
             /// Create a new borrowed identifier from a `&str`.
             pub fn new(value: &str) -> DmResult<&$B> {
-                dev_id_check(value, $MAX - 1)?;
+                $check(value, $MAX - 1)?;
                 Ok(unsafe { transmute(value) })
             }
         }
@@ -159,7 +159,7 @@ macro_rules! dev_id {
         impl $O {
             /// Construct a new owned identifier.
             pub fn new(value: String) -> DmResult<$O> {
-                dev_id_check(&value, $MAX - 1)?;
+                $check(&value, $MAX - 1)?;
                 Ok($O { inner: value })
             }
         }
@@ -188,11 +188,11 @@ macro_rules! dev_id {
 /// A devicemapper name. Really just a string, but also the argument type of
 /// DevId::Name. Used in function arguments to indicate that the function
 /// takes only a name, not a devicemapper uuid.
-dev_id!(DmName, DmNameBuf, DM_NAME_LEN);
+str_id!(DmName, DmNameBuf, DM_NAME_LEN, dev_id_check);
 
 /// A devicemapper uuid. A devicemapper uuid has a devicemapper-specific
 /// format.
-dev_id!(DmUuid, DmUuidBuf, DM_UUID_LEN);
+str_id!(DmUuid, DmUuidBuf, DM_UUID_LEN, dev_id_check);
 
 /// Used as a parameter for functions that take either a Device name
 /// or a Device UUID.

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -522,10 +522,10 @@ impl DM {
             targ.status = 0;
 
             let dst: &mut [u8] = unsafe { transmute(&mut targ.target_type[..]) };
-            let ttyp = t.target_type.as_ref();
-            assert!(ttyp.len() <= dst.len(),
+            let bytes = t.target_type.as_bytes();
+            assert!(bytes.len() <= dst.len(),
                     "TargetType max length = targ.target_type.len()");
-            dst[..ttyp.len()].clone_from_slice(ttyp.as_bytes());
+            dst[..bytes.len()].clone_from_slice(bytes);
 
             let mut params = t.params.to_owned();
             let params_len = params.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,4 +124,4 @@ pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolW
 pub use thindev::{ThinDev, ThinStatus};
 pub use thindevid::ThinDevId;
 pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, MetaBlocks,
-                Sectors, TargetType, TargetTypeBuf};
+                Sectors, TargetLine, TargetType, TargetTypeBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,4 +124,4 @@ pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolW
 pub use thindev::{ThinDev, ThinStatus};
 pub use thindevid::ThinDevId;
 pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, MetaBlocks,
-                Sectors};
+                Sectors, TargetType, TargetTypeBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod loopbacked;
 
 
 pub use consts::{IEC, SECTOR_SIZE};
-pub use dm::{DM, DevId, DmFlags, DmName, DmNameBuf, DmUuid, DmUuidBuf};
+pub use dm::{DM, DmFlags};
 
 // Export the DmFlags individually. In theory, they can be accessed by
 // DmFlags::DM_READONLY, but in practice this requires explicitly using
@@ -123,4 +123,5 @@ pub use shared::{DmDevice, device_exists};
 pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
 pub use thindev::{ThinDev, ThinStatus};
 pub use thindevid::ThinDevId;
-pub use types::{Bytes, DataBlocks, MetaBlocks, Sectors};
+pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, MetaBlocks,
+                Sectors};

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -100,10 +100,12 @@ impl LinearDev {
         let mut logical_start_offset = Sectors(0);
         for segment in segments {
             let (physical_start_offset, length) = (segment.start, segment.length);
-            let line = (logical_start_offset,
-                        length,
-                        TargetTypeBuf::new("linear".into()).expect("< length limit"),
-                        format!("{} {}", segment.device, *physical_start_offset));
+            let line = TargetLine {
+                start: logical_start_offset,
+                length: length,
+                target_type: TargetTypeBuf::new("linear".into()).expect("< length limit"),
+                params: format!("{} {}", segment.device, *physical_start_offset),
+            };
             debug!("dmtable line : {:?}", line);
             table.push(line);
             logical_start_offset += length;

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -6,11 +6,11 @@ use std::path::PathBuf;
 
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::{DM, DevId, DmFlags, DmName, DmUuid};
+use super::dm::{DM, DmFlags};
 use super::result::{DmResult, DmError, ErrorEnum};
 use super::segment::Segment;
 use super::shared::{DmDevice, device_setup, table_reload};
-use super::types::{Sectors, TargetLine};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine};
 
 /// A DM construct of combined Segments
 #[derive(Debug)]

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -10,7 +10,7 @@ use super::dm::{DM, DmFlags};
 use super::result::{DmResult, DmError, ErrorEnum};
 use super::segment::Segment;
 use super::shared::{DmDevice, device_setup, table_reload};
-use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetTypeBuf};
 
 /// A DM construct of combined Segments
 #[derive(Debug)]
@@ -102,7 +102,7 @@ impl LinearDev {
             let (physical_start_offset, length) = (segment.start, segment.length);
             let line = (logical_start_offset,
                         length,
-                        "linear".to_owned(),
+                        TargetTypeBuf::new("linear".into()).expect("< length limit"),
                         format!("{} {}", segment.device, *physical_start_offset));
             debug!("dmtable line : {:?}", line);
             table.push(line);

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -11,7 +11,7 @@ use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DM_STATUS_TABLE, DM_SUSPEND, DmFlags};
 use super::result::{DmError, DmResult, ErrorEnum};
-use super::types::{DevId, DmName, DmUuid, Sectors, TargetLineArg};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine};
 
 /// A trait capturing some shared properties of DM devices.
 pub trait DmDevice {
@@ -32,13 +32,11 @@ pub trait DmDevice {
 }
 
 /// Create a device, load a table, and resume it.
-pub fn device_create<T>(dm: &DM,
-                        name: &DmName,
-                        uuid: Option<&DmUuid>,
-                        table: &[TargetLineArg<T>])
-                        -> DmResult<DeviceInfo>
-    where T: AsRef<str>
-{
+pub fn device_create(dm: &DM,
+                     name: &DmName,
+                     uuid: Option<&DmUuid>,
+                     table: &[TargetLine])
+                     -> DmResult<DeviceInfo> {
     dm.device_create(name, uuid, DmFlags::empty())?;
 
     let id = DevId::Name(name);
@@ -59,7 +57,7 @@ pub fn device_create<T>(dm: &DM,
 fn device_match(dm: &DM,
                 name: &DmName,
                 uuid: Option<&DmUuid>,
-                table: &[TargetLineArg<String>])
+                table: &[TargetLine])
                 -> DmResult<DeviceInfo> {
     let table_status = dm.table_status(&DevId::Name(name), DM_STATUS_TABLE)?;
     if table_status.1 != table {
@@ -87,7 +85,7 @@ fn device_match(dm: &DM,
 pub fn device_setup(dm: &DM,
                     name: &DmName,
                     uuid: Option<&DmUuid>,
-                    table: &[TargetLineArg<String>])
+                    table: &[TargetLine])
                     -> DmResult<DeviceInfo> {
     if device_exists(dm, name)? {
         device_match(dm, name, uuid, table)
@@ -97,9 +95,7 @@ pub fn device_setup(dm: &DM,
 }
 
 /// Reload the table for a device
-pub fn table_reload<T>(dm: &DM, id: &DevId, table: &[TargetLineArg<T>]) -> DmResult<DeviceInfo>
-    where T: AsRef<str>
-{
+pub fn table_reload(dm: &DM, id: &DevId, table: &[TargetLine]) -> DmResult<DeviceInfo> {
     let dev_info = dm.table_load(id, table)?;
     dm.device_suspend(id, DM_SUSPEND)?;
     dm.device_suspend(id, DmFlags::empty())?;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -32,13 +32,12 @@ pub trait DmDevice {
 }
 
 /// Create a device, load a table, and resume it.
-pub fn device_create<T1, T2>(dm: &DM,
-                             name: &DmName,
-                             uuid: Option<&DmUuid>,
-                             table: &[TargetLineArg<T1, T2>])
-                             -> DmResult<DeviceInfo>
-    where T1: AsRef<str>,
-          T2: AsRef<str>
+pub fn device_create<T>(dm: &DM,
+                        name: &DmName,
+                        uuid: Option<&DmUuid>,
+                        table: &[TargetLineArg<T>])
+                        -> DmResult<DeviceInfo>
+    where T: AsRef<str>
 {
     dm.device_create(name, uuid, DmFlags::empty())?;
 
@@ -60,7 +59,7 @@ pub fn device_create<T1, T2>(dm: &DM,
 fn device_match(dm: &DM,
                 name: &DmName,
                 uuid: Option<&DmUuid>,
-                table: &[TargetLineArg<String, String>])
+                table: &[TargetLineArg<String>])
                 -> DmResult<DeviceInfo> {
     let table_status = dm.table_status(&DevId::Name(name), DM_STATUS_TABLE)?;
     if table_status.1 != table {
@@ -88,7 +87,7 @@ fn device_match(dm: &DM,
 pub fn device_setup(dm: &DM,
                     name: &DmName,
                     uuid: Option<&DmUuid>,
-                    table: &[TargetLineArg<String, String>])
+                    table: &[TargetLineArg<String>])
                     -> DmResult<DeviceInfo> {
     if device_exists(dm, name)? {
         device_match(dm, name, uuid, table)
@@ -98,12 +97,8 @@ pub fn device_setup(dm: &DM,
 }
 
 /// Reload the table for a device
-pub fn table_reload<T1, T2>(dm: &DM,
-                            id: &DevId,
-                            table: &[TargetLineArg<T1, T2>])
-                            -> DmResult<DeviceInfo>
-    where T1: AsRef<str>,
-          T2: AsRef<str>
+pub fn table_reload<T>(dm: &DM, id: &DevId, table: &[TargetLineArg<T>]) -> DmResult<DeviceInfo>
+    where T: AsRef<str>
 {
     let dev_info = dm.table_load(id, table)?;
     dm.device_suspend(id, DM_SUSPEND)?;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -9,9 +9,9 @@ use std::path::PathBuf;
 
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::{DevId, DM, DM_STATUS_TABLE, DM_SUSPEND, DmFlags, DmName, DmUuid};
+use super::dm::{DM, DM_STATUS_TABLE, DM_SUSPEND, DmFlags};
 use super::result::{DmError, DmResult, ErrorEnum};
-use super::types::{Sectors, TargetLineArg};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetLineArg};
 
 /// A trait capturing some shared properties of DM devices.
 pub trait DmDevice {

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -11,7 +11,7 @@ use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, device_create, device_exists, device_setup, table_reload};
 use super::thindevid::ThinDevId;
 use super::thinpooldev::ThinPoolDev;
-use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetTypeBuf};
 
 /// DM construct for a thin block device
 #[derive(Debug)]
@@ -156,7 +156,10 @@ impl ThinDev {
     /// There is exactly one entry in the table.
     fn dm_table(thin_pool: Device, thin_id: ThinDevId, length: Sectors) -> Vec<TargetLine> {
         let params = format!("{} {}", thin_pool, thin_id);
-        vec![(Sectors::default(), length, "thin".to_owned(), params)]
+        vec![(Sectors::default(),
+              length,
+              TargetTypeBuf::new("thin".into()).expect("< length limit"),
+              params)]
     }
 
     /// return the thin id of the linear device

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -156,10 +156,12 @@ impl ThinDev {
     /// There is exactly one entry in the table.
     fn dm_table(thin_pool: Device, thin_id: ThinDevId, length: Sectors) -> Vec<TargetLine> {
         let params = format!("{} {}", thin_pool, thin_id);
-        vec![(Sectors::default(),
-              length,
-              TargetTypeBuf::new("thin".into()).expect("< length limit"),
-              params)]
+        vec![TargetLine {
+                 start: Sectors::default(),
+                 length: length,
+                 target_type: TargetTypeBuf::new("thin".into()).expect("< length limit"),
+                 params: params,
+             }]
     }
 
     /// return the thin id of the linear device
@@ -175,7 +177,7 @@ impl ThinDev {
                    1,
                    "Kernel must return 1 line table for thin status");
 
-        let status_line = &table.first().expect("assertion above holds").3;
+        let status_line = &table.first().expect("assertion above holds").params;
         if status_line.starts_with("Fail") {
             return Ok(ThinStatus::Fail);
         }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -6,12 +6,12 @@ use std::path::PathBuf;
 
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::{DM, DM_SUSPEND, DevId, DmFlags, DmName, DmUuid};
+use super::dm::{DM, DM_SUSPEND, DmFlags};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, device_create, device_exists, device_setup, table_reload};
 use super::thindevid::ThinDevId;
 use super::thinpooldev::ThinPoolDev;
-use super::types::{Sectors, TargetLine};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine};
 
 /// DM construct for a thin block device
 #[derive(Debug)]

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -7,12 +7,12 @@ use std::path::PathBuf;
 use super::consts::IEC;
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::{DM, DevId, DmFlags, DmName, DmUuid};
+use super::dm::{DM, DmFlags};
 use super::lineardev::LinearDev;
 use super::result::{DmResult, DmError, ErrorEnum};
 use super::segment::Segment;
 use super::shared::{DmDevice, device_create, device_exists, device_setup, table_reload};
-use super::types::{DataBlocks, MetaBlocks, Sectors, TargetLine};
+use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetLine};
 
 #[cfg(test)]
 use std::path::Path;

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -195,10 +195,12 @@ impl ThinPoolDev {
                              data.device(),
                              *data_block_size,
                              *low_water_mark);
-        vec![(Sectors::default(),
-              length,
-              TargetTypeBuf::new("thin-pool".into()).expect("< length limit"),
-              params)]
+        vec![TargetLine {
+                 start: Sectors::default(),
+                 length: length,
+                 target_type: TargetTypeBuf::new("thin-pool".into()).expect("< length limit"),
+                 params: params,
+             }]
     }
 
     /// send a message to DM thin pool
@@ -218,7 +220,7 @@ impl ThinPoolDev {
                    1,
                    "Kernel must return 1 line from thin pool status");
 
-        let status_line = status.pop().expect("assertion above holds").3;
+        let status_line = status.pop().expect("assertion above holds").params;
         if status_line.starts_with("Fail") {
             return Ok(ThinPoolStatus::Fail);
         }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -12,7 +12,8 @@ use super::lineardev::LinearDev;
 use super::result::{DmResult, DmError, ErrorEnum};
 use super::segment::Segment;
 use super::shared::{DmDevice, device_create, device_exists, device_setup, table_reload};
-use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetLine};
+use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetLine,
+                   TargetTypeBuf};
 
 #[cfg(test)]
 use std::path::Path;
@@ -194,7 +195,10 @@ impl ThinPoolDev {
                              data.device(),
                              *data_block_size,
                              *low_water_mark);
-        vec![(Sectors::default(), length, "thin-pool".to_owned(), params)]
+        vec![(Sectors::default(),
+              length,
+              TargetTypeBuf::new("thin-pool".into()).expect("< length limit"),
+              params)]
     }
 
     /// send a message to DM thin pool

--- a/src/types.rs
+++ b/src/types.rs
@@ -406,11 +406,18 @@ const DM_TARGET_TYPE_LEN: usize = 16;
 
 str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
 
-/// This 4-tuple consists of starting offset (sectors), length
-/// (sectors), target type (string, e.g. "linear"), and
-/// params(string). See target documentation for the format of each
-/// target type's params field.
-pub type TargetLine = (Sectors, Sectors, TargetTypeBuf, String);
+/// One line of a device mapper table.
+#[derive(Debug, PartialEq)]
+pub struct TargetLine {
+    /// The start of the segment
+    pub start: Sectors,
+    /// The length of the segment
+    pub length: Sectors,
+    /// The target type
+    pub target_type: TargetTypeBuf,
+    /// The target specific parameters
+    pub params: String,
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/types.rs
+++ b/src/types.rs
@@ -272,7 +272,7 @@ impl fmt::Display for Sectors {
 }
 
 /// Returns an error if value is unsuitable.
-fn dev_id_check(value: &str, max_allowed_chars: usize) -> DmResult<()> {
+fn str_check(value: &str, max_allowed_chars: usize) -> DmResult<()> {
     if !value.is_ascii() {
         let err_msg = format!("value {} has some non-ascii characters", value);
         return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
@@ -375,11 +375,11 @@ macro_rules! str_id {
 /// A devicemapper name. Really just a string, but also the argument type of
 /// DevId::Name. Used in function arguments to indicate that the function
 /// takes only a name, not a devicemapper uuid.
-str_id!(DmName, DmNameBuf, DM_NAME_LEN, dev_id_check);
+str_id!(DmName, DmNameBuf, DM_NAME_LEN, str_check);
 
 /// A devicemapper uuid. A devicemapper uuid has a devicemapper-specific
 /// format.
-str_id!(DmUuid, DmUuidBuf, DM_UUID_LEN, dev_id_check);
+str_id!(DmUuid, DmUuidBuf, DM_UUID_LEN, str_check);
 
 /// Used as a parameter for functions that take either a Device name
 /// or a Device UUID.
@@ -400,15 +400,21 @@ impl<'a> fmt::Display for DevId<'a> {
     }
 }
 
+
+/// Number of bytes in Struct_dm_target_spec::target_type field.
+const DM_TARGET_TYPE_LEN: usize = 16;
+
+str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
+
 /// This 4-tuple consists of starting offset (sectors), length
 /// (sectors), target type (string, e.g. "linear"), and
 /// params(string). See target documentation for the format of each
 /// target type's params field.
-pub type TargetLine = (Sectors, Sectors, String, String);
+pub type TargetLine = (Sectors, Sectors, TargetTypeBuf, String);
 
 /// The same as TargetLine, except generalized for argument rather than
 /// return type.
-pub type TargetLineArg<T1, T2> = (Sectors, Sectors, T1, T2);
+pub type TargetLineArg<T> = (Sectors, Sectors, TargetTypeBuf, T);
 
 #[cfg(test)]
 mod tests {

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,11 +14,17 @@
 
 use consts::SECTOR_SIZE;
 
+use std::ascii::AsciiExt;
+use std::borrow::Borrow;
 use std::fmt;
 use std::iter::Sum;
-use std::ops::{Div, Mul, Rem, Add};
+use std::mem::transmute;
+use std::ops::{Deref, Div, Mul, Rem, Add};
 
 use serde;
+
+use super::deviceinfo::{DM_NAME_LEN, DM_UUID_LEN};
+use super::result::{DmError, DmResult, ErrorEnum};
 
 /// a kernel defined block size constant for a DM meta device
 /// defined in drivers/md/persistent-data/dm-space-map-metadata.h line 12
@@ -265,6 +271,134 @@ impl fmt::Display for Sectors {
     }
 }
 
+/// Returns an error if value is unsuitable.
+fn dev_id_check(value: &str, max_allowed_chars: usize) -> DmResult<()> {
+    if !value.is_ascii() {
+        let err_msg = format!("value {} has some non-ascii characters", value);
+        return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
+    }
+    let num_chars = value.len();
+    if num_chars == 0 {
+        return Err(DmError::Dm(ErrorEnum::Invalid, "value has zero characters".into()));
+    }
+    if num_chars > max_allowed_chars {
+        let err_msg = format!("value {} has {} chars which is greater than maximum allowed {}",
+                              value,
+                              num_chars,
+                              max_allowed_chars);
+        return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
+    }
+    Ok(())
+}
+
+/// Define borrowed and owned versions of string types that guarantee
+/// conformance to DM restrictions, such as maximum length.
+// This implementation follows the example of Path/PathBuf as closely as
+// possible.
+macro_rules! str_id {
+    ($B: ident, $O: ident, $MAX: ident, $check: ident) => {
+        /// The borrowed version of the DM identifier.
+        #[derive(Debug, PartialEq, Eq, Hash)]
+        pub struct $B {
+            inner: str,
+        }
+
+        /// The owned version of the DM identifier.
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $O {
+            inner: String,
+        }
+
+        impl $B {
+            /// Create a new borrowed identifier from a `&str`.
+            pub fn new(value: &str) -> DmResult<&$B> {
+                $check(value, $MAX - 1)?;
+                Ok(unsafe { transmute(value) })
+            }
+        }
+
+        impl ToOwned for $B {
+            type Owned = $O;
+            fn to_owned(&self) -> $O {
+                $O { inner: self.inner.to_owned() }
+            }
+        }
+
+        impl AsRef<str> for $B {
+            fn as_ref(&self) -> &str {
+                &self.inner
+            }
+        }
+
+        impl Deref for $B {
+            type Target = str;
+            fn deref(&self) -> &str {
+                &self.inner
+            }
+        }
+
+        impl fmt::Display for $B {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{}", &self.inner)
+            }
+        }
+
+        impl $O {
+            /// Construct a new owned identifier.
+            pub fn new(value: String) -> DmResult<$O> {
+                $check(&value, $MAX - 1)?;
+                Ok($O { inner: value })
+            }
+        }
+
+        impl AsRef<$B> for $O {
+            fn as_ref(&self) -> &$B {
+                self
+            }
+        }
+
+        impl Borrow<$B> for $O {
+            fn borrow(&self) -> &$B {
+                self.deref()
+            }
+        }
+
+        impl Deref for $O {
+            type Target = $B;
+            fn deref(&self) -> &$B {
+                $B::new(&self.inner).expect("inner satisfies all correctness criteria for $B::new")
+            }
+        }
+    }
+}
+
+/// A devicemapper name. Really just a string, but also the argument type of
+/// DevId::Name. Used in function arguments to indicate that the function
+/// takes only a name, not a devicemapper uuid.
+str_id!(DmName, DmNameBuf, DM_NAME_LEN, dev_id_check);
+
+/// A devicemapper uuid. A devicemapper uuid has a devicemapper-specific
+/// format.
+str_id!(DmUuid, DmUuidBuf, DM_UUID_LEN, dev_id_check);
+
+/// Used as a parameter for functions that take either a Device name
+/// or a Device UUID.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DevId<'a> {
+    /// The parameter is the device's name
+    Name(&'a DmName),
+    /// The parameter is the device's devicemapper uuid
+    Uuid(&'a DmUuid),
+}
+
+impl<'a> fmt::Display for DevId<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DevId::Name(name) => write!(f, "{}", name),
+            DevId::Uuid(uuid) => write!(f, "{}", uuid),
+        }
+    }
+}
 
 /// This 4-tuple consists of starting offset (sectors), length
 /// (sectors), target type (string, e.g. "linear"), and

--- a/src/types.rs
+++ b/src/types.rs
@@ -315,25 +315,17 @@ macro_rules! str_id {
                 $check(value, $MAX - 1)?;
                 Ok(unsafe { transmute(value) })
             }
+
+            /// Get the inner value as bytes
+            pub fn as_bytes(&self) -> &[u8] {
+                self.inner.as_bytes()
+            }
         }
 
         impl ToOwned for $B {
             type Owned = $O;
             fn to_owned(&self) -> $O {
                 $O { inner: self.inner.to_owned() }
-            }
-        }
-
-        impl AsRef<str> for $B {
-            fn as_ref(&self) -> &str {
-                &self.inner
-            }
-        }
-
-        impl Deref for $B {
-            type Target = str;
-            fn deref(&self) -> &str {
-                &self.inner
             }
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -412,10 +412,6 @@ str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
 /// target type's params field.
 pub type TargetLine = (Sectors, Sectors, TargetTypeBuf, String);
 
-/// The same as TargetLine, except generalized for argument rather than
-/// return type.
-pub type TargetLineArg<T> = (Sectors, Sectors, TargetTypeBuf, T);
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
it would have been nice to use an enum, but the list of target names is a bit open-ended.

The nice part is that now the first error that can result from a bogus target name in the table passed as an argument goes away. Instead, the check is done at the point where the target name is created.