### PR TITLE
Do not use TargetLine in devicemapper core methods

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -12,9 +12,9 @@ use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DmFlags};
 use super::lineardev::LinearDev;
 use super::result::{DmResult, DmError, ErrorEnum};
-use super::shared::{DmDevice, device_create, device_exists, device_match, parse_device};
-use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetLine,
-                   TargetParams, TargetTypeBuf};
+use super::shared::{DmDevice, TargetLine, TargetParams, device_create, device_exists,
+                    device_match, parse_device};
+use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetTypeBuf};
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct CacheDevTargetParams {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,4 +118,4 @@ pub use thinpooldev::{ThinPoolUsage, ThinPoolDev, ThinPoolNoSpacePolicy, ThinPoo
 pub use thindev::{ThinDev, ThinDevWorkingStatus, ThinStatus};
 pub use thindevid::ThinDevId;
 pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, MetaBlocks,
-                Sectors, TargetLine, TargetType, TargetTypeBuf};
+                Sectors, TargetType, TargetTypeBuf};

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -11,9 +11,9 @@ use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DmFlags};
 use super::result::{DmResult, DmError, ErrorEnum};
 use super::segment::Segment;
-use super::shared::{DmDevice, device_create, device_exists, device_match, parse_device,
-                    table_reload};
-use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetParams, TargetTypeBuf};
+use super::shared::{DmDevice, TargetLine, TargetParams, device_create, device_exists,
+                    device_match, parse_device, table_reload};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetTypeBuf};
 
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -5,6 +5,7 @@
 /// A module to contain functionality shared among the various types of
 /// devices.
 
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -12,7 +13,27 @@ use super::device::{Device, devnode_to_devno};
 use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DmFlags};
 use super::result::{DmError, DmResult, ErrorEnum};
-use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetParams};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetTypeBuf};
+
+
+/// The trait for properties of the params string of TargetType
+pub trait TargetParams: fmt::Debug + fmt::Display + Eq + FromStr + PartialEq {}
+
+impl TargetParams for String {}
+
+/// One line of a device mapper table.
+#[derive(Debug, Eq, PartialEq)]
+pub struct TargetLine<T: TargetParams> {
+    /// The start of the segment
+    pub start: Sectors,
+    /// The length of the segment
+    pub length: Sectors,
+    /// The target type
+    pub target_type: TargetTypeBuf,
+    /// The target specific parameters
+    pub params: T,
+}
+
 
 /// A trait capturing some shared properties of DM devices.
 pub trait DmDevice<T: TargetParams> {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -76,14 +76,7 @@ pub fn device_create<T: TargetParams>(dm: &DM,
     let id = DevId::Name(name);
     let table = table
         .iter()
-        .map(|x| {
-                 TargetLine {
-                     start: x.start,
-                     length: x.length,
-                     target_type: x.target_type.clone(),
-                     params: x.params.to_string(),
-                 }
-             })
+        .map(|x| (x.start, x.length, x.target_type.clone(), x.params.to_string()))
         .collect::<Vec<_>>();
     let dev_info = match dm.table_load(&id, &table) {
         Err(e) => {
@@ -131,14 +124,7 @@ pub fn table_reload<T: TargetParams>(dm: &DM,
                                      -> DmResult<DeviceInfo> {
     let table = table
         .iter()
-        .map(|x| {
-                 TargetLine {
-                     start: x.start,
-                     length: x.length,
-                     target_type: x.target_type.clone(),
-                     params: x.params.to_string(),
-                 }
-             })
+        .map(|x| (x.start, x.length, x.target_type.clone(), x.params.to_string()))
         .collect::<Vec<_>>();
     let dev_info = dm.table_load(id, &table)?;
     dm.device_suspend(id, DmFlags::DM_SUSPEND)?;

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -10,11 +10,11 @@ use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DmFlags};
 use super::result::{DmError, DmResult, ErrorEnum};
-use super::shared::{DmDevice, device_create, device_exists, device_match, message, parse_device,
-                    table_reload};
+use super::shared::{DmDevice, TargetLine, TargetParams, device_create, device_exists,
+                    device_match, message, parse_device, table_reload};
 use super::thindevid::ThinDevId;
 use super::thinpooldev::ThinPoolDev;
-use super::types::{DevId, DmName, DmUuid, Sectors, TargetLine, TargetParams, TargetTypeBuf};
+use super::types::{DevId, DmName, DmUuid, Sectors, TargetTypeBuf};
 
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -13,10 +13,9 @@ use super::dm::{DM, DmFlags};
 use super::lineardev::LinearDev;
 use super::result::{DmResult, DmError, ErrorEnum};
 use super::segment::Segment;
-use super::shared::{DmDevice, device_create, device_exists, device_match, parse_device,
-                    table_reload};
-use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetLine,
-                   TargetParams, TargetTypeBuf};
+use super::shared::{DmDevice, TargetLine, TargetParams, device_create, device_exists,
+                    device_match, parse_device, table_reload};
+use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetTypeBuf};
 
 #[cfg(test)]
 use std::path::Path;

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,7 +21,6 @@ use std::fmt;
 use std::iter::Sum;
 use std::mem::transmute;
 use std::ops::{Deref, Div, Mul, Rem, Add};
-use std::str::FromStr;
 
 use serde;
 
@@ -423,23 +422,6 @@ const DM_TARGET_TYPE_LEN: usize = 16;
 
 str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
 
-/// The trait for properties of the params string of TargetType
-pub trait TargetParams: fmt::Debug + fmt::Display + Eq + FromStr + PartialEq {}
-
-impl TargetParams for String {}
-
-/// One line of a device mapper table.
-#[derive(Debug, PartialEq)]
-pub struct TargetLine<T: TargetParams> {
-    /// The start of the segment
-    pub start: Sectors,
-    /// The length of the segment
-    pub length: Sectors,
-    /// The target type
-    pub target_type: TargetTypeBuf,
-    /// The target specific parameters
-    pub params: T,
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This takes the use of TargetLine and TargetParams, in terms of which TargetLine is defined out of core methods and confines its use to the outer layer.

TargetLine can only be used in one place in the core, ```DM::table_load```, and the only benefit to this use is using names instead of indices to access values. One could go further, and parameterize ```DM::table_load``` on the TargetParams, but then you get as many copies of this method as there are types of device, thin, thinpool, etc., all for the benefit of calling ```to_string()``` in exactly one place in the method. I'm pretty sure that is not enough benefit.