### PR TITLE
Export META_BLOCK_SIZE in public interface of devicemapper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,5 +143,5 @@ pub use thinpooldev::{ThinPoolUsage, ThinPoolDev, ThinPoolNoSpacePolicy, ThinPoo
                       ThinPoolStatusSummary, ThinPoolWorkingStatus};
 pub use thindev::{ThinDev, ThinDevWorkingStatus, ThinStatus};
 pub use thindevid::ThinDevId;
-pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, MetaBlocks,
-                Sectors, TargetType, TargetTypeBuf};
+pub use types::{Bytes, DataBlocks, DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf, META_BLOCK_SIZE,
+                MetaBlocks, Sectors, TargetType, TargetTypeBuf};

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,7 +32,7 @@ use super::result::{DmError, DmResult};
 /// a DM meta device may store cache device or thinpool device metadata
 /// defined in drivers/md/persistent-data/dm-space-map-metadata.h as
 /// DM_SM_METADATA_BLOCK_SIZE.
-const META_BLOCK_SIZE: Sectors = Sectors(8);
+pub const META_BLOCK_SIZE: Sectors = Sectors(8);
 
 /// The maximum size of a metadata device.
 /// defined in drivers/md/persistent-data/dm-space-map-metadata.h as


### PR DESCRIPTION
It's a useful thing to compare various status values against.

Signed-off-by: mulhern <amulhern@redhat.com>