### PR TITLE
Set event_nr in IOCTL hdr

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -30,6 +30,10 @@ const DM_VERSION_MINOR: u32 = 30;
 /// Patch level
 const DM_VERSION_PATCHLEVEL: u32 = 0;
 
+// See https://sourceware.org/git/?p=lvm2.git;a=blob;f=libdm/libdevmapper.h#l3708
+// Note: flag is only upper 16 bits.
+const DM_UDEV_PRIMARY_SOURCE_FLAG: u16 = 0x0040;
+
 /// Start with a large buffer to make BUFFER_FULL rare. Libdm does this too.
 const MIN_BUF_SIZE: usize = 16 * 1024;
 
@@ -58,6 +62,7 @@ impl DM {
         hdr.version[2] = DM_VERSION_PATCHLEVEL;
 
         hdr.flags = flags.bits();
+        hdr.event_nr = (DM_UDEV_PRIMARY_SOURCE_FLAG as u32) << 16;
 
         hdr.data_start = size_of::<dmi::Struct_dm_ioctl>() as u32;
     }


### PR DESCRIPTION
From guidance given to us by Peter Rajnoha, we need to set the upper 16 bits
of event_nr to 0x0040 (DM_UDEV_PRIMARY_SOURCE_FLAG) to get some good default
behavior from the dm-* udev rule files.  This and the information stated in
lvm2 commit 942d6ef29ff0e8ae5f76ca50ed7570ae8f7c5a66, it appears that this
flag should always be set.

Testing shows that we are getting udev db entries which allow us to be usable
with this flag set.

Signed-off-by: Tony Asleson <tasleson@redhat.com>