### PR TITLE
More tweaks about thinpool devices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,8 @@ pub use lineardev::LinearDev;
 pub use result::{DmResult, DmError, ErrorEnum};
 pub use segment::Segment;
 pub use shared::{DmDevice, device_exists};
-pub use thinpooldev::{ThinPoolBlockUsage, ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
+pub use thinpooldev::{ThinPoolUsage, ThinPoolDev, ThinPoolNoSpacePolicy, ThinPoolStatus,
+                      ThinPoolStatusSummary, ThinPoolWorkingStatus};
 pub use thindev::{ThinDev, ThinStatus};
 pub use thindevid::ThinDevId;
 pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, MetaBlocks,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -246,7 +246,10 @@ impl ThinPoolDev {
             "needs_check" => {
                 return Ok(ThinPoolStatus::Good(ThinPoolWorkingStatus::NeedsCheck, usage))
             }
-            _ => panic!("Kernel returned unexpected 8th value in thin pool status"),
+            val => {
+                panic!(format!("Kernel returned unexpected 8th value \"{}\" in thin pool status",
+                               val))
+            }
         }
 
         match status_vals[4] {
@@ -255,7 +258,10 @@ impl ThinPoolDev {
             "out_of_data_space" => {
                 Ok(ThinPoolStatus::Good(ThinPoolWorkingStatus::OutOfSpace, usage))
             }
-            _ => panic!("Kernel returned unexpected 5th value in thin pool status"),
+            val => {
+                panic!(format!("Kernel returned unexpected 5th value \"{}\" in thin pool status",
+                               val))
+            }
         }
     }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -207,13 +207,13 @@ impl ThinPoolDev {
     /// Panics if there is an error parsing the status value.
     // Justification: see comment above DM::parse_table_status.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
-        let (_, mut status) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
+        let (_, status) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
 
         assert_eq!(status.len(),
                    1,
                    "Kernel must return 1 line from thin pool status");
 
-        let status_line = status.pop().expect("assertion above holds").params;
+        let status_line = &status.get(0).expect("assertion above holds").params;
         if status_line.starts_with("Fail") {
             return Ok(ThinPoolStatus::Fail);
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,9 +28,19 @@ use super::deviceinfo::{DM_NAME_LEN, DM_UUID_LEN};
 use super::errors::ErrorKind;
 use super::result::{DmError, DmResult};
 
-/// a kernel defined block size constant for a DM meta device
-/// defined in drivers/md/persistent-data/dm-space-map-metadata.h line 12
+/// a kernel defined block size constant for any DM meta device
+/// a DM meta device may store cache device or thinpool device metadata
+/// defined in drivers/md/persistent-data/dm-space-map-metadata.h as
+/// DM_SM_METADATA_BLOCK_SIZE.
 const META_BLOCK_SIZE: Sectors = Sectors(8);
+
+/// The maximum size of a metadata device.
+/// defined in drivers/md/persistent-data/dm-space-map-metadata.h as
+/// DM_SM_METADATA_MAX_BLOCKS.
+/// As far as I can tell, this is not a limit on the size of a designated
+/// metadata device, but instead on the possible usage of that device.
+#[allow(dead_code)]
+const MAX_META_DEV_SIZE: MetaBlocks = MetaBlocks(255 * ((1 << 14) - 64));
 
 // division by self
 macro_rules! self_div {


### PR DESCRIPTION
Some minor tweaks to ThinPoolDev implementation and related.

These come up since CacheDev is more similar to ThinPoolDev than any other device implemented so far.