### PR TITLE
Update nix to v0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["Linux", "device", "mapper", "libdm", "storage"]
 license = "MPL-2.0"
 
 [dependencies]
-libc = "0.2.31"
-nix = "0.9"
+libc = "0.2.36"
+nix = "0.10"
 bitflags = "1"
 newtype_derive = "0.1"
 macro-attr = "0.2.0"

--- a/src/device.rs
+++ b/src/device.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use libc::{dev_t, major, makedev, minor};
-use nix::sys::stat::{S_IFBLK, S_IFMT};
+use nix::sys::stat::SFlag;
 
 use super::errors::{Error, ErrorKind};
 use super::result::{DmError, DmResult};
@@ -102,7 +102,7 @@ impl Device {
 pub fn devnode_to_devno(path: &Path) -> DmResult<Option<u64>> {
     match path.metadata() {
         Ok(metadata) => {
-            Ok(if metadata.st_mode() & S_IFMT.bits() == S_IFBLK.bits() {
+            Ok(if metadata.st_mode() & SFlag::S_IFMT.bits() == SFlag::S_IFBLK.bits() {
                    Some(metadata.st_rdev())
                } else {
                    None

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -366,7 +366,7 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
 
-    use nix::mount::{MNT_DETACH, MsFlags, mount, umount2};
+    use nix::mount::{MntFlags, MsFlags, mount, umount2};
     use tempdir::TempDir;
     use uuid::Uuid;
 
@@ -580,7 +580,7 @@ mod tests {
                      "data")
                     .unwrap();
         }
-        umount2(tmp_dir.path(), MNT_DETACH).unwrap();
+        umount2(tmp_dir.path(), MntFlags::MNT_DETACH).unwrap();
 
         let data_usage_2 = match tp.status(&dm).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,


### PR DESCRIPTION
This requires an explicitly higher version of backtrace and of libc.

Signed-off-by: mulhern <amulhern@redhat.com>

Resolves: #263.