### PR TITLE
Some work on messages

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -761,12 +761,12 @@ impl DM {
         Ok(targets)
     }
 
-    /// Send a message to the target at a given sector. If sector is
-    /// not needed use 0.  DM-wide messages start with '@', and may
-    /// return a string; targets do not.
+    /// Send a message to the device specified by id and the sector
+    /// specified by sector. If sending to the whole device, set sector to
+    /// None.
     pub fn target_msg(&self,
                       id: &DevId,
-                      sector: Sectors,
+                      sector: Option<Sectors>,
                       msg: &str)
                       -> DmResult<(DeviceInfo, Option<String>)> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
@@ -778,7 +778,7 @@ impl DM {
         };
 
         let mut msg_struct: dmi::Struct_dm_target_msg = Default::default();
-        msg_struct.sector = *sector;
+        msg_struct.sector = *sector.unwrap_or_default();
         let mut data_in = unsafe {
             let ptr = &msg_struct as *const dmi::Struct_dm_target_msg as *mut u8;
             slice::from_raw_parts(ptr, size_of::<dmi::Struct_dm_target_msg>()).to_vec()

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -31,6 +31,12 @@ pub trait DmDevice {
     fn teardown(self, dm: &DM) -> DmResult<()>;
 }
 
+/// Send a message that expects no reply to target device.
+pub fn message(dm: &DM, target: &DmDevice, msg: &str) -> DmResult<()> {
+    dm.target_msg(&DevId::Name(target.name()), None, msg)?;
+    Ok(())
+}
+
 /// Create a device, load a table, and resume it.
 pub fn device_create(dm: &DM,
                      name: &DmName,

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -8,7 +8,7 @@ use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DM_SUSPEND, DmFlags};
 use super::result::{DmError, DmResult, ErrorEnum};
-use super::shared::{DmDevice, device_create, device_exists, device_setup, table_reload};
+use super::shared::{DmDevice, device_create, device_exists, device_setup, message, table_reload};
 use super::thindevid::ThinDevId;
 use super::thinpooldev::ThinPoolDev;
 use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetTypeBuf};
@@ -69,8 +69,7 @@ impl ThinDev {
                length: Sectors)
                -> DmResult<ThinDev> {
 
-        thin_pool
-            .message(dm, &format!("create_thin {}", thin_id))?;
+        message(dm, thin_pool, &format!("create_thin {}", thin_id))?;
 
         if device_exists(dm, name)? {
             let err_msg = "Uncreated device should not be known to kernel";
@@ -130,9 +129,9 @@ impl ThinDev {
                     -> DmResult<ThinDev> {
         let source_id = DevId::Name(self.name());
         dm.device_suspend(&source_id, DM_SUSPEND)?;
-        thin_pool
-            .message(dm,
-                     &format!("create_snap {} {}", snapshot_thin_id, self.thin_id))?;
+        message(dm,
+                thin_pool,
+                &format!("create_snap {} {}", snapshot_thin_id, self.thin_id))?;
         dm.device_suspend(&source_id, DmFlags::empty())?;
         let dev_info = Box::new(device_create(dm,
                                               snapshot_name,
@@ -217,8 +216,7 @@ impl ThinDev {
     pub fn destroy(self, dm: &DM, thin_pool: &ThinPoolDev) -> DmResult<()> {
         let thin_id = self.thin_id;
         self.teardown(dm)?;
-        thin_pool.message(dm, &format!("delete {}", thin_id))?;
-
+        message(dm, thin_pool, &format!("delete {}", thin_id))?;
         Ok(())
     }
 }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -202,12 +202,6 @@ impl ThinPoolDev {
              }]
     }
 
-    /// send a message to DM thin pool
-    pub fn message(&self, dm: &DM, message: &str) -> DmResult<()> {
-        dm.target_msg(&DevId::Name(self.name()), None, message)?;
-        Ok(())
-    }
-
     /// Get the current status of the thinpool.
     /// Returns an error if there was an error getting the status value.
     /// Panics if there is an error parsing the status value.

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -204,7 +204,7 @@ impl ThinPoolDev {
 
     /// send a message to DM thin pool
     pub fn message(&self, dm: &DM, message: &str) -> DmResult<()> {
-        dm.target_msg(&DevId::Name(self.name()), Sectors(0), message)?;
+        dm.target_msg(&DevId::Name(self.name()), None, message)?;
         Ok(())
     }
 


### PR DESCRIPTION
Introduce a generic way of messaging a device. This should be just as useful for messaging cache devs as for messaging thinpool devs.