### PR TITLE
Add method to suspend a DM device with DM_NOFLUSH

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -94,6 +94,13 @@ pub trait DmDevice<T: TargetTable> {
         Ok(())
     }
 
+    /// Suspend I/O on the device without flushing.
+    fn suspend_noflush(&mut self, dm: &DM) -> DmResult<()> {
+        dm.device_suspend(&DevId::Name(self.name()),
+                            DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH)?;
+        Ok(())
+    }
+
     /// What the device thinks its table is.
     fn table(&self) -> &T;
 


### PR DESCRIPTION
The DM_NOFLUSH option is required when expanding the meta or data devices for a thin-pool.