### PR TITLE
Change default for pool to error_if_no_space

### DIFF
--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -424,7 +424,8 @@ impl ThinPoolDev {
                                                               data_block_size,
                                                               low_water_mark,
                                                               vec!["skip_block_zeroing"
-                                                                       .to_owned()]))
+                                                                       .to_owned(),
+                                                                   "error_if_no_space".to_owned()]))
     }
 
     /// Get the current status of the thinpool.


### PR DESCRIPTION
If the pool is out of space, we want the pool to return errors to XFS as soon as possible.