### PR TITLE
Verify that data block size is within bounds in ThinPoolDev methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,8 @@ pub use lineardev::LinearDev;
 pub use result::{DmResult, DmError, ErrorEnum};
 pub use segment::Segment;
 pub use shared::{DmDevice, device_exists};
-pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
+pub use thinpooldev::{MIN_DATA_BLOCK_SIZE, MAX_DATA_BLOCK_SIZE, ThinPoolBlockUsage, ThinPoolDev,
+                      ThinPoolStatus, ThinPoolWorkingStatus, verify_data_block_size};
 pub use thindev::{ThinDev, ThinStatus};
 pub use thindevid::ThinDevId;
 pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, MetaBlocks,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -20,11 +20,13 @@ use std::path::Path;
 #[cfg(test)]
 use super::loopbacked::devnode_to_devno;
 
+/// Minimum data block size permitted.
+pub const MIN_DATA_BLOCK_SIZE: Sectors = Sectors(128); // 64 KiB
+
+/// Maximum data block size permitted.
+pub const MAX_DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Mi); // 1 GiB
+
 /// Values are explicitly stated in the device-mapper kernel documentation.
-#[allow(dead_code)]
-const MIN_DATA_BLOCK_SIZE: Sectors = Sectors(128); // 64 KiB
-#[allow(dead_code)]
-const MAX_DATA_BLOCK_SIZE: Sectors = Sectors(2 * IEC::Mi); // 1 GiB
 #[allow(dead_code)]
 const MIN_RECOMMENDED_METADATA_SIZE: Sectors = Sectors(4 * IEC::Ki); // 2 MiB
 #[allow(dead_code)]
@@ -102,6 +104,29 @@ pub enum ThinPoolWorkingStatus {
     NeedsCheck,
 }
 
+/// Verify that data block size has acceptable value
+pub fn verify_data_block_size(size: Sectors) -> DmResult<()> {
+    if size < MIN_DATA_BLOCK_SIZE {
+        let err_msg = format!("data block size specified ({}) < minimum permitted ({})",
+                              size,
+                              MIN_DATA_BLOCK_SIZE);
+        return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
+    }
+    if size > MAX_DATA_BLOCK_SIZE {
+        let err_msg = format!("data block size specified ({}) > maximum permitted ({})",
+                              size,
+                              MAX_DATA_BLOCK_SIZE);
+        return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
+    }
+    if size % MIN_DATA_BLOCK_SIZE != Sectors(0) {
+        let err_msg = format!("data block size specified ({}) not divisible by {}",
+                              size,
+                              MIN_DATA_BLOCK_SIZE);
+        return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
+    }
+    Ok(())
+}
+
 /// Use DM to create a "thin-pool".  A "thin-pool" is shared space for
 /// other thin provisioned devices to use.
 ///
@@ -120,6 +145,7 @@ impl ThinPoolDev {
                meta: LinearDev,
                data: LinearDev)
                -> DmResult<ThinPoolDev> {
+        verify_data_block_size(data_block_size)?;
         if device_exists(dm, name)? {
             let err_msg = format!("thinpooldev {} already exists", name);
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
@@ -166,6 +192,7 @@ impl ThinPoolDev {
                  meta: LinearDev,
                  data: LinearDev)
                  -> DmResult<ThinPoolDev> {
+        verify_data_block_size(data_block_size)?;
         let table = ThinPoolDev::dm_table(&meta, &data, data_block_size, low_water_mark);
         let dev_info = device_setup(dm, name, uuid, &table)?;
 
@@ -330,7 +357,6 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
 mod tests {
     use std::path::Path;
 
-    use super::super::errors::{Error, ErrorKind};
     use super::super::loopbacked::test_with_spec;
 
     use super::*;
@@ -391,7 +417,7 @@ mod tests {
                                        DataBlocks(1),
                                        meta,
                                        data) {
-                    Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+                    Err(DmError::Dm(ErrorEnum::Invalid, _)) => true,
                     _ => false,
                 });
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -130,6 +130,7 @@ custom_derive! {
     #[derive(NewtypeAdd, NewtypeAddAssign,
              NewtypeDeref,
              NewtypeFrom,
+             NewtypeRem,
              NewtypeSub, NewtypeSubAssign,
              Debug, Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
     /// A type for Data Blocks as used by the thin pool.
@@ -156,6 +157,7 @@ custom_derive! {
              NewtypeDeref,
              NewtypeFrom,
              NewtypeSub,
+             NewtypeRem,
              Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
     /// A type for Meta Data blocks as used by the thin pool.
     /// MetaBlocks have a kernel defined constant size of META_BLOCK_SIZE
@@ -188,6 +190,7 @@ custom_derive! {
     #[derive(NewtypeAdd, NewtypeAddAssign,
              NewtypeDeref,
              NewtypeFrom,
+             NewtypeRem,
              NewtypeSub, NewtypeSubAssign,
              Debug, Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
     /// Structure to represent bytes
@@ -223,6 +226,7 @@ custom_derive! {
     #[derive(NewtypeAdd, NewtypeAddAssign,
              NewtypeDeref,
              NewtypeFrom,
+             NewtypeRem,
              NewtypeSub, NewtypeSubAssign,
              Debug, Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
     /// A separate type to store counts and offsets expressed in


### PR DESCRIPTION
It's not costly to do, and it uses some otherwise dead code.

It's a lot clearer and more specific than the ioctl return code which is
what would otherwise be returned on bad values.

Export the minimum and maximum values that we believe in.

Signed-off-by: mulhern <amulhern@redhat.com>