### PR TITLE
Be more explicit about default values in tables

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -404,7 +404,7 @@ impl CacheDev {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let table = CacheDev::dm_table(&meta, &cache, &origin, cache_block_size);
+        let table = CacheDev::gen_default_table(&meta, &cache, &origin, cache_block_size);
         let dev_info = device_create(dm, name, uuid, &table)?;
 
         Ok(CacheDev {
@@ -425,7 +425,7 @@ impl CacheDev {
                  origin: LinearDev,
                  cache_block_size: Sectors)
                  -> DmResult<CacheDev> {
-        let table = CacheDev::dm_table(&meta, &origin, &cache, cache_block_size);
+        let table = CacheDev::gen_default_table(&meta, &origin, &cache, cache_block_size);
         let dev = if device_exists(dm, name)? {
             let dev_info = dm.device_info(&DevId::Name(name))?;
             let dev = CacheDev {
@@ -459,11 +459,12 @@ impl CacheDev {
     /// <#num feature args (0)> <replacement policy (default)>
     /// <#num policy args (0)>
     /// There is exactly one entry in the table.
-    fn dm_table(meta: &LinearDev,
-                cache: &LinearDev,
-                origin: &LinearDev,
-                cache_block_size: Sectors)
-                -> Vec<TargetLine<CacheDevTargetParams>> {
+    /// Various defaults are hard coded in the method.
+    fn gen_default_table(meta: &LinearDev,
+                         cache: &LinearDev,
+                         origin: &LinearDev,
+                         cache_block_size: Sectors)
+                         -> Vec<TargetLine<CacheDevTargetParams>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: origin.size(),

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -132,7 +132,7 @@ impl LinearDev {
                                    "linear device must have at least one segment".into()));
         }
 
-        let table = LinearDev::gen_default_table(segments);
+        let table = LinearDev::gen_table(segments);
         let dev = if device_exists(dm, name)? {
             let dev_info = dm.device_info(&DevId::Name(name))?;
             let dev = LinearDev {
@@ -161,8 +161,9 @@ impl LinearDev {
     /// <logical start offset> <length> "linear" <linear-specific string>
     /// where the linear-specific string has the format:
     /// <maj:min> <physical start offset>
-    /// Various defaults are hard coded in the method.
-    fn gen_default_table(segments: &[Segment]) -> Vec<TargetLine<LinearDevTargetParams>> {
+    /// The table has no configuration parameters, so the segments argument
+    /// fully specifies the table.
+    fn gen_table(segments: &[Segment]) -> Vec<TargetLine<LinearDevTargetParams>> {
         assert_ne!(segments.len(), 0);
 
         let mut table = Vec::new();
@@ -193,7 +194,7 @@ impl LinearDev {
                                    "linear device must have at least one segment".into()));
         }
 
-        let table = LinearDev::gen_default_table(segments);
+        let table = LinearDev::gen_table(segments);
         table_reload(dm, &DevId::Name(self.name()), &table)?;
         self.segments = segments.to_vec();
         Ok(())
@@ -324,8 +325,7 @@ mod tests {
                 .unwrap();
 
         let table = ld.table(&dm).unwrap();
-        assert!(LinearDev::equivalent_tables(&table, &LinearDev::gen_default_table(&segments))
-                    .unwrap());
+        assert!(LinearDev::equivalent_tables(&table, &LinearDev::gen_table(&segments)).unwrap());
 
         ld.teardown(&dm).unwrap();
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -132,7 +132,7 @@ impl LinearDev {
                                    "linear device must have at least one segment".into()));
         }
 
-        let table = LinearDev::dm_table(segments);
+        let table = LinearDev::gen_default_table(segments);
         let dev = if device_exists(dm, name)? {
             let dev_info = dm.device_info(&DevId::Name(name))?;
             let dev = LinearDev {
@@ -161,7 +161,8 @@ impl LinearDev {
     /// <logical start offset> <length> "linear" <linear-specific string>
     /// where the linear-specific string has the format:
     /// <maj:min> <physical start offset>
-    fn dm_table(segments: &[Segment]) -> Vec<TargetLine<LinearDevTargetParams>> {
+    /// Various defaults are hard coded in the method.
+    fn gen_default_table(segments: &[Segment]) -> Vec<TargetLine<LinearDevTargetParams>> {
         assert_ne!(segments.len(), 0);
 
         let mut table = Vec::new();
@@ -192,7 +193,7 @@ impl LinearDev {
                                    "linear device must have at least one segment".into()));
         }
 
-        let table = LinearDev::dm_table(segments);
+        let table = LinearDev::gen_default_table(segments);
         table_reload(dm, &DevId::Name(self.name()), &table)?;
         self.segments = segments.to_vec();
         Ok(())
@@ -323,7 +324,8 @@ mod tests {
                 .unwrap();
 
         let table = ld.table(&dm).unwrap();
-        assert!(LinearDev::equivalent_tables(&table, &LinearDev::dm_table(&segments)).unwrap());
+        assert!(LinearDev::equivalent_tables(&table, &LinearDev::gen_default_table(&segments))
+                    .unwrap());
 
         ld.teardown(&dm).unwrap();
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -83,6 +83,15 @@ impl DmDevice<LinearDevTargetParams> for LinearDev {
         devnode!(self)
     }
 
+    // Since linear devices have no default or configuration parameters,
+    // and the ordering of segments matters, two linear devices represent
+    // the same linear device only if their tables match exactly.
+    fn equivalent_tables(left: &[TargetLine<LinearDevTargetParams>],
+                         right: &[TargetLine<LinearDevTargetParams>])
+                         -> DmResult<bool> {
+        Ok(left == right)
+    }
+
     fn name(&self) -> &DmName {
         name!(self)
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -44,9 +44,7 @@ pub trait DmDevice<T: TargetParams> {
     fn device(&self) -> Device;
 
     /// Check if tables indicate an equivalent device.
-    fn equivalent_tables(left: &[TargetLine<T>], right: &[TargetLine<T>]) -> DmResult<bool> {
-        Ok(left == right)
-    }
+    fn equivalent_tables(left: &[TargetLine<T>], right: &[TargetLine<T>]) -> DmResult<bool>;
 
     /// The device's name.
     fn name(&self) -> &DmName;

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -75,6 +75,14 @@ impl DmDevice<ThinDevTargetParams> for ThinDev {
         devnode!(self)
     }
 
+    // This method is incomplete. It is expected that it will be refined so
+    // that it will return true in more cases, i.e., to be less stringent.
+    fn equivalent_tables(left: &[TargetLine<ThinDevTargetParams>],
+                         right: &[TargetLine<ThinDevTargetParams>])
+                         -> DmResult<bool> {
+        Ok(left == right)
+    }
+
     fn name(&self) -> &DmName {
         name!(self)
     }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -146,7 +146,7 @@ impl ThinDev {
         }
 
         let thin_pool_device = thin_pool.device();
-        let table = ThinDev::dm_table(length, thin_pool_device, thin_id);
+        let table = ThinDev::gen_default_table(length, thin_pool_device, thin_id);
         let dev_info = device_create(dm, name, uuid, &table)?;
 
         Ok(ThinDev {
@@ -175,7 +175,7 @@ impl ThinDev {
                  -> DmResult<ThinDev> {
 
         let thin_pool_device = thin_pool.device();
-        let table = ThinDev::dm_table(length, thin_pool_device, thin_id);
+        let table = ThinDev::gen_default_table(length, thin_pool_device, thin_id);
         let dev = if device_exists(dm, name)? {
             let dev_info = dm.device_info(&DevId::Name(name))?;
             let dev = ThinDev {
@@ -218,9 +218,9 @@ impl ThinDev {
         let dev_info = Box::new(device_create(dm,
                                               snapshot_name,
                                               None,
-                                              &ThinDev::dm_table(self.size(),
-                                                                 thin_pool.device(),
-                                                                 snapshot_thin_id))?);
+                                              &ThinDev::gen_default_table(self.size(),
+                                                                          thin_pool.device(),
+                                                                          snapshot_thin_id))?);
         Ok(ThinDev {
                dev_info: dev_info,
                thin_id: snapshot_thin_id,
@@ -235,10 +235,11 @@ impl ThinDev {
     /// where the thin device specific string has the format:
     /// <thinpool maj:min> <thin_id>
     /// There is exactly one entry in the table.
-    fn dm_table(length: Sectors,
-                thin_pool: Device,
-                thin_id: ThinDevId)
-                -> Vec<TargetLine<ThinDevTargetParams>> {
+    /// Various defaults are hard coded in the method.
+    fn gen_default_table(length: Sectors,
+                         thin_pool: Device,
+                         thin_id: ThinDevId)
+                         -> Vec<TargetLine<ThinDevTargetParams>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: length,
@@ -291,7 +292,7 @@ impl ThinDev {
         let new_size = self.size + sectors;
         table_reload(dm,
                      &DevId::Name(self.name()),
-                     &ThinDev::dm_table(new_size, self.thinpool, self.thin_id))?;
+                     &ThinDev::gen_default_table(new_size, self.thinpool, self.thin_id))?;
         self.size = new_size;
         Ok(())
     }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -147,6 +147,14 @@ impl DmDevice<ThinPoolDevTargetParams> for ThinPoolDev {
         devnode!(self)
     }
 
+    // This method is incomplete. It is expected that it will be refined so
+    // that it will return true in more cases, i.e., to be less stringent.
+    fn equivalent_tables(left: &[TargetLine<ThinPoolDevTargetParams>],
+                         right: &[TargetLine<ThinPoolDevTargetParams>])
+                         -> DmResult<bool> {
+        Ok(left == right)
+    }
+
     fn name(&self) -> &DmName {
         name!(self)
     }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -276,7 +276,7 @@ impl ThinPoolDev {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let table = ThinPoolDev::dm_table(&meta, &data, data_block_size, low_water_mark);
+        let table = ThinPoolDev::gen_default_table(&meta, &data, data_block_size, low_water_mark);
         let dev_info = device_create(dm, name, uuid, &table)?;
 
         Ok(ThinPoolDev {
@@ -317,7 +317,7 @@ impl ThinPoolDev {
                  data_block_size: Sectors,
                  low_water_mark: DataBlocks)
                  -> DmResult<ThinPoolDev> {
-        let table = ThinPoolDev::dm_table(&meta, &data, data_block_size, low_water_mark);
+        let table = ThinPoolDev::gen_default_table(&meta, &data, data_block_size, low_water_mark);
         let dev = if device_exists(dm, name)? {
             let dev_info = dm.device_info(&DevId::Name(name))?;
             let dev = ThinPoolDev {
@@ -348,11 +348,12 @@ impl ThinPoolDev {
     /// where the thin-pool-specific string has the format:
     /// <meta maj:min> <data maj:min> <block size> <low water mark>
     /// There is exactly one entry in the table.
-    fn dm_table(meta: &LinearDev,
-                data: &LinearDev,
-                data_block_size: Sectors,
-                low_water_mark: DataBlocks)
-                -> Vec<TargetLine<ThinPoolDevTargetParams>> {
+    /// Various defaults are hard coded in the method.
+    fn gen_default_table(meta: &LinearDev,
+                         data: &LinearDev,
+                         data_block_size: Sectors,
+                         low_water_mark: DataBlocks)
+                         -> Vec<TargetLine<ThinPoolDevTargetParams>> {
         vec![TargetLine {
                  start: Sectors::default(),
                  length: data.size(),
@@ -464,10 +465,10 @@ impl ThinPoolDev {
         self.meta_dev.set_segments(dm, segments)?;
         table_reload(dm,
                      &DevId::Name(self.name()),
-                     &ThinPoolDev::dm_table(&self.meta_dev,
-                                            &self.data_dev,
-                                            self.data_block_size,
-                                            self.low_water_mark))?;
+                     &ThinPoolDev::gen_default_table(&self.meta_dev,
+                                                     &self.data_dev,
+                                                     self.data_block_size,
+                                                     self.low_water_mark))?;
         Ok(())
     }
 
@@ -480,10 +481,10 @@ impl ThinPoolDev {
         self.data_dev.set_segments(dm, segments)?;
         table_reload(dm,
                      &DevId::Name(self.name()),
-                     &ThinPoolDev::dm_table(&self.meta_dev,
-                                            &self.data_dev,
-                                            self.data_block_size,
-                                            self.low_water_mark))?;
+                     &ThinPoolDev::gen_default_table(&self.meta_dev,
+                                                     &self.data_dev,
+                                                     self.data_block_size,
+                                                     self.low_water_mark))?;
         Ok(())
     }
 }


### PR DESCRIPTION
This changes the name of internal ```dm_table``` function, and implements ```equivalent_tables``` for all devices.

Resolves: #232.