### PR TITLE
Disable clippy test until a fix is pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ language: rust
 cache: cargo
 
 matrix:
+    allow_failures:
+        - env: TASK=clippy
     include:
         - rust: stable
           env: TASK=travis_fmt


### PR DESCRIPTION
Or some other recommended way to get clippy updates is decided on by
clippy maintainers.

Signed-off-by: mulhern <amulhern@redhat.com>