### PR TITLE
Fix bug when parsing a device with 3 or more tables

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -641,10 +641,9 @@ impl DM {
         let mut targets = Vec::new();
         if !buf.is_empty() {
             let mut next_off = 0;
-            let mut result = &buf[..];
 
             for _ in 0..count {
-                result = &result[next_off..];
+                let result = &buf[next_off..];
                 let targ = unsafe {
                     (result.as_ptr() as *const dmi::Struct_dm_target_spec)
                         .as_ref()


### PR DESCRIPTION
targ.next (next_off) apparently counts from the start of the entire buffer,
not the end of the previous target entry! This only bites us when a device has 3
or more entries.

Signed-off-by: Andy Grover <agrover@redhat.com>