### PR TITLE
Clean up between unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ nix = "0.10"
 bitflags = "1"
 newtype_derive = "0.1"
 macro-attr = "0.2.0"
+mnt = "0.3.1"
 serde = "1"
 clippy = {version = "0", optional = true}
 error-chain = "0.11"

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -715,6 +715,8 @@ use super::device::devnode_to_devno;
 use super::lineardev::LinearTargetParams;
 #[cfg(test)]
 use super::loopbacked::blkdev_size;
+#[cfg(test)]
+use super::test_lib::test_name;
 
 // Specified in kernel docs
 /// The minimum size recommended in the docs for a cache block.
@@ -731,7 +733,7 @@ pub fn minimal_cachedev(dm: &DM, paths: &[&Path]) -> CacheDev {
     assert!(paths.len() >= 2);
     let dev1 = Device::from(devnode_to_devno(paths[0]).unwrap().unwrap());
 
-    let meta_name = DmName::new("cache-meta").expect("valid format");
+    let meta_name = test_name("cache-meta").expect("valid format");
 
     // Minimum recommended metadata size for thinpool
     let meta_length = Sectors(4 * IEC::Ki);
@@ -739,29 +741,29 @@ pub fn minimal_cachedev(dm: &DM, paths: &[&Path]) -> CacheDev {
     let meta_table = vec![TargetLine::new(Sectors(0),
                                           meta_length,
                                           LinearDevTargetParams::Linear(meta_params))];
-    let meta = LinearDev::setup(&dm, meta_name, None, meta_table).unwrap();
+    let meta = LinearDev::setup(&dm, &meta_name, None, meta_table).unwrap();
 
-    let cache_name = DmName::new("cache-cache").expect("valid format");
+    let cache_name = test_name("cache-cache").expect("valid format");
     let cache_offset = meta_length;
     let cache_length = MIN_CACHE_BLOCK_SIZE;
     let cache_params = LinearTargetParams::new(dev1, cache_offset);
     let cache_table = vec![TargetLine::new(Sectors(0),
                                            cache_length,
                                            LinearDevTargetParams::Linear(cache_params))];
-    let cache = LinearDev::setup(&dm, cache_name, None, cache_table).unwrap();
+    let cache = LinearDev::setup(&dm, &cache_name, None, cache_table).unwrap();
 
     let dev2_size = blkdev_size(&OpenOptions::new().read(true).open(paths[1]).unwrap()).sectors();
     let dev2 = Device::from(devnode_to_devno(paths[1]).unwrap().unwrap());
 
-    let origin_name = DmName::new("cache-origin").expect("valid format");
+    let origin_name = test_name("cache-origin").expect("valid format");
     let origin_params = LinearTargetParams::new(dev2, Sectors(0));
     let origin_table = vec![TargetLine::new(Sectors(0),
                                             dev2_size,
                                             LinearDevTargetParams::Linear(origin_params))];
-    let origin = LinearDev::setup(&dm, origin_name, None, origin_table).unwrap();
+    let origin = LinearDev::setup(&dm, &origin_name, None, origin_table).unwrap();
 
     CacheDev::new(&dm,
-                  DmName::new("cache").expect("valid format"),
+                  &test_name("cache").expect("valid format"),
                   None,
                   meta,
                   cache,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@ extern crate loopdev;
 extern crate tempdir;
 #[cfg(test)]
 extern crate uuid;
+#[cfg(test)]
+extern crate mnt;
 
 /// rust definitions of ioctl structs and consts
 mod dm_ioctl;
@@ -130,6 +132,8 @@ mod errors;
 #[cfg(test)]
 mod loopbacked;
 
+#[cfg(test)]
+mod test_lib;
 
 pub use cachedev::{CacheDev, CacheDevPerformance, CacheDevStatus, CacheDevUsage,
                    CacheDevWorkingStatus, MAX_CACHE_BLOCK_SIZE, MIN_CACHE_BLOCK_SIZE};

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -496,13 +496,14 @@ mod tests {
 
     use super::super::device::{Device, devnode_to_devno};
     use super::super::loopbacked::{blkdev_size, test_with_spec};
+    use super::super::test_lib::test_name;
 
     use super::*;
 
     /// Verify that a new linear dev with 0 segments fails.
     fn test_empty(_paths: &[&Path]) -> () {
         assert!(LinearDev::setup(&DM::new().unwrap(),
-                                 DmName::new("new").expect("valid format"),
+                                 &test_name("new").expect("valid format"),
                                  None,
                                  vec![])
                         .is_err());
@@ -513,14 +514,13 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let name = "name";
+        let name = test_name("name").expect("valid format");
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let mut ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
-            .unwrap();
+        let mut ld = LinearDev::setup(&dm, &name, None, table).unwrap();
 
         assert!(ld.set_table(&dm, vec![]).is_err());
         ld.resume(&dm).unwrap();
@@ -532,18 +532,16 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let name = "name";
+        let name = test_name("name").expect("valid format");
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let mut ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
-            .unwrap();
+        let mut ld = LinearDev::setup(&dm, &name, None, table).unwrap();
 
-        ld.set_name(&dm, DmName::new(name).expect("valid format"))
-            .unwrap();
-        assert_eq!(ld.name(), DmName::new(name).expect("valid format"));
+        ld.set_name(&dm, &name).unwrap();
+        assert_eq!(ld.name(), &*name);
 
         ld.teardown(&dm).unwrap();
     }
@@ -553,19 +551,17 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let name = "name";
+        let name = test_name("name").expect("valid format");
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let mut ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
-            .unwrap();
+        let mut ld = LinearDev::setup(&dm, &name, None, table).unwrap();
 
-        let new_name = "new_name";
-        ld.set_name(&dm, DmName::new(new_name).expect("valid format"))
-            .unwrap();
-        assert_eq!(ld.name(), DmName::new(new_name).expect("valid format"));
+        let new_name = test_name("new_name").expect("valid format");
+        ld.set_name(&dm, &new_name).unwrap();
+        assert_eq!(ld.name(), &*new_name);
 
         ld.teardown(&dm).unwrap();
     }
@@ -578,7 +574,7 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let name = "name";
+        let name = test_name("name").expect("valid format");
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
@@ -589,8 +585,7 @@ mod tests {
                                          LinearDevTargetParams::Linear(params))];
         let range: Sectors = table.iter().map(|s| s.length).sum();
         let count = table.len();
-        let ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
-            .unwrap();
+        let ld = LinearDev::setup(&dm, &name, None, table).unwrap();
 
         let table = LinearDev::read_kernel_table(&dm, &DevId::Name(ld.name()))
             .unwrap()
@@ -621,7 +616,7 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let name = "name";
+        let name = test_name("name").expect("valid format");
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let table = (0..5)
             .map(|n| {
@@ -631,11 +626,7 @@ mod tests {
                                                                                       Sectors(n))))
                  })
             .collect::<Vec<_>>();
-        let ld = LinearDev::setup(&dm,
-                                  DmName::new(name).expect("valid format"),
-                                  None,
-                                  table.clone())
-                .unwrap();
+        let ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
 
         let loaded_table = LinearDev::read_kernel_table(&dm, &DevId::Name(ld.name())).unwrap();
         assert!(LinearDev::equivalent_tables(&LinearDevTargetTable::new(table), &loaded_table)
@@ -650,25 +641,19 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let name = "name";
+        let name = test_name("name").expect("valid format");
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let ld = LinearDev::setup(&dm,
-                                  DmName::new(name).expect("valid format"),
-                                  None,
-                                  table.clone())
-                .unwrap();
+        let ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
         let params2 = LinearTargetParams::new(dev, Sectors(1));
         let table2 = vec![TargetLine::new(Sectors(0),
                                           Sectors(1),
                                           LinearDevTargetParams::Linear(params2))];
-        assert!(LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table2)
-                    .is_err());
-        assert!(LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
-                    .is_ok());
+        assert!(LinearDev::setup(&dm, &name, None, table2).is_err());
+        assert!(LinearDev::setup(&dm, &name, None, table).is_ok());
         ld.teardown(&dm).unwrap();
     }
 
@@ -677,20 +662,15 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
+        let name = test_name("name").expect("valid format");
+        let ersatz = test_name("ersatz").expect("valid format");
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let ld = LinearDev::setup(&dm,
-                                  DmName::new("name").expect("valid format"),
-                                  None,
-                                  table.clone())
-                .unwrap();
-        let ld2 = LinearDev::setup(&dm,
-                                   DmName::new("ersatz").expect("valid format"),
-                                   None,
-                                   table);
+        let ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
+        let ld2 = LinearDev::setup(&dm, &ersatz, None, table);
         assert!(ld2.is_ok());
 
         ld2.unwrap().teardown(&dm).unwrap();
@@ -702,13 +682,13 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
+        let name = test_name("name").expect("valid format");
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let mut ld = LinearDev::setup(&dm, DmName::new("name").expect("valid format"), None, table)
-            .unwrap();
+        let mut ld = LinearDev::setup(&dm, &name, None, table).unwrap();
 
         ld.suspend(&dm, false).unwrap();
         ld.suspend(&dm, false).unwrap();

--- a/src/loopbacked.rs
+++ b/src/loopbacked.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::{io, panic};
 use std::fs::{File, OpenOptions};
-use std::io;
 use std::io::{Seek, SeekFrom, Write};
 use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -12,6 +12,7 @@ use loopdev::{LoopControl, LoopDevice};
 use tempdir::TempDir;
 
 use super::consts::{IEC, SECTOR_SIZE};
+use super::test_lib::clean_up;
 use super::types::{Bytes, Sectors};
 
 
@@ -119,12 +120,18 @@ fn get_devices(count: u8, dir: &TempDir) -> Vec<LoopTestDev> {
 /// Then, run the designated test.
 /// Then, take down the loop devices.
 pub fn test_with_spec<F>(count: u8, test: F) -> ()
-    where F: Fn(&[&Path]) -> ()
+    where F: Fn(&[&Path]) -> () + panic::RefUnwindSafe
 {
+    clean_up().unwrap();
+
     let tmpdir = TempDir::new("devicemapper").unwrap();
     let loop_devices: Vec<LoopTestDev> = get_devices(count, &tmpdir);
     let device_paths: Vec<PathBuf> = loop_devices.iter().map(|x| x.path()).collect();
     let device_paths: Vec<&Path> = device_paths.iter().map(|x| x.as_path()).collect();
 
-    test(&device_paths);
+    let result = panic::catch_unwind(|| test(&device_paths));
+    let tear_down = clean_up();
+
+    result.unwrap();
+    tear_down.unwrap();
 }

--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::path::PathBuf;
+
+use mnt::get_submounts;
+use nix::mount::{MntFlags, umount2};
+
+use super::DM;
+use super::dm_flags::DmFlags;
+use super::result::DmResult;
+use super::types::{DevId, DmNameBuf, DmUuidBuf};
+
+mod cleanup_errors {
+    use mnt;
+    use nix;
+
+    error_chain!{
+        foreign_links {
+            Mnt(mnt::ParseError);
+            Nix(nix::Error);
+        }
+    }
+}
+
+use self::cleanup_errors::{Error, Result};
+
+/// String that is to be concatenated with test supplied name, so that we can easily identify and
+/// remove.
+static DM_TEST_ID: &str = "_dm-rs_test_delme";
+
+/// Generate the test path string given the test supplied name.
+pub fn test_path(name: &str) -> String {
+    let mut namestr = String::from(name);
+    namestr.push_str(DM_TEST_ID);
+    namestr
+}
+
+/// Generate the test name given the test supplied name.
+pub fn test_name(name: &str) -> DmResult<DmNameBuf> {
+    let mut namestr = String::from(name);
+    namestr.push_str(DM_TEST_ID);
+    DmNameBuf::new(namestr)
+}
+
+/// Generate the test uuid given the test supplied name.
+pub fn test_uuid(name: &str) -> DmResult<DmUuidBuf> {
+    let mut namestr = String::from(name);
+    namestr.push_str(DM_TEST_ID);
+    DmUuidBuf::new(namestr)
+}
+
+/// Attempt to remove all device mapper devices which have DM_TEST_ID contained in name.
+/// FIXME: Current implementation complicated by https://bugzilla.redhat.com/show_bug.cgi?id=1506287
+fn dm_test_devices_remove() -> Result<()> {
+
+    let dm = DM::new().unwrap();
+
+    /// One iteration of removing devicemapper devices
+    fn one_iteration(dm: &DM) -> Result<(bool, Vec<String>)> {
+        let mut progress_made = false;
+        let mut remain = Vec::new();
+
+        for d in dm.list_devices()
+                .unwrap()
+                .iter()
+                .filter(|d| format!("{}", d.0.as_ref()).contains(DM_TEST_ID)) {
+
+            match dm.device_remove(&DevId::Name(&d.0), DmFlags::empty()) {
+                Ok(_) => progress_made = true,
+                Err(_) => remain.push(format!("{}", d.0.as_ref())),
+            }
+        }
+        Ok((progress_made, remain))
+    }
+
+    loop {
+        let (progress_made, remain) = one_iteration(&dm)
+            .map_err(|e| {
+                         Error::with_chain(e,
+                                           "Error while attempting to remove device mapper devices")
+                     })?;
+
+        if !progress_made {
+            if remain.len() != 0 {
+                bail!("We were unable to remove all stratis device mapper devices {:?}",
+                      remain);
+            }
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// Try and un-mount any filesystems that contain DM_TEST_ID in the mount point, returning
+/// immediately on the first one we are unable to unmount.
+fn dm_test_fs_unmount() -> Result<()> {
+    || -> Result<()> {
+        let mounts = get_submounts(&PathBuf::from("/"))?;
+        for m in mounts
+                .iter()
+                .filter(|m| {
+                            m.file
+                                .to_str()
+                                .map_or(false, |s| s.contains(DM_TEST_ID))
+                        }) {
+            umount2(&m.file, MntFlags::MNT_DETACH)?;
+        }
+        Ok(())
+    }()
+            .map_err(|e| {
+                         Error::with_chain(e, "unable to unmount all devicemapper test filesystems")
+                     })
+}
+
+/// When a unit test panics we can leave the system in an inconsistent state.  This function
+/// tries to clean up by un-mounting any mounted file systems, device mapper devices which contain
+/// DM_TEST_ID in the path or name.
+pub fn clean_up() -> Result<()> {
+    dm_test_fs_unmount()?;
+    dm_test_devices_remove()?;
+    Ok(())
+}

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -385,6 +385,7 @@ mod tests {
     use super::super::shared::DmDevice;
     use super::super::thinpooldev::{ThinPoolStatus, minimal_thinpool};
     use super::super::types::DataBlocks;
+    use super::super::test_lib::{test_name, test_path, test_uuid};
 
     use super::super::errors::{Error, ErrorKind};
 
@@ -400,7 +401,7 @@ mod tests {
         let tp = minimal_thinpool(&dm, paths[0]);
 
         assert!(ThinDev::new(&dm,
-                             &DmName::new("name").expect("is valid DM name"),
+                             &test_name("name").expect("is valid DM name"),
                              None,
                              Sectors(0),
                              &tp,
@@ -421,7 +422,7 @@ mod tests {
 
         let td_size = MIN_THIN_DEV_SIZE;
         assert!(match ThinDev::setup(&dm,
-                                     &DmName::new("name").expect("is valid DM name"),
+                                     &test_name("name").expect("is valid DM name"),
                                      None,
                                      td_size,
                                      &tp,
@@ -447,7 +448,7 @@ mod tests {
         let dm = DM::new().unwrap();
         let tp = minimal_thinpool(&dm, paths[0]);
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
-        let id = DmName::new("name").expect("is valid DM name");
+        let id = test_name("name").expect("is valid DM name");
 
         let td_size = MIN_THIN_DEV_SIZE;
         let td = ThinDev::new(&dm, &id, None, td_size, &tp, thin_id).unwrap();
@@ -477,7 +478,7 @@ mod tests {
                 });
 
         // Verify that the device of that name does exist.
-        assert!(device_exists(&dm, id).unwrap());
+        assert!(device_exists(&dm, &id).unwrap());
 
         // Setting up the just created thin dev succeeds.
         assert!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).is_ok());
@@ -516,7 +517,7 @@ mod tests {
 
         // Create new ThinDev as source for snapshot
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
-        let thin_name = DmName::new("name").expect("is valid DM name");
+        let thin_name = test_name("name").expect("is valid DM name");
         let td = ThinDev::new(&dm, &thin_name, None, td_size, &tp, thin_id).unwrap();
 
         let data_usage_1 = match tp.status(&dm).unwrap() {
@@ -528,8 +529,8 @@ mod tests {
 
         // Create a snapshot of the source
         let ss_id = ThinDevId::new_u64(1).expect("is below limit");
-        let ss_name = DmName::new("snap_name").expect("is valid DM name");
-        let ss = td.snapshot(&dm, ss_name, None, &tp, ss_id).unwrap();
+        let ss_name = test_name("snap_name").expect("is valid DM name");
+        let ss = td.snapshot(&dm, &ss_name, None, &tp, ss_id).unwrap();
 
         let data_usage_2 = match tp.status(&dm).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
@@ -556,7 +557,7 @@ mod tests {
         let tp = minimal_thinpool(&dm, paths[0]);
 
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
-        let thin_name = DmName::new("name").expect("is valid DM name");
+        let thin_name = test_name("name").expect("is valid DM name");
         let td = ThinDev::new(&dm, &thin_name, None, tp.size(), &tp, thin_id).unwrap();
 
         let orig_data_usage = match tp.status(&dm).unwrap() {
@@ -578,7 +579,7 @@ mod tests {
         };
         assert!(data_usage_1 > DataBlocks(0));
 
-        let tmp_dir = TempDir::new("stratis_testing").unwrap();
+        let tmp_dir = TempDir::new(&test_path("stratis_testing")).unwrap();
         mount(Some(&td.devnode()),
               tmp_dir.path(),
               Some("xfs"),
@@ -623,7 +624,7 @@ mod tests {
         let tp = minimal_thinpool(&dm, paths[0]);
 
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
-        let thin_name = DmName::new("name").expect("is valid DM name");
+        let thin_name = test_name("name").expect("is valid DM name");
         let td = ThinDev::new(&dm, &thin_name, None, Sectors(2 * IEC::Mi), &tp, thin_id).unwrap();
 
         let orig_data_usage = match tp.status(&dm).unwrap() {
@@ -647,9 +648,9 @@ mod tests {
 
         // Create a snapshot of the source
         let ss_id = ThinDevId::new_u64(1).expect("is below limit");
-        let ss_name = DmName::new("snap_name").expect("is valid DM name");
-        let ss_uuid = DmUuid::new("snap_uuid").expect("is valid DM uuid");
-        let ss = td.snapshot(&dm, ss_name, Some(ss_uuid), &tp, ss_id)
+        let ss_name = test_name("snap_name").expect("is valid DM name");
+        let ss_uuid = test_uuid("snap_uuid").expect("is valid DM uuid");
+        let ss = td.snapshot(&dm, &ss_name, Some(&ss_uuid), &tp, ss_id)
             .unwrap();
 
         let data_usage_2 = match tp.status(&dm).unwrap() {
@@ -677,7 +678,7 @@ mod tests {
         assert!(data_usage_3 - data_usage_2 > data_usage_1 / 2usize);
 
         let thin_id = ThinDevId::new_u64(2).expect("is below limit");
-        let thin_name = DmName::new("name1").expect("is valid DM name");
+        let thin_name = test_name("name1").expect("is valid DM name");
         let td1 = ThinDev::new(&dm, &thin_name, None, Sectors(2 * IEC::Gi), &tp, thin_id).unwrap();
 
         let data_usage_4 = match tp.status(&dm).unwrap() {

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -571,6 +571,8 @@ use super::consts::IEC;
 use super::lineardev::LinearTargetParams;
 #[cfg(test)]
 use super::loopbacked::blkdev_size;
+#[cfg(test)]
+use super::test_lib::test_name;
 
 /// Values are explicitly stated in the device-mapper kernel documentation.
 #[cfg(test)]
@@ -595,7 +597,7 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
                                           MIN_RECOMMENDED_METADATA_SIZE,
                                           LinearDevTargetParams::Linear(meta_params))];
     let meta = LinearDev::setup(dm,
-                                DmName::new("meta").expect("valid format"),
+                                &test_name("meta").expect("valid format"),
                                 None,
                                 meta_table)
             .unwrap();
@@ -605,13 +607,13 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
                                           dev_size - MIN_RECOMMENDED_METADATA_SIZE,
                                           LinearDevTargetParams::Linear(data_params))];
     let data = LinearDev::setup(dm,
-                                DmName::new("data").expect("valid format"),
+                                &test_name("data").expect("valid format"),
                                 None,
                                 data_table)
             .unwrap();
 
     ThinPoolDev::new(dm,
-                     DmName::new("pool").expect("valid format"),
+                     &test_name("pool").expect("valid format"),
                      None,
                      meta,
                      data,
@@ -673,22 +675,22 @@ mod tests {
 
         let dm = DM::new().unwrap();
 
-        let meta_name = DmName::new("meta").expect("valid format");
+        let meta_name = test_name("meta").expect("valid format");
         let meta_params = LinearTargetParams::new(dev, Sectors(0));
         let meta_table = vec![TargetLine::new(Sectors(0),
                                               MIN_RECOMMENDED_METADATA_SIZE,
                                               LinearDevTargetParams::Linear(meta_params))];
-        let meta = LinearDev::setup(&dm, meta_name, None, meta_table).unwrap();
+        let meta = LinearDev::setup(&dm, &meta_name, None, meta_table).unwrap();
 
-        let data_name = DmName::new("data").expect("valid format");
+        let data_name = test_name("data").expect("valid format");
         let data_params = LinearTargetParams::new(dev, MIN_RECOMMENDED_METADATA_SIZE);
         let data_table = vec![TargetLine::new(Sectors(0),
                                               512u64 * MIN_DATA_BLOCK_SIZE,
                                               LinearDevTargetParams::Linear(data_params))];
-        let data = LinearDev::setup(&dm, data_name, None, data_table).unwrap();
+        let data = LinearDev::setup(&dm, &data_name, None, data_table).unwrap();
 
         assert!(match ThinPoolDev::new(&dm,
-                                       DmName::new("pool").expect("valid format"),
+                                       &test_name("pool").expect("valid format"),
                                        None,
                                        meta,
                                        data,
@@ -698,9 +700,9 @@ mod tests {
                     _ => false,
                 });
 
-        dm.device_remove(&DevId::Name(meta_name), DmFlags::empty())
+        dm.device_remove(&DevId::Name(&meta_name), DmFlags::empty())
             .unwrap();
-        dm.device_remove(&DevId::Name(data_name), DmFlags::empty())
+        dm.device_remove(&DevId::Name(&data_name), DmFlags::empty())
             .unwrap();
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -359,6 +359,11 @@ macro_rules! str_id {
             pub fn as_bytes(&self) -> &[u8] {
                 self.inner.as_bytes()
             }
+
+            /// Get the inner value as str
+            pub fn as_str(&self) -> &str {
+                &self.inner
+            }
         }
 
         impl ToOwned for $B {


### PR DESCRIPTION
We did something similar to this before for stratisd, adapted for devicemapper-rs.  This should address:

https://github.com/stratis-storage/devicemapper-rs/issues/212
~~https://github.com/stratis-storage/devicemapper-rs/issues/256~~

With this in place I get a lot less failures when running https://github.com/stratis-storage/devicemapper-rs/pull/296 locally (it reduces the number of failing error cases to examine).

UPDATED:
* Using @agrover change to use function instead of macro
