### PR TITLE
Add suspend() and resume() methods to DmDevice

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -865,14 +865,40 @@ mod tests {
         let extra_length = MIN_CACHE_BLOCK_SIZE;
         let cache_params = LinearTargetParams::new(dev3, Sectors(0));
         let current_length = cache.cache_dev.size();
+
+        match cache.status(&dm).unwrap() {
+            CacheDevStatus::Working(ref status) => {
+                let usage = &status.usage;
+                assert_eq!(*usage.total_cache * usage.cache_block_size, current_length);
+            }
+            CacheDevStatus::Fail => panic!("cache should not have failed"),
+        }
+
         cache_table.push(TargetLine::new(current_length,
                                          extra_length,
                                          LinearDevTargetParams::Linear(cache_params)));
         assert!(cache.set_cache_table(&dm, cache_table.clone()).is_ok());
 
+        match cache.status(&dm).unwrap() {
+            CacheDevStatus::Working(ref status) => {
+                let usage = &status.usage;
+                assert_eq!(*usage.total_cache * usage.cache_block_size,
+                           current_length + extra_length);
+            }
+            CacheDevStatus::Fail => panic!("cache should not have failed"),
+        }
+
         cache_table.pop();
 
         assert!(cache.set_cache_table(&dm, cache_table).is_ok());
+
+        match cache.status(&dm).unwrap() {
+            CacheDevStatus::Working(ref status) => {
+                let usage = &status.usage;
+                assert_eq!(*usage.total_cache * usage.cache_block_size, current_length);
+            }
+            CacheDevStatus::Fail => panic!("cache should not have failed"),
+        }
 
         cache.teardown(&dm).unwrap();
     }
@@ -880,6 +906,41 @@ mod tests {
     #[test]
     fn loop_test_cache_size_change() {
         test_with_spec(3, test_cache_size_change);
+    }
+
+    /// Test changing the size of the origin device.
+    /// Verify that once changed, the new size is reflected in origin device
+    /// and cache device.
+    fn test_origin_size_change(paths: &[&Path]) {
+        assert!(paths.len() >= 3);
+
+        let dm = DM::new().unwrap();
+        let mut cache = minimal_cachedev(&dm, paths);
+
+        let mut origin_table = cache.origin_dev.table().table.clone();
+        let origin_size = cache.origin_dev.size();
+
+        let dev3_size = blkdev_size(&OpenOptions::new().read(true).open(paths[2]).unwrap())
+            .sectors();
+        let dev3 = Device::from(devnode_to_devno(paths[2]).unwrap().unwrap());
+        let origin_params = LinearTargetParams::new(dev3, Sectors(0));
+
+        origin_table.push(TargetLine::new(origin_size,
+                                          dev3_size,
+                                          LinearDevTargetParams::Linear(origin_params)));
+
+        cache.set_origin_table(&dm, origin_table).unwrap();
+
+        let origin_size = origin_size + dev3_size;
+        assert_eq!(cache.origin_dev.size(), origin_size);
+        assert_eq!(cache.size(), origin_size);
+
+        cache.teardown(&dm).unwrap();
+    }
+
+    #[test]
+    fn loop_test_origin_size_change() {
+        test_with_spec(3, test_origin_size_change);
     }
 
     /// Verify that suspending and resuming the cache doesn't fail.

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -866,4 +866,20 @@ mod tests {
     fn loop_test_cache_size_change() {
         test_with_spec(3, test_cache_size_change);
     }
+
+    /// Verify that suspending and resuming the cache doesn't fail.
+    fn test_suspend(paths: &[&Path]) {
+        assert!(paths.len() >= 2);
+
+        let dm = DM::new().unwrap();
+        let mut cache = minimal_cachedev(&dm, paths);
+        cache.suspend(&dm).unwrap();
+        cache.resume(&dm).unwrap();
+        cache.teardown(&dm).unwrap();
+    }
+
+    #[test]
+    fn loop_test_suspend() {
+        test_with_spec(2, test_suspend);
+    }
 }

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -531,6 +531,12 @@ impl CacheDev {
         // what the test is doing.
         self.suspend(dm)?;
         self.cache_dev.set_table(dm, table)?;
+
+        // Reload the table, even though it is unchanged. Otherwise, we
+        // suffer from whacky smq bug documented in the following PR:
+        // https://github.com/stratis-storage/devicemapper-rs/pull/279.
+        self.table_load(dm, self.table())?;
+
         self.resume(dm)?;
 
         Ok(())

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -13,7 +13,7 @@ use super::dm::{DM, DmFlags};
 use super::lineardev::{LinearDev, LinearDevTargetParams};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, TargetLine, TargetParams, TargetTable, device_create, device_exists,
-                    device_match, parse_device, table_reload};
+                    device_match, parse_device};
 use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetTypeBuf};
 
 
@@ -504,13 +504,11 @@ impl CacheDev {
         // what the test is doing.
         self.suspend(dm)?;
 
-        self.origin_dev.suspend(dm)?;
         self.origin_dev.set_table(dm, table)?;
-        self.origin_dev.resume(dm)?;
 
         let mut table = self.table.clone();
         table.table.length = self.origin_dev.size();
-        table_reload(dm, &DevId::Name(self.name()), &table)?;
+        self.table_load(dm, &table)?;
 
         self.resume(dm)?;
 
@@ -532,11 +530,7 @@ impl CacheDev {
         // cache_stack.rb. This looks funky, but it does seem to be exactly
         // what the test is doing.
         self.suspend(dm)?;
-
-        self.cache_dev.suspend(dm)?;
         self.cache_dev.set_table(dm, table)?;
-        self.cache_dev.resume(dm)?;
-
         self.resume(dm)?;
 
         Ok(())

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -12,7 +12,7 @@ use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DmFlags};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, TargetLine, TargetParams, TargetTable, device_create, device_exists,
-                    device_match, parse_device, table_reload};
+                    device_match, parse_device};
 use super::types::{DevId, DmName, DmUuid, Sectors, TargetTypeBuf};
 
 
@@ -460,7 +460,9 @@ impl LinearDev {
                      table: Vec<TargetLine<LinearDevTargetParams>>)
                      -> DmResult<()> {
         let table = LinearDevTargetTable::new(table);
-        table_reload(dm, &DevId::Name(self.name()), &table)?;
+        self.suspend(dm)?;
+        self.table_load(dm, &table)?;
+        self.resume(dm)?;
         self.table = table;
         Ok(())
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -684,6 +684,25 @@ mod tests {
         ld.teardown(&dm).unwrap();
     }
 
+    /// Verify that suspending and immediately resuming doesn't fail.
+    fn test_suspend(paths: &[&Path]) -> () {
+        assert!(paths.len() >= 1);
+
+        let dm = DM::new().unwrap();
+        let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
+        let params = LinearTargetParams::new(dev, Sectors(0));
+        let table = vec![TargetLine::new(Sectors(0),
+                                         Sectors(1),
+                                         LinearDevTargetParams::Linear(params))];
+        let mut ld = LinearDev::setup(&dm, DmName::new("name").expect("valid format"), None, table)
+            .unwrap();
+
+        ld.suspend(&dm).unwrap();
+        ld.resume(&dm).unwrap();
+
+        ld.teardown(&dm).unwrap();
+    }
+
     #[test]
     fn loop_test_duplicate_segments() {
         test_with_spec(1, test_duplicate_segments);
@@ -722,5 +741,10 @@ mod tests {
     #[test]
     fn loop_test_several_segments() {
         test_with_spec(1, test_several_segments);
+    }
+
+    #[test]
+    fn loop_test_suspend() {
+        test_with_spec(1, test_suspend);
     }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -96,6 +96,12 @@ pub trait DmDevice<T: TargetTable> {
     /// What the device thinks its table is.
     fn table(&self) -> &T;
 
+    /// Load a table
+    fn table_load(&self, dm: &DM, table: &T) -> DmResult<()> {
+        dm.table_load(&DevId::Name(self.name()), &table.to_raw_table())?;
+        Ok(())
+    }
+
     /// Erase the kernel's memory of this device.
     fn teardown(self, dm: &DM) -> DmResult<()>;
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -78,8 +78,20 @@ pub trait DmDevice<T: TargetTable> {
     /// The device's name.
     fn name(&self) -> &DmName;
 
+    /// Resume I/O on the device.
+    fn resume(&mut self, dm: &DM) -> DmResult<()> {
+        dm.device_suspend(&DevId::Name(self.name()), DmFlags::empty())?;
+        Ok(())
+    }
+
     /// The number of sectors available for user data.
     fn size(&self) -> Sectors;
+
+    /// Suspend I/O on the device.
+    fn suspend(&mut self, dm: &DM) -> DmResult<()> {
+        dm.device_suspend(&DevId::Name(self.name()), DmFlags::DM_SUSPEND)?;
+        Ok(())
+    }
 
     /// What the device thinks its table is.
     fn table(&self) -> &T;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -162,14 +162,6 @@ pub fn device_match<T: TargetTable, D: DmDevice<T>>(dm: &DM,
     Ok(())
 }
 
-/// Reload the table for a device
-pub fn table_reload<T: TargetTable>(dm: &DM, id: &DevId, table: &T) -> DmResult<DeviceInfo> {
-    let dev_info = dm.table_load(id, &table.to_raw_table())?;
-    dm.device_suspend(id, DmFlags::DM_SUSPEND)?;
-    dm.device_suspend(id, DmFlags::empty())?;
-    Ok(dev_info)
-}
-
 /// Check if a device of the given name exists.
 pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
     // TODO: Why do we have to call .as_ref() here instead of relying on deref

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -11,7 +11,7 @@ use super::deviceinfo::DeviceInfo;
 use super::dm::{DM, DmFlags};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, TargetLine, TargetParams, TargetTable, device_create, device_exists,
-                    device_match, message, parse_device, table_reload};
+                    device_match, message, parse_device};
 use super::thindevid::ThinDevId;
 use super::thinpooldev::ThinPoolDev;
 use super::types::{DevId, DmName, DmUuid, Sectors, TargetTypeBuf};
@@ -344,7 +344,11 @@ impl ThinDev {
     pub fn extend(&mut self, dm: &DM, extend_amt: Sectors) -> DmResult<()> {
         let mut table = self.table.clone();
         table.table.length = self.table.table.length + extend_amt;
-        table_reload(dm, &DevId::Name(self.name()), &table)?;
+
+        self.suspend(dm)?;
+        self.table_load(dm, &table)?;
+        self.resume(dm)?;
+
         self.table = table;
         Ok(())
     }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -692,4 +692,20 @@ mod tests {
     fn loop_test_low_data_block_size() {
         test_with_spec(1, test_low_data_block_size);
     }
+
+    /// Just test that suspending and resuming a thinpool has no errors.
+    fn test_suspend(paths: &[&Path]) -> () {
+        assert!(paths.len() >= 1);
+
+        let dm = DM::new().unwrap();
+        let mut tp = minimal_thinpool(&dm, paths[0]);
+        tp.suspend(&dm).unwrap();
+        tp.resume(&dm).unwrap();
+        tp.teardown(&dm).unwrap();
+    }
+
+    #[test]
+    fn loop_test_suspend() {
+        test_with_spec(1, test_suspend);
+    }
 }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -705,6 +705,75 @@ mod tests {
         test_with_spec(1, test_low_data_block_size);
     }
 
+    /// Verify that setting the data table does not fail and results in
+    /// the correct size data device.
+    fn test_set_data(paths: &[&Path]) -> () {
+        assert!(paths.len() > 1);
+
+        let dm = DM::new().unwrap();
+        let mut tp = minimal_thinpool(&dm, paths[0]);
+
+        let mut data_table = tp.data_dev.table().table.clone();
+        let data_size = tp.data_dev.size();
+
+        let dev2 = Device::from(devnode_to_devno(paths[1]).unwrap().unwrap());
+        let data_params = LinearTargetParams::new(dev2, Sectors(0));
+        data_table.push(TargetLine::new(data_size,
+                                        data_size,
+                                        LinearDevTargetParams::Linear(data_params)));
+        tp.set_data_table(&dm, data_table).unwrap();
+
+        match tp.status(&dm).unwrap() {
+            ThinPoolStatus::Working(ref status) => {
+                let usage = &status.usage;
+                assert_eq!(*usage.total_data * tp.table().table.params.data_block_size,
+                           2u8 * data_size);
+            }
+            ThinPoolStatus::Fail => panic!("thin pool should not have failed"),
+        }
+
+        tp.teardown(&dm).unwrap();
+    }
+
+    #[test]
+    fn loop_test_set_data() {
+        test_with_spec(2, test_set_data);
+    }
+
+    /// Verify that setting the meta table does not fail and results in
+    /// the correct size meta device.
+    fn test_set_meta(paths: &[&Path]) -> () {
+        assert!(paths.len() > 1);
+
+        let dm = DM::new().unwrap();
+        let mut tp = minimal_thinpool(&dm, paths[0]);
+
+        let mut meta_table = tp.meta_dev.table().table.clone();
+        let meta_size = tp.meta_dev.size();
+
+        let dev2 = Device::from(devnode_to_devno(paths[1]).unwrap().unwrap());
+        let meta_params = LinearTargetParams::new(dev2, Sectors(0));
+        meta_table.push(TargetLine::new(meta_size,
+                                        meta_size,
+                                        LinearDevTargetParams::Linear(meta_params)));
+        tp.set_meta_table(&dm, meta_table).unwrap();
+
+        match tp.status(&dm).unwrap() {
+            ThinPoolStatus::Working(ref status) => {
+                let usage = &status.usage;
+                assert_eq!(usage.total_meta.sectors(), 2u8 * meta_size);
+            }
+            ThinPoolStatus::Fail => panic!("thin pool should not have failed"),
+        }
+
+        tp.teardown(&dm).unwrap();
+    }
+
+    #[test]
+    fn loop_test_set_meta() {
+        test_with_spec(2, test_set_meta);
+    }
+
     /// Just test that suspending and resuming a thinpool has no errors.
     fn test_suspend(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);


### PR DESCRIPTION
Rewrite methods that set tables to use these methods in what seems like the appropriate manner.