### PR TITLE
Make a special make target for fmt test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache: cargo
 matrix:
     include:
         - rust: stable
-          env: TASK=fmt
+          env: TASK=travis_fmt
         - rust: stable
           env: TASK=build
         - rust: stable

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ tree: ${HOME}/.cargo/bin/cargo-tree
 	PATH=${HOME}/.cargo/bin:${PATH} cargo tree
 
 fmt: ${HOME}/.cargo/bin/cargo-fmt
-	PATH=${HOME}/.cargo/bin:${PATH} cargo fmt -- --write-mode=diff
+	PATH=${HOME}/.cargo/bin:${PATH} cargo fmt
+
+travis_fmt:
+	rustup run stable cargo install rustfmt --vers 0.8.3 --force
+	cargo fmt -- --write-mode=diff
 
 build:
 	RUSTFLAGS='-D warnings' cargo build


### PR DESCRIPTION
Use rustup to set the version of rustfmt so that it is recognized.
Modify the existing fmt target so that it just reformats text inline.
This seems the handier thing for regular command-line users.

Signed-off-by: mulhern <amulhern@redhat.com>