### PR TITLE
Improve implementation and use of TargetLine type

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -505,7 +505,7 @@ impl CacheDev {
                    1,
                    "Kernel must return 1 line from cache dev status");
 
-        let status_line = &status.get(0).expect("assertion above holds").3;
+        let status_line = &status.first().expect("assertion above holds").3;
         if status_line.starts_with("Fail") {
             return Ok(CacheDevStatus::Fail);
         }

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -17,7 +17,7 @@ use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, Targe
                    TargetParams, TargetTypeBuf};
 
 #[derive(Debug, Eq, PartialEq)]
-struct CacheDevTargetParams {
+pub struct CacheDevTargetParams {
     pub meta: Device,
     pub cache: Device,
     pub origin: Device,
@@ -312,7 +312,7 @@ pub struct CacheDev {
     block_size: Sectors,
 }
 
-impl DmDevice for CacheDev {
+impl DmDevice<CacheDevTargetParams> for CacheDev {
     fn device(&self) -> Device {
         device!(self)
     }

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -494,7 +494,8 @@ mod tests {
     use std::path::Path;
 
     use super::super::consts::IEC;
-    use super::super::loopbacked::{devnode_to_devno, test_with_spec};
+    use super::super::device::devnode_to_devno;
+    use super::super::loopbacked::test_with_spec;
     use super::super::segment::Segment;
 
     use super::*;

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -419,7 +419,7 @@ impl CacheDev {
                 cache: &LinearDev,
                 origin: &LinearDev,
                 cache_block_size: Sectors)
-                -> Vec<TargetLine<String>> {
+                -> Vec<TargetLine<CacheDevTargetParams>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: origin.size(),
@@ -430,8 +430,7 @@ impl CacheDev {
                                                    cache_block_size,
                                                    vec![],
                                                    "default".to_owned(),
-                                                   vec![])
-                         .to_string(),
+                                                   vec![]),
              }]
     }
 

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -204,10 +204,10 @@ impl CacheDev {
     pub fn new(dm: &DM,
                name: &DmName,
                uuid: Option<&DmUuid>,
-               cache_block_size: Sectors,
                meta: LinearDev,
                cache: LinearDev,
-               origin: LinearDev)
+               origin: LinearDev,
+               cache_block_size: Sectors)
                -> DmResult<CacheDev> {
         if device_exists(dm, name)? {
             let err_msg = format!("cachedev {} already exists", name);
@@ -230,10 +230,10 @@ impl CacheDev {
     pub fn setup(dm: &DM,
                  name: &DmName,
                  uuid: Option<&DmUuid>,
-                 cache_block_size: Sectors,
                  meta: LinearDev,
                  cache: LinearDev,
-                 origin: LinearDev)
+                 origin: LinearDev,
+                 cache_block_size: Sectors)
                  -> DmResult<CacheDev> {
         let table = CacheDev::dm_table(&meta, &origin, &cache, cache_block_size);
         let dev_info = device_setup(dm, name, uuid, &table)?;
@@ -460,10 +460,10 @@ mod tests {
         let cache = CacheDev::new(&dm,
                                   DmName::new("cache").expect("valid format"),
                                   None,
-                                  MIN_CACHE_BLOCK_SIZE,
                                   meta,
                                   cache,
-                                  origin)
+                                  origin,
+                                  MIN_CACHE_BLOCK_SIZE)
                 .unwrap();
 
         match cache.status(&dm).unwrap() {

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -366,7 +366,7 @@ impl CacheDev {
                    1,
                    "Kernel must return 1 line from cache dev status");
 
-        let status_line = &status.get(0).expect("assertion above holds").params;
+        let status_line = &status.get(0).expect("assertion above holds").3;
         if status_line.starts_with("Fail") {
             return Ok(CacheDevStatus::Fail);
         }

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -261,6 +261,10 @@ impl DmDevice for CacheDev {
         self.meta_dev.teardown(dm)?;
         Ok(())
     }
+
+    fn uuid(&self) -> Option<&DmUuid> {
+        uuid!(self)
+    }
 }
 
 

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -671,6 +671,15 @@ mod tests {
             _ => assert!(false),
         }
 
+        let table = cache.table(&dm).unwrap();
+        assert_eq!(table.len(), 1);
+
+        let line = &table[0];
+        let params = &line.params;
+        assert_eq!(params.cache_block_size, MIN_CACHE_BLOCK_SIZE);
+        assert_eq!(params.feature_args, HashSet::new());
+        assert_eq!(params.policy, "default");
+
         cache.teardown(&dm).unwrap();
     }
 

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -16,7 +16,7 @@ use super::shared::{DmDevice, device_create, device_exists, device_match, parse_
 use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetLine,
                    TargetParams, TargetTypeBuf};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 struct CacheDevTargetParams {
     pub meta: Device,
     pub cache: Device,

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -89,7 +89,7 @@ impl fmt::Display for CacheDevTargetParams {
 impl FromStr for CacheDevTargetParams {
     type Err = DmError;
 
-    fn from_str(s: &str) -> Result<CacheDevTargetParams, DmError> {
+    fn from_str(s: &str) -> DmResult<CacheDevTargetParams> {
         let vals = s.split(' ').collect::<Vec<_>>();
 
         if vals.len() < 7 {

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -630,7 +630,7 @@ mod tests {
     // Verify that status method executes and gives reasonable values.
     fn test_minimal_cache_dev(paths: &[&Path]) -> () {
         assert!(paths.len() >= 2);
-        let dev1 = Device::from(devnode_to_devno(paths[0]).unwrap());
+        let dev1 = Device::from(devnode_to_devno(paths[0]).unwrap().unwrap());
 
         let dm = DM::new().unwrap();
 
@@ -653,7 +653,7 @@ mod tests {
                                      &[Segment::new(dev1, cache_offset, cache_length)])
                 .unwrap();
 
-        let dev2 = Device::from(devnode_to_devno(paths[1]).unwrap());
+        let dev2 = Device::from(devnode_to_devno(paths[1]).unwrap().unwrap());
 
         let origin_name = DmName::new("cache-origin").expect("valid format");
         let origin_length = 512u64 * MIN_CACHE_BLOCK_SIZE;

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -419,7 +419,7 @@ impl CacheDev {
                 cache: &LinearDev,
                 origin: &LinearDev,
                 cache_block_size: Sectors)
-                -> Vec<TargetLine> {
+                -> Vec<TargetLine<String>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: origin.size(),

--- a/src/device.rs
+++ b/src/device.rs
@@ -100,7 +100,6 @@ impl Device {
 /// Get a device number from a device node.
 /// Return None if the device is not a block device; devicemapper is not
 /// interested in other sorts of devices.
-#[allow(dead_code)]
 pub fn devnode_to_devno(path: &Path) -> Option<u64> {
     let metadata = path.metadata().unwrap();
     if metadata.st_mode() & S_IFMT.bits() == S_IFBLK.bits() {

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -512,7 +512,7 @@ impl DM {
     /// let id = DevId::Name(name);
     /// dm.table_load(&id, &table).unwrap();
     /// ```
-    pub fn table_load(&self, id: &DevId, targets: &[TargetLine]) -> DmResult<DeviceInfo> {
+    pub fn table_load(&self, id: &DevId, targets: &[TargetLine<String>]) -> DmResult<DeviceInfo> {
         let mut targs = Vec::new();
 
         // Construct targets first, since we need to know how many & size

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -439,7 +439,7 @@ impl DM {
     /// Get DeviceInfo for a device. This is also returned by other
     /// methods, but if just the DeviceInfo is desired then this just
     /// gets it.
-    pub fn device_status(&self, id: &DevId) -> DmResult<DeviceInfo> {
+    pub fn device_info(&self, id: &DevId) -> DmResult<DeviceInfo> {
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         Self::initialize_hdr(&mut hdr, DmFlags::empty());
@@ -923,12 +923,12 @@ mod tests {
         let uuid = DmUuid::new("example-363333333333333").expect("is valid DM uuid");
         let result = dm.device_rename(name, &DevId::Uuid(uuid)).unwrap();
         assert_eq!(result.uuid(), None);
-        assert_eq!(dm.device_status(&DevId::Name(name))
+        assert_eq!(dm.device_info(&DevId::Name(name))
                        .unwrap()
                        .uuid()
                        .unwrap(),
                    uuid);
-        assert!(dm.device_status(&DevId::Uuid(uuid)).is_ok());
+        assert!(dm.device_info(&DevId::Uuid(uuid)).is_ok());
         dm.device_remove(&DevId::Name(name), DmFlags::empty())
             .unwrap();
     }
@@ -960,11 +960,11 @@ mod tests {
         let new_name = DmName::new("example-dev-2").expect("is valid DM name");
         dm.device_rename(name, &DevId::Name(new_name)).unwrap();
 
-        assert!(match dm.device_status(&DevId::Name(name)) {
+        assert!(match dm.device_info(&DevId::Name(name)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        assert!(dm.device_status(&DevId::Name(new_name)).is_ok());
+        assert!(dm.device_info(&DevId::Name(new_name)).is_ok());
 
         let devices = dm.list_devices().unwrap();
         assert_eq!(devices.len(), 1);
@@ -1071,7 +1071,7 @@ mod tests {
     /// by name returns an error.
     fn sudo_status_no_name() {
         let name = DmName::new("example_dev").expect("is valid DM name");
-        assert!(match DM::new().unwrap().device_status(&DevId::Name(name)) {
+        assert!(match DM::new().unwrap().device_info(&DevId::Name(name)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub use segment::Segment;
 pub use shared::{DmDevice, device_exists};
 pub use thinpooldev::{ThinPoolUsage, ThinPoolDev, ThinPoolNoSpacePolicy, ThinPoolStatus,
                       ThinPoolStatusSummary, ThinPoolWorkingStatus};
-pub use thindev::{ThinDev, ThinStatus};
+pub use thindev::{ThinDev, ThinDevWorkingStatus, ThinStatus};
 pub use thindevid::ThinDevId;
 pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, MetaBlocks,
                 Sectors, TargetLine, TargetType, TargetTypeBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub use cachedev::{CacheDev, CacheDevPerformance, CacheDevStatus, CacheDevUsage,
 pub use consts::{IEC, SECTOR_SIZE};
 pub use dm::{DM, DmFlags};
 
-pub use device::Device;
+pub use device::{Device, devnode_to_devno};
 pub use lineardev::LinearDev;
 pub use result::{DmResult, DmError, ErrorEnum};
 pub use segment::Segment;

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -40,7 +40,7 @@ impl fmt::Display for LinearDevTargetParams {
 impl FromStr for LinearDevTargetParams {
     type Err = DmError;
 
-    fn from_str(s: &str) -> Result<LinearDevTargetParams, DmError> {
+    fn from_str(s: &str) -> DmResult<LinearDevTargetParams> {
         let vals = s.split(' ').collect::<Vec<_>>();
         if vals.len() != 2 {
             let err_msg = format!("expected two values in params string \"{}\", found {}",

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -188,8 +188,8 @@ mod tests {
     use std::fs::OpenOptions;
     use std::path::Path;
 
-    use super::super::device::Device;
-    use super::super::loopbacked::{blkdev_size, devnode_to_devno, test_with_spec};
+    use super::super::device::{Device, devnode_to_devno};
+    use super::super::loopbacked::{blkdev_size, test_with_spec};
 
     use super::*;
 

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -16,7 +16,7 @@ use super::shared::{DmDevice, device_create, device_exists, device_match, parse_
 use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetParams, TargetTypeBuf};
 
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 struct LinearDevTargetParams {
     pub device: Device,
     pub physical_start_offset: Sectors,

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -67,6 +67,10 @@ impl DmDevice for LinearDev {
         dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
+
+    fn uuid(&self) -> Option<&DmUuid> {
+        uuid!(self)
+    }
 }
 
 /// Use DM to concatenate a list of segments together into a

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -161,7 +161,7 @@ impl LinearDev {
     /// <logical start offset> <length> "linear" <linear-specific string>
     /// where the linear-specific string has the format:
     /// <maj:min> <physical start offset>
-    fn dm_table(segments: &[Segment]) -> Vec<TargetLine<String>> {
+    fn dm_table(segments: &[Segment]) -> Vec<TargetLine<LinearDevTargetParams>> {
         assert_ne!(segments.len(), 0);
 
         let mut table = Vec::new();
@@ -172,8 +172,7 @@ impl LinearDev {
                 start: logical_start_offset,
                 length: length,
                 target_type: TargetTypeBuf::new("linear".into()).expect("< length limit"),
-                params: LinearDevTargetParams::new(segment.device, physical_start_offset)
-                    .to_string(),
+                params: LinearDevTargetParams::new(segment.device, physical_start_offset),
             };
             debug!("dmtable line : {:?}", line);
             table.push(line);

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -235,7 +235,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let mut ld = LinearDev::setup(&dm,
                                       DmName::new(name).expect("valid format"),
                                       None,
@@ -255,7 +255,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let mut ld = LinearDev::setup(&dm,
                                       DmName::new(name).expect("valid format"),
                                       None,
@@ -279,7 +279,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1)),
                          Segment::new(dev, Sectors(0), Sectors(1))];
         let range: Sectors = segments.iter().map(|s| s.length).sum();
@@ -312,7 +312,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let segments = (0..5)
             .map(|n| Segment::new(dev, Sectors(n), Sectors(1)))
             .collect::<Vec<Segment>>();
@@ -336,7 +336,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let name = "name";
-        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
         let ld = LinearDev::setup(&dm,
                                   DmName::new(name).expect("valid format"),
@@ -361,7 +361,7 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
         let ld = LinearDev::setup(&dm,
                                   DmName::new("name").expect("valid format"),

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -137,7 +137,7 @@ impl LinearDev {
             return Ok(());
         }
         dm.device_rename(self.name(), &DevId::Name(name))?;
-        self.dev_info = Box::new(dm.device_status(&DevId::Name(name))?);
+        self.dev_info = Box::new(dm.device_info(&DevId::Name(name))?);
         Ok(())
     }
 }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -272,7 +272,8 @@ mod tests {
 
     /// Verify that passing the same segments two times gets two segments.
     /// Verify that the size of the devnode is the size of the sum of the
-    /// ranges of the segments.
+    /// ranges of the segments. Verify that the table contains entries for both
+    /// segments.
     fn test_duplicate_segments(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
@@ -288,12 +289,12 @@ mod tests {
                                   None,
                                   segments)
                 .unwrap();
-        assert_eq!(dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
-                                   DmFlags::DM_STATUS_TABLE)
-                       .unwrap()
-                       .1
-                       .len(),
-                   count);
+
+        let table = ld.table(&dm).unwrap();
+        assert_eq!(table.len(), count);
+        assert_eq!(table[0].params.device, dev);
+        assert_eq!(table[1].params.device, dev);
+
         assert_eq!(blkdev_size(&OpenOptions::new()
                                     .read(true)
                                     .open(ld.devnode())

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -272,7 +272,6 @@ mod tests {
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
         let segments = &[Segment::new(dev, Sectors(0), Sectors(1))];
-        let table = LinearDev::dm_table(segments);
         let ld = LinearDev::setup(&dm,
                                   DmName::new(name).expect("valid format"),
                                   None,
@@ -288,12 +287,6 @@ mod tests {
                                  None,
                                  segments)
                         .is_ok());
-        assert_eq!(table,
-                   dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
-                                   DmFlags::DM_STATUS_TABLE)
-                       .unwrap()
-                       .1);
-
         ld.teardown(&dm).unwrap();
     }
 
@@ -316,29 +309,6 @@ mod tests {
         assert!(ld2.is_ok());
 
         ld2.unwrap().teardown(&dm).unwrap();
-        ld.teardown(&dm).unwrap();
-    }
-
-    /// Verify that table status returns the expected table.
-    fn test_table_status(paths: &[&Path]) -> () {
-        assert!(paths.len() >= 1);
-
-        let dm = DM::new().unwrap();
-        let name = "name";
-        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap());
-        let segments = &[Segment::new(dev, Sectors(0), Sectors(1)),
-                         Segment::new(dev, Sectors(1), Sectors(1))];
-        let table = LinearDev::dm_table(segments);
-        let ld = LinearDev::setup(&dm,
-                                  DmName::new(name).expect("valid format"),
-                                  None,
-                                  segments)
-                .unwrap();
-        assert_eq!(table,
-                   dm.table_status(&DevId::Name(DmName::new(name).expect("valid format")),
-                                   DmFlags::DM_STATUS_TABLE)
-                       .unwrap()
-                       .1);
         ld.teardown(&dm).unwrap();
     }
 
@@ -370,10 +340,5 @@ mod tests {
     #[test]
     fn loop_test_segment() {
         test_with_spec(1, test_same_segment);
-    }
-
-    #[test]
-    fn loop_test_table_status() {
-        test_with_spec(1, test_table_status);
     }
 }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -17,7 +17,7 @@ use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetParams, Tar
 
 
 #[derive(Debug, Eq, PartialEq)]
-struct LinearDevTargetParams {
+pub struct LinearDevTargetParams {
     pub device: Device,
     pub physical_start_offset: Sectors,
 }
@@ -74,7 +74,7 @@ pub struct LinearDev {
     segments: Vec<Segment>,
 }
 
-impl DmDevice for LinearDev {
+impl DmDevice<LinearDevTargetParams> for LinearDev {
     fn device(&self) -> Device {
         device!(self)
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -161,7 +161,7 @@ impl LinearDev {
     /// <logical start offset> <length> "linear" <linear-specific string>
     /// where the linear-specific string has the format:
     /// <maj:min> <physical start offset>
-    fn dm_table(segments: &[Segment]) -> Vec<TargetLine> {
+    fn dm_table(segments: &[Segment]) -> Vec<TargetLine<String>> {
         assert_ne!(segments.len(), 0);
 
         let mut table = Vec::new();

--- a/src/loopbacked.rs
+++ b/src/loopbacked.rs
@@ -5,12 +5,10 @@
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::{Seek, SeekFrom, Write};
-use std::os::linux::fs::MetadataExt;
 use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use loopdev::{LoopControl, LoopDevice};
-use nix::sys::stat::{S_IFBLK, S_IFMT};
 use tempdir::TempDir;
 
 use super::consts::{IEC, SECTOR_SIZE};
@@ -28,17 +26,6 @@ pub fn blkdev_size(file: &File) -> Bytes {
     Bytes(val)
 }
 
-/// Get a device number from a device node.
-/// Return None if the device is not a block device; devicemapper is not
-/// interested in other sorts of devices.
-pub fn devnode_to_devno(path: &Path) -> Option<u64> {
-    let metadata = path.metadata().unwrap();
-    if metadata.st_mode() & S_IFMT.bits() == S_IFBLK.bits() {
-        Some(metadata.st_rdev())
-    } else {
-        None
-    }
-}
 
 /// Write buf at offset length times.
 fn write_sectors<P: AsRef<Path>>(path: P,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -23,8 +23,8 @@ pub trait DmDevice<T: TargetParams> {
     fn device(&self) -> Device;
 
     /// Check if tables indicate an equivalent device.
-    fn equivalent_tables(left: &[TargetLine<T>], right: &[TargetLine<T>]) -> bool {
-        left == right
+    fn equivalent_tables(left: &[TargetLine<T>], right: &[TargetLine<T>]) -> DmResult<bool> {
+        Ok(left == right)
     }
 
     /// The device's name.
@@ -106,7 +106,7 @@ pub fn device_match<T: TargetParams, D: DmDevice<T>>(dm: &DM,
     where DmError: From<<T as FromStr>::Err>
 {
     let kernel_table = dev.table(dm)?;
-    if !D::equivalent_tables(&kernel_table, table) {
+    if !D::equivalent_tables(&kernel_table, table)? {
         let err_msg = format!("Specified new table \"{:?}\" does not match kernel table \"{:?}\"",
                               table,
                               kernel_table);

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -157,7 +157,7 @@ pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
 /// Parse a device from either of a path or a maj:min pair
 pub fn parse_device(val: &str) -> DmResult<Device> {
     let device = if val.starts_with('/') {
-        devnode_to_devno(Path::new(val))
+        devnode_to_devno(Path::new(val))?
             .ok_or_else(|| {
                             DmError::Dm(ErrorEnum::Invalid,
                                         format!("failed to parse device number from \"{}\"", val))

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -27,6 +27,22 @@ pub trait DmDevice {
     /// The number of sectors available for user data.
     fn size(&self) -> Sectors;
 
+    /// The devicemapper table
+    fn table(&self, dm: &DM) -> DmResult<Vec<TargetLine>> {
+        let (_, table) = dm.table_status(&DevId::Name(self.name()), DmFlags::DM_STATUS_TABLE)?;
+        Ok(table
+               .into_iter()
+               .map(|x| {
+                        TargetLine {
+                            start: x.0,
+                            length: x.1,
+                            target_type: x.2,
+                            params: x.3,
+                        }
+                    })
+               .collect())
+    }
+
     /// Erase the kernel's memory of this device.
     fn teardown(self, dm: &DM) -> DmResult<()>;
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -65,23 +65,23 @@ fn device_match(dm: &DM,
                 uuid: Option<&DmUuid>,
                 table: &[TargetLine])
                 -> DmResult<DeviceInfo> {
-    let table_status = dm.table_status(&DevId::Name(name), DmFlags::DM_STATUS_TABLE)?;
-    if table_status.1 != table {
+    let (dev_info, kernel_table) = dm.table_status(&DevId::Name(name), DmFlags::DM_STATUS_TABLE)?;
+    if kernel_table != table {
         let err_msg = format!("Specified new table \"{:?}\" does not match kernel table \"{:?}\"",
                               table,
-                              table_status.1);
+                              kernel_table);
 
         return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
     }
-    let status = table_status.0;
-    if status.uuid() != uuid {
+
+    if dev_info.uuid() != uuid {
         let err_msg = format!("Specified uuid \"{:?}\" does not match kernel uuuid \"{:?}\"",
                               uuid,
-                              status.uuid());
+                              dev_info.uuid());
 
         return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
     }
-    Ok(status)
+    Ok(dev_info)
 }
 
 /// Setup a device.

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -28,7 +28,7 @@ pub trait DmDevice {
     fn size(&self) -> Sectors;
 
     /// The devicemapper table
-    fn table(&self, dm: &DM) -> DmResult<Vec<TargetLine>> {
+    fn table(&self, dm: &DM) -> DmResult<Vec<TargetLine<String>>> {
         let (_, table) = dm.table_status(&DevId::Name(self.name()), DmFlags::DM_STATUS_TABLE)?;
         Ok(table
                .into_iter()
@@ -61,7 +61,7 @@ pub fn message(dm: &DM, target: &DmDevice, msg: &str) -> DmResult<()> {
 pub fn device_create(dm: &DM,
                      name: &DmName,
                      uuid: Option<&DmUuid>,
-                     table: &[TargetLine])
+                     table: &[TargetLine<String>])
                      -> DmResult<DeviceInfo> {
     dm.device_create(name, uuid, DmFlags::empty())?;
 
@@ -82,7 +82,7 @@ pub fn device_create(dm: &DM,
 pub fn device_match(dm: &DM,
                     dev: &DmDevice,
                     uuid: Option<&DmUuid>,
-                    table: &[TargetLine])
+                    table: &[TargetLine<String>])
                     -> DmResult<()> {
     let kernel_table = dev.table(dm)?;
     if kernel_table != table {
@@ -104,7 +104,7 @@ pub fn device_match(dm: &DM,
 }
 
 /// Reload the table for a device
-pub fn table_reload(dm: &DM, id: &DevId, table: &[TargetLine]) -> DmResult<DeviceInfo> {
+pub fn table_reload(dm: &DM, id: &DevId, table: &[TargetLine<String>]) -> DmResult<DeviceInfo> {
     let dev_info = dm.table_load(id, table)?;
     dm.device_suspend(id, DmFlags::DM_SUSPEND)?;
     dm.device_suspend(id, DmFlags::empty())?;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -45,6 +45,10 @@ pub trait DmDevice {
 
     /// Erase the kernel's memory of this device.
     fn teardown(self, dm: &DM) -> DmResult<()>;
+
+    /// The device's UUID, if available.
+    /// Note that the UUID is not any standard UUID format.
+    fn uuid(&self) -> Option<&DmUuid>;
 }
 
 /// Send a message that expects no reply to target device.

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -21,6 +21,11 @@ pub trait DmDevice {
     /// The device.
     fn device(&self) -> Device;
 
+    /// Check if tables indicate an equivalent device.
+    fn equivalent_tables(left: &[TargetLine<String>], right: &[TargetLine<String>]) -> bool {
+        left == right
+    }
+
     /// The device's name.
     fn name(&self) -> &DmName;
 
@@ -52,7 +57,7 @@ pub trait DmDevice {
 }
 
 /// Send a message that expects no reply to target device.
-pub fn message(dm: &DM, target: &DmDevice, msg: &str) -> DmResult<()> {
+pub fn message<D: DmDevice>(dm: &DM, target: &D, msg: &str) -> DmResult<()> {
     dm.target_msg(&DevId::Name(target.name()), None, msg)?;
     Ok(())
 }
@@ -79,13 +84,13 @@ pub fn device_create(dm: &DM,
 }
 
 /// Verify that kernel data matches arguments passed.
-pub fn device_match(dm: &DM,
-                    dev: &DmDevice,
-                    uuid: Option<&DmUuid>,
-                    table: &[TargetLine<String>])
-                    -> DmResult<()> {
+pub fn device_match<D: DmDevice>(dm: &DM,
+                                 dev: &D,
+                                 uuid: Option<&DmUuid>,
+                                 table: &[TargetLine<String>])
+                                 -> DmResult<()> {
     let kernel_table = dev.table(dm)?;
-    if kernel_table != table {
+    if !D::equivalent_tables(&kernel_table, table) {
         let err_msg = format!("Specified new table \"{:?}\" does not match kernel table \"{:?}\"",
                               table,
                               kernel_table);

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -66,6 +66,18 @@ fn device_match(dm: &DM,
                 table: &[TargetLine])
                 -> DmResult<DeviceInfo> {
     let (dev_info, kernel_table) = dm.table_status(&DevId::Name(name), DmFlags::DM_STATUS_TABLE)?;
+    // FIXME: this should go away in completed version
+    let kernel_table = kernel_table
+        .iter()
+        .map(|x| {
+                 TargetLine {
+                     start: x.0,
+                     length: x.1,
+                     target_type: x.2.to_owned(),
+                     params: x.3.to_owned(),
+                 }
+             })
+        .collect::<Vec<_>>();
     if kernel_table != table {
         let err_msg = format!("Specified new table \"{:?}\" does not match kernel table \"{:?}\"",
                               table,

--- a/src/shared_macros.rs
+++ b/src/shared_macros.rs
@@ -17,6 +17,12 @@ macro_rules! name {
     }
 }
 
+macro_rules! uuid {
+    ($s: ident) => {
+        $s.dev_info.uuid()
+    }
+}
+
 macro_rules! devnode {
     ($s: ident) => {
         ["/dev", &format!("dm-{}", $s.dev_info.device().minor)].iter().collect()

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -235,7 +235,7 @@ impl ThinDev {
     /// where the thin device specific string has the format:
     /// <thinpool maj:min> <thin_id>
     /// There is exactly one entry in the table.
-    fn dm_table(length: Sectors, thin_pool: Device, thin_id: ThinDevId) -> Vec<TargetLine> {
+    fn dm_table(length: Sectors, thin_pool: Device, thin_id: ThinDevId) -> Vec<TargetLine<String>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: length,

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -235,12 +235,15 @@ impl ThinDev {
     /// where the thin device specific string has the format:
     /// <thinpool maj:min> <thin_id>
     /// There is exactly one entry in the table.
-    fn dm_table(length: Sectors, thin_pool: Device, thin_id: ThinDevId) -> Vec<TargetLine<String>> {
+    fn dm_table(length: Sectors,
+                thin_pool: Device,
+                thin_id: ThinDevId)
+                -> Vec<TargetLine<ThinDevTargetParams>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: length,
                  target_type: TargetTypeBuf::new("thin".into()).expect("< length limit"),
-                 params: ThinDevTargetParams::new(thin_pool, thin_id).to_string(),
+                 params: ThinDevTargetParams::new(thin_pool, thin_id),
              }]
     }
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -385,6 +385,13 @@ mod tests {
         let td_size = MIN_THIN_DEV_SIZE;
         let td = ThinDev::new(&dm, &id, None, td_size, &tp, thin_id).unwrap();
 
+        let table = td.table(&dm).unwrap();
+        assert_eq!(table.len(), 1);
+
+        let line = &table[0];
+        assert_eq!(line.params.pool, tp.device());
+        assert_eq!(line.params.thin_id, thin_id);
+
         assert!(match td.status(&dm).unwrap() {
                     ThinStatus::Fail => false,
                     _ => true,

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::fmt;
 use std::path::PathBuf;
 
 use super::device::Device;
@@ -11,7 +12,32 @@ use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, device_create, device_exists, device_setup, message, table_reload};
 use super::thindevid::ThinDevId;
 use super::thinpooldev::ThinPoolDev;
-use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetTypeBuf};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetParams, TargetTypeBuf};
+
+
+#[derive(Debug, PartialEq)]
+struct ThinDevTargetParams {
+    pub pool: Device,
+    pub thin_id: ThinDevId,
+}
+
+impl ThinDevTargetParams {
+    pub fn new(pool: Device, thin_id: ThinDevId) -> ThinDevTargetParams {
+        ThinDevTargetParams {
+            pool: pool,
+            thin_id: thin_id,
+        }
+    }
+}
+
+impl fmt::Display for ThinDevTargetParams {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", self.pool, self.thin_id)
+    }
+}
+
+impl TargetParams for ThinDevTargetParams {}
+
 
 /// DM construct for a thin block device
 #[derive(Debug)]
@@ -175,12 +201,11 @@ impl ThinDev {
     /// <thinpool maj:min> <thin_id>
     /// There is exactly one entry in the table.
     fn dm_table(length: Sectors, thin_pool: Device, thin_id: ThinDevId) -> Vec<TargetLine> {
-        let params = format!("{} {}", thin_pool, thin_id);
         vec![TargetLine {
                  start: Sectors::default(),
                  length: length,
                  target_type: TargetTypeBuf::new("thin".into()).expect("< length limit"),
-                 params: params,
+                 params: ThinDevTargetParams::new(thin_pool, thin_id).to_string(),
              }]
     }
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -222,7 +222,7 @@ impl ThinDev {
                    1,
                    "Kernel must return 1 line table for thin status");
 
-        let status_line = &table.first().expect("assertion above holds").params;
+        let status_line = &table.first().expect("assertion above holds").3;
         if status_line.starts_with("Fail") {
             return Ok(ThinStatus::Fail);
         }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -69,6 +69,10 @@ impl DmDevice for ThinDev {
         dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
+
+    fn uuid(&self) -> Option<&DmUuid> {
+        uuid!(self)
+    }
 }
 
 /// Status values for a thin device that is working

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -18,7 +18,7 @@ use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetParams, Tar
 
 
 #[derive(Debug, Eq, PartialEq)]
-struct ThinDevTargetParams {
+pub struct ThinDevTargetParams {
     pub pool: Device,
     pub thin_id: ThinDevId,
 }
@@ -66,7 +66,7 @@ pub struct ThinDev {
     thinpool: Device,
 }
 
-impl DmDevice for ThinDev {
+impl DmDevice<ThinDevTargetParams> for ThinDev {
     fn device(&self) -> Device {
         device!(self)
     }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -257,6 +257,8 @@ mod tests {
     use super::super::loopbacked::{blkdev_size, test_with_spec};
     use super::super::thinpooldev::minimal_thinpool;
 
+    use super::super::errors::{Error, ErrorKind};
+
     use super::*;
 
     const MIN_THIN_DEV_SIZE: Sectors = Sectors(1);
@@ -279,7 +281,9 @@ mod tests {
     }
 
     /// Verify that setting up a thin device without first calling new()
-    /// causes an error.
+    /// causes an error. The underlying reason is that the thin pool hasn't
+    /// been informed about the thin device by messaging the value of the
+    /// thin id.
     fn test_setup_without_new(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
@@ -287,13 +291,15 @@ mod tests {
         let tp = minimal_thinpool(&dm, paths[0]);
 
         let td_size = MIN_THIN_DEV_SIZE;
-        assert!(ThinDev::setup(&dm,
-                               &DmName::new("name").expect("is valid DM name"),
-                               None,
-                               td_size,
-                               &tp,
-                               ThinDevId::new_u64(0).expect("is below limit"))
-                        .is_err());
+        assert!(match ThinDev::setup(&dm,
+                                     &DmName::new("name").expect("is valid DM name"),
+                                     None,
+                                     td_size,
+                                     &tp,
+                                     ThinDevId::new_u64(0).expect("is below limit")) {
+                    Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+                    _ => false,
+                });
 
         tp.teardown(&dm).unwrap();
     }
@@ -328,7 +334,13 @@ mod tests {
                    td_size.bytes());
 
         // New thindev w/ same id fails.
-        assert!(ThinDev::new(&dm, &id, None, td_size, &tp, thin_id).is_err());
+        assert!(match ThinDev::new(&dm, &id, None, td_size, &tp, thin_id) {
+                    Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+                    _ => false,
+                });
+
+        // Verify that the device of that name does exist.
+        assert!(device_exists(&dm, id).unwrap());
 
         // Setting up the just created thin dev succeeds.
         assert!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).is_ok());

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -17,7 +17,7 @@ use super::thinpooldev::ThinPoolDev;
 use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetParams, TargetTypeBuf};
 
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 struct ThinDevTargetParams {
     pub pool: Device,
     pub thin_id: ThinDevId,

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -85,9 +85,9 @@ impl ThinDev {
     pub fn new(dm: &DM,
                name: &DmName,
                uuid: Option<&DmUuid>,
+               length: Sectors,
                thin_pool: &ThinPoolDev,
-               thin_id: ThinDevId,
-               length: Sectors)
+               thin_id: ThinDevId)
                -> DmResult<ThinDev> {
 
         message(dm, thin_pool, &format!("create_thin {}", thin_id))?;
@@ -98,7 +98,7 @@ impl ThinDev {
         }
 
         let thin_pool_device = thin_pool.device();
-        let table = ThinDev::dm_table(thin_pool_device, thin_id, length);
+        let table = ThinDev::dm_table(length, thin_pool_device, thin_id);
         let dev_info = device_create(dm, name, uuid, &table)?;
 
         Ok(ThinDev {
@@ -121,13 +121,13 @@ impl ThinDev {
     pub fn setup(dm: &DM,
                  name: &DmName,
                  uuid: Option<&DmUuid>,
+                 length: Sectors,
                  thin_pool: &ThinPoolDev,
-                 thin_id: ThinDevId,
-                 length: Sectors)
+                 thin_id: ThinDevId)
                  -> DmResult<ThinDev> {
 
         let thin_pool_device = thin_pool.device();
-        let table = ThinDev::dm_table(thin_pool_device, thin_id, length);
+        let table = ThinDev::dm_table(length, thin_pool_device, thin_id);
         let dev_info = device_setup(dm, name, uuid, &table)?;
 
         Ok(ThinDev {
@@ -157,9 +157,9 @@ impl ThinDev {
         let dev_info = Box::new(device_create(dm,
                                               snapshot_name,
                                               None,
-                                              &ThinDev::dm_table(thin_pool.device(),
-                                                                 snapshot_thin_id,
-                                                                 self.size()))?);
+                                              &ThinDev::dm_table(self.size(),
+                                                                 thin_pool.device(),
+                                                                 snapshot_thin_id))?);
         Ok(ThinDev {
                dev_info: dev_info,
                thin_id: snapshot_thin_id,
@@ -174,7 +174,7 @@ impl ThinDev {
     /// where the thin device specific string has the format:
     /// <thinpool maj:min> <thin_id>
     /// There is exactly one entry in the table.
-    fn dm_table(thin_pool: Device, thin_id: ThinDevId, length: Sectors) -> Vec<TargetLine> {
+    fn dm_table(length: Sectors, thin_pool: Device, thin_id: ThinDevId) -> Vec<TargetLine> {
         let params = format!("{} {}", thin_pool, thin_id);
         vec![TargetLine {
                  start: Sectors::default(),
@@ -228,7 +228,7 @@ impl ThinDev {
         let new_size = self.size + sectors;
         table_reload(dm,
                      &DevId::Name(self.name()),
-                     &ThinDev::dm_table(self.thinpool, self.thin_id, new_size))?;
+                     &ThinDev::dm_table(new_size, self.thinpool, self.thin_id))?;
         self.size = new_size;
         Ok(())
     }
@@ -271,9 +271,9 @@ mod tests {
         assert!(ThinDev::new(&dm,
                              &DmName::new("name").expect("is valid DM name"),
                              None,
+                             Sectors(0),
                              &tp,
-                             ThinDevId::new_u64(0).expect("is below limit"),
-                             Sectors(0))
+                             ThinDevId::new_u64(0).expect("is below limit"))
                         .is_err());
         tp.teardown(&dm).unwrap();
     }
@@ -290,9 +290,9 @@ mod tests {
         assert!(ThinDev::setup(&dm,
                                &DmName::new("name").expect("is valid DM name"),
                                None,
+                               td_size,
                                &tp,
-                               ThinDevId::new_u64(0).expect("is below limit"),
-                               td_size)
+                               ThinDevId::new_u64(0).expect("is below limit"))
                         .is_err());
 
         tp.teardown(&dm).unwrap();
@@ -314,7 +314,7 @@ mod tests {
         let id = DmName::new("name").expect("is valid DM name");
 
         let td_size = MIN_THIN_DEV_SIZE;
-        let td = ThinDev::new(&dm, &id, None, &tp, thin_id, td_size).unwrap();
+        let td = ThinDev::new(&dm, &id, None, td_size, &tp, thin_id).unwrap();
 
         assert!(match td.status(&dm).unwrap() {
                     ThinStatus::Fail => false,
@@ -328,17 +328,17 @@ mod tests {
                    td_size.bytes());
 
         // New thindev w/ same id fails.
-        assert!(ThinDev::new(&dm, &id, None, &tp, thin_id, td_size).is_err());
+        assert!(ThinDev::new(&dm, &id, None, td_size, &tp, thin_id).is_err());
 
         // Setting up the just created thin dev succeeds.
-        assert!(ThinDev::setup(&dm, &id, None, &tp, thin_id, td_size).is_ok());
+        assert!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).is_ok());
 
         // Setting up the just created thin dev once more succeeds.
-        assert!(ThinDev::setup(&dm, &id, None, &tp, thin_id, td_size).is_ok());
+        assert!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).is_ok());
 
         // Teardown the thindev, then set it back up.
         td.teardown(&dm).unwrap();
-        let td = ThinDev::setup(&dm, &id, None, &tp, thin_id, td_size);
+        let td = ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id);
         assert!(td.is_ok());
 
         td.unwrap().destroy(&dm, &tp).unwrap();
@@ -356,7 +356,7 @@ mod tests {
         // Create new ThinDev as source for snapshot
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
         let thin_name = DmName::new("name").expect("is valid DM name");
-        let td = ThinDev::new(&dm, &thin_name, None, &tp, thin_id, td_size).unwrap();
+        let td = ThinDev::new(&dm, &thin_name, None, td_size, &tp, thin_id).unwrap();
 
         // Create a snapshot of the source
         let ss_id = ThinDevId::new_u64(1).expect("is below limit");
@@ -381,7 +381,7 @@ mod tests {
 
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
         let thin_name = DmName::new("name").expect("is valid DM name");
-        let td = ThinDev::new(&dm, &thin_name, None, &tp, thin_id, tp.size()).unwrap();
+        let td = ThinDev::new(&dm, &thin_name, None, tp.size(), &tp, thin_id).unwrap();
 
         Command::new("mkfs.xfs")
             .arg("-f")

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -41,7 +41,7 @@ impl fmt::Display for ThinDevTargetParams {
 impl FromStr for ThinDevTargetParams {
     type Err = DmError;
 
-    fn from_str(s: &str) -> Result<ThinDevTargetParams, DmError> {
+    fn from_str(s: &str) -> DmResult<ThinDevTargetParams> {
         let vals = s.split(' ').collect::<Vec<_>>();
         if vals.len() != 2 {
             let err_msg = format!("expected two values in params string \"{}\", found {}",

--- a/src/thindevid.rs
+++ b/src/thindevid.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fmt;
+use std::str::FromStr;
 
 use serde;
 
@@ -38,6 +39,19 @@ impl From<ThinDevId> for u32 {
 impl fmt::Display for ThinDevId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.value, f)
+    }
+}
+
+impl FromStr for ThinDevId {
+    type Err = DmError;
+
+    fn from_str(s: &str) -> Result<ThinDevId, DmError> {
+        s.parse::<u64>()
+            .map_err(|_| {
+                         DmError::Dm(ErrorEnum::Invalid,
+                                     format!("failed to parse value for thindev id \"{}\"", s))
+                     })
+            .map(ThinDevId::new_u64)?
     }
 }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -154,10 +154,10 @@ impl ThinPoolDev {
     pub fn new(dm: &DM,
                name: &DmName,
                uuid: Option<&DmUuid>,
-               data_block_size: Sectors,
-               low_water_mark: DataBlocks,
                meta: LinearDev,
-               data: LinearDev)
+               data: LinearDev,
+               data_block_size: Sectors,
+               low_water_mark: DataBlocks)
                -> DmResult<ThinPoolDev> {
         if device_exists(dm, name)? {
             let err_msg = format!("thinpooldev {} already exists", name);
@@ -200,10 +200,10 @@ impl ThinPoolDev {
     pub fn setup(dm: &DM,
                  name: &DmName,
                  uuid: Option<&DmUuid>,
-                 data_block_size: Sectors,
-                 low_water_mark: DataBlocks,
                  meta: LinearDev,
-                 data: LinearDev)
+                 data: LinearDev,
+                 data_block_size: Sectors,
+                 low_water_mark: DataBlocks)
                  -> DmResult<ThinPoolDev> {
         let table = ThinPoolDev::dm_table(&meta, &data, data_block_size, low_water_mark);
         let dev_info = device_setup(dm, name, uuid, &table)?;
@@ -400,10 +400,10 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
     ThinPoolDev::new(dm,
                      DmName::new("pool").expect("valid format"),
                      None,
-                     MIN_DATA_BLOCK_SIZE,
-                     DataBlocks(1),
                      meta,
-                     data)
+                     data,
+                     MIN_DATA_BLOCK_SIZE,
+                     DataBlocks(1))
             .unwrap()
 }
 
@@ -473,10 +473,10 @@ mod tests {
         assert!(match ThinPoolDev::new(&dm,
                                        DmName::new("pool").expect("valid format"),
                                        None,
-                                       MIN_DATA_BLOCK_SIZE / 2u64,
-                                       DataBlocks(1),
                                        meta,
-                                       data) {
+                                       data,
+                                       MIN_DATA_BLOCK_SIZE / 2u64,
+                                       DataBlocks(1)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 use super::device::devnode_to_devno;
 
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 struct ThinPoolDevTargetParams {
     pub metadata_dev: Device,
     pub data_dev: Device,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -303,7 +303,7 @@ impl ThinPoolDev {
                    1,
                    "Kernel must return 1 line from thin pool status");
 
-        let status_line = &status.get(0).expect("assertion above holds").params;
+        let status_line = &status.get(0).expect("assertion above holds").3;
         if status_line.starts_with("Fail") {
             return Ok(ThinPoolStatus::Fail);
         }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -25,7 +25,7 @@ use super::device::devnode_to_devno;
 
 
 #[derive(Debug, Eq, PartialEq)]
-struct ThinPoolDevTargetParams {
+pub struct ThinPoolDevTargetParams {
     pub metadata_dev: Device,
     pub data_dev: Device,
     pub data_block_size: Sectors,
@@ -139,7 +139,7 @@ pub struct ThinPoolDev {
     low_water_mark: DataBlocks,
 }
 
-impl DmDevice for ThinPoolDev {
+impl DmDevice<ThinPoolDevTargetParams> for ThinPoolDev {
     fn device(&self) -> Device {
         device!(self)
     }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -102,6 +102,10 @@ impl DmDevice for ThinPoolDev {
         self.meta_dev.teardown(dm)?;
         Ok(())
     }
+
+    fn uuid(&self) -> Option<&DmUuid> {
+        uuid!(self)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -77,7 +77,7 @@ impl fmt::Display for ThinPoolDevTargetParams {
 impl FromStr for ThinPoolDevTargetParams {
     type Err = DmError;
 
-    fn from_str(s: &str) -> Result<ThinPoolDevTargetParams, DmError> {
+    fn from_str(s: &str) -> DmResult<ThinPoolDevTargetParams> {
         let vals = s.split(' ').collect::<Vec<_>>();
 
         if vals.len() < 5 {

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -506,7 +506,7 @@ const MAX_RECOMMENDED_METADATA_SIZE: Sectors = Sectors(32 * IEC::Mi); // 16 GiB
 
 #[cfg(test)]
 pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
-    let dev = Device::from(devnode_to_devno(path).unwrap());
+    let dev = Device::from(devnode_to_devno(path).unwrap().unwrap());
     let meta = LinearDev::setup(dm,
                                 DmName::new("meta").expect("valid format"),
                                 None,
@@ -582,7 +582,7 @@ mod tests {
     /// Verify that data block size less than minimum results in a failure.
     fn test_low_data_block_size(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
-        let dev = Device::from(devnode_to_devno(paths[0]).unwrap());
+        let dev = Device::from(devnode_to_devno(paths[0]).unwrap().unwrap());
 
         let dm = DM::new().unwrap();
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -18,7 +18,7 @@ use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, Targe
 #[cfg(test)]
 use std::path::Path;
 #[cfg(test)]
-use super::loopbacked::devnode_to_devno;
+use super::device::devnode_to_devno;
 
 
 #[derive(Debug, PartialEq)]

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -563,6 +563,14 @@ mod tests {
             _ => assert!(false),
         }
 
+        let table = tp.table(&dm).unwrap();
+        assert_eq!(table.len(), 1);
+
+        let line = &table[0];
+        let params = &line.params;
+        assert_eq!(params.metadata_dev, tp.meta_dev().device());
+        assert_eq!(params.data_dev, tp.data_dev().device());
+
         tp.teardown(&dm).unwrap();
     }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -353,7 +353,7 @@ impl ThinPoolDev {
                 data: &LinearDev,
                 data_block_size: Sectors,
                 low_water_mark: DataBlocks)
-                -> Vec<TargetLine<String>> {
+                -> Vec<TargetLine<ThinPoolDevTargetParams>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: data.size(),
@@ -362,8 +362,7 @@ impl ThinPoolDev {
                                                       data.device(),
                                                       data_block_size,
                                                       low_water_mark,
-                                                      vec!["skip_block_zeroing".to_owned()])
-                         .to_string(),
+                                                      vec!["skip_block_zeroing".to_owned()]),
              }]
     }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -353,7 +353,7 @@ impl ThinPoolDev {
                 data: &LinearDev,
                 data_block_size: Sectors,
                 low_water_mark: DataBlocks)
-                -> Vec<TargetLine> {
+                -> Vec<TargetLine<String>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: data.size(),

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -380,7 +380,7 @@ impl ThinPoolDev {
                    1,
                    "Kernel must return 1 line from thin pool status");
 
-        let status_line = &status.get(0).expect("assertion above holds").3;
+        let status_line = &status.first().expect("assertion above holds").3;
         if status_line.starts_with("Fail") {
             return Ok(ThinPoolStatus::Fail);
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -426,9 +426,11 @@ str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
 /// The trait for properties of the params string of TargetType
 pub trait TargetParams: fmt::Debug + fmt::Display + Eq + FromStr + PartialEq {}
 
+impl TargetParams for String {}
+
 /// One line of a device mapper table.
 #[derive(Debug, PartialEq)]
-pub struct TargetLine {
+pub struct TargetLine<T: TargetParams> {
     /// The start of the segment
     pub start: Sectors,
     /// The length of the segment
@@ -436,7 +438,7 @@ pub struct TargetLine {
     /// The target type
     pub target_type: TargetTypeBuf,
     /// The target specific parameters
-    pub params: String,
+    pub params: T,
 }
 
 #[cfg(test)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,6 +21,7 @@ use std::fmt;
 use std::iter::Sum;
 use std::mem::transmute;
 use std::ops::{Deref, Div, Mul, Rem, Add};
+use std::str::FromStr;
 
 use serde;
 
@@ -423,7 +424,7 @@ const DM_TARGET_TYPE_LEN: usize = 16;
 str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
 
 /// The trait for properties of the params string of TargetType
-pub trait TargetParams: fmt::Debug + fmt::Display + PartialEq {}
+pub trait TargetParams: fmt::Debug + fmt::Display + FromStr + PartialEq {}
 
 /// One line of a device mapper table.
 #[derive(Debug, PartialEq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -422,6 +422,9 @@ const DM_TARGET_TYPE_LEN: usize = 16;
 
 str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
 
+/// The trait for properties of the params string of TargetType
+pub trait TargetParams: fmt::Debug + fmt::Display + PartialEq {}
+
 /// One line of a device mapper table.
 #[derive(Debug, PartialEq)]
 pub struct TargetLine {

--- a/src/types.rs
+++ b/src/types.rs
@@ -424,7 +424,7 @@ const DM_TARGET_TYPE_LEN: usize = 16;
 str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
 
 /// The trait for properties of the params string of TargetType
-pub trait TargetParams: fmt::Debug + fmt::Display + FromStr + PartialEq {}
+pub trait TargetParams: fmt::Debug + fmt::Display + Eq + FromStr + PartialEq {}
 
 /// One line of a device mapper table.
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This PR addresses the problem that we check equality of two devices by checking equivalence of tables, but that we do this by checking string equality of the string representing their device-specific parameters. This PR introduces a notion of equality embedded in a type called TargetParams and allows this notion of equality, implemented in the method ```equivalent_tables()``` to be modified for each type of device. It also introduces a modification to CacheDev's notion of equality to omit the replacement policy from its equivalence check. There are almost certainly other values stored in tables that should also be omitted in an equality check, but this PR leaves that for further work when a better understanding of the meaning and importance of these values has been gained.

This PR has various other useful effects.
* Devices in tables can be specified either by device node or by number using ```<major>:<minor>``` format. This PR abstracts over that difference.
* There are various arguments that can be specified in arbitrary order. This PR uses sets and maps to make the order irrelevant when performing a comparison.
* Changes the type of ```DM::table_status()```. This method can return either a target table or a status value, so a ```&[TargetLine]``` was a deceptive return type. Using a tuple instead. Change ```device_status``` method name to ```device_info``` for similar reason.
* Introduce a ```TargetParams``` type which handles display and parsing of TargetParams.
* Parameterize ```DmDevice``` on a ```TargetParams``` type.
* Abstracts displaying target params from choice of defaults. This means that later, when it may be found necessary to pass more arguments to ```new()``` or ```setup()``` methods, see #222, this will require virtually no additional work.
* Introduces parsing of target params.

Some cherry picks from #224.

Left for future work:
* Further refinement of ```equivalent_tables()``` methods for all devices.
* Investigation of using a dedicated type for each device's table and parameterizing DmDevice on that type.
* Improving ```status()``` method using a dedicated StatusLine and StatusParams type.
* Making ```new()``` and ```setup()``` methods more flexible, by passing more table arguments as parameter.

Resolves: #226.