### PR TITLE
No longer allow failures for clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ language: rust
 cache: cargo
 
 matrix:
-    allow_failures:
-        - env: TASK=clippy
     include:
         - rust: stable
           env: TASK=travis_fmt


### PR DESCRIPTION
A new version has been released, which we hope will work.

Signed-off-by: mulhern <amulhern@redhat.com>