### PR TITLE
Remove DM struct

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -33,108 +33,91 @@ const DM_VERSION_PATCHLEVEL: u32 = 0;
 /// Start with a large buffer to make BUFFER_FULL rare. Libdm does this too.
 const MIN_BUF_SIZE: usize = 16 * 1024;
 
-/// Context needed for communicating with devicemapper.
-pub struct DM {
-    file: File,
+
+/// Return an open File for the devicemapper control file, to be used for polling purposes.
+pub fn get_device_file() -> DmResult<File> {
+    Ok(File::open(DM_CTL_PATH)
+           .map_err(|e| Error::with_chain(e, ErrorKind::ContextInitError))?)
 }
 
-impl DM {
-    /// Create a new context for communicating with DM.
-    pub fn new() -> DmResult<DM> {
-        Ok(DM {
-               file: File::open(DM_CTL_PATH)
-                   .map_err(|e| Error::with_chain(e, ErrorKind::ContextInitError))?,
-           })
+fn initialize_hdr(hdr: &mut dmi::Struct_dm_ioctl, flags: DmFlags) -> () {
+    hdr.version[0] = DM_VERSION_MAJOR;
+    hdr.version[1] = DM_VERSION_MINOR;
+    hdr.version[2] = DM_VERSION_PATCHLEVEL;
+
+    hdr.flags = flags.bits();
+
+    hdr.data_start = size_of::<dmi::Struct_dm_ioctl>() as u32;
+}
+
+fn hdr_set_name(hdr: &mut dmi::Struct_dm_ioctl, name: &DmName) -> () {
+    let name_dest: &mut [u8; DM_NAME_LEN] =
+        unsafe { &mut *(&mut hdr.name as *mut [i8; DM_NAME_LEN] as *mut [u8; DM_NAME_LEN]) };
+    let bytes = name.as_bytes();
+    name_dest[..bytes.len()].clone_from_slice(bytes);
+}
+
+fn hdr_set_uuid(hdr: &mut dmi::Struct_dm_ioctl, uuid: &DmUuid) -> () {
+    let uuid_dest: &mut [u8; DM_UUID_LEN] =
+        unsafe { &mut *(&mut hdr.uuid as *mut [i8; DM_UUID_LEN] as *mut [u8; DM_UUID_LEN]) };
+    let bytes = uuid.as_bytes();
+    uuid_dest[..bytes.len()].clone_from_slice(bytes);
+}
+
+// Give this a filled-in header and optionally add'l stuff.
+// Does the ioctl and maybe returns stuff. Handles BUFFER_FULL flag.
+//
+fn do_ioctl(ioctl: u8,
+            hdr: &mut dmi::Struct_dm_ioctl,
+            in_data: Option<&[u8]>)
+            -> DmResult<Vec<u8>> {
+    // Create in-buf by copying hdr and any in-data into a linear
+    // Vec v.  'hdr_slc' also aliases hdr as a &[u8], used first
+    // to copy the hdr into v, and later to update the
+    // possibly-modified hdr.
+
+    // Start with a large buffer to make BUFFER_FULL rare. Libdm
+    // does this too.
+    hdr.data_size = cmp::max(MIN_BUF_SIZE,
+                             size_of::<dmi::Struct_dm_ioctl>() +
+                             in_data.map_or(0, |x| x.len())) as u32;
+    let mut v: Vec<u8> = Vec::with_capacity(hdr.data_size as usize);
+
+    let hdr_slc = unsafe {
+        let len = hdr.data_start as usize;
+        let ptr = hdr as *mut dmi::Struct_dm_ioctl as *mut u8;
+        slice::from_raw_parts_mut(ptr, len)
+    };
+
+    v.extend_from_slice(hdr_slc);
+    if let Some(in_data) = in_data {
+        v.extend(in_data.iter().cloned());
     }
 
-    /// Get the file within the DM context, likely for polling purposes.
-    pub fn file(&self) -> &File {
-        &self.file
-    }
+    // zero out the rest
+    let cap = v.capacity();
+    v.resize(cap, 0);
 
-    fn initialize_hdr(hdr: &mut dmi::Struct_dm_ioctl, flags: DmFlags) -> () {
-        hdr.version[0] = DM_VERSION_MAJOR;
-        hdr.version[1] = DM_VERSION_MINOR;
-        hdr.version[2] = DM_VERSION_PATCHLEVEL;
+    let op = iorw!(DM_IOCTL, ioctl, size_of::<dmi::Struct_dm_ioctl>()) as c_ulong;
+    loop {
 
-        hdr.flags = flags.bits();
+        let ioctl_result;
 
-        hdr.data_start = size_of::<dmi::Struct_dm_ioctl>() as u32;
-    }
+        {
+            let device_file = File::open(DM_CTL_PATH)
+                .map_err(|e| Error::with_chain(e, ErrorKind::ContextInitError))?;
 
-    fn hdr_set_name(hdr: &mut dmi::Struct_dm_ioctl, name: &DmName) -> () {
-        let name_dest: &mut [u8; DM_NAME_LEN] =
-            unsafe { &mut *(&mut hdr.name as *mut [i8; DM_NAME_LEN] as *mut [u8; DM_NAME_LEN]) };
-        let bytes = name.as_bytes();
-        name_dest[..bytes.len()].clone_from_slice(bytes);
-    }
-
-    fn hdr_set_uuid(hdr: &mut dmi::Struct_dm_ioctl, uuid: &DmUuid) -> () {
-        let uuid_dest: &mut [u8; DM_UUID_LEN] =
-            unsafe { &mut *(&mut hdr.uuid as *mut [i8; DM_UUID_LEN] as *mut [u8; DM_UUID_LEN]) };
-        let bytes = uuid.as_bytes();
-        uuid_dest[..bytes.len()].clone_from_slice(bytes);
-    }
-
-    // Give this a filled-in header and optionally add'l stuff.
-    // Does the ioctl and maybe returns stuff. Handles BUFFER_FULL flag.
-    //
-    fn do_ioctl(&self,
-                ioctl: u8,
-                hdr: &mut dmi::Struct_dm_ioctl,
-                in_data: Option<&[u8]>)
-                -> DmResult<Vec<u8>> {
-        // Create in-buf by copying hdr and any in-data into a linear
-        // Vec v.  'hdr_slc' also aliases hdr as a &[u8], used first
-        // to copy the hdr into v, and later to update the
-        // possibly-modified hdr.
-
-        // Start with a large buffer to make BUFFER_FULL rare. Libdm
-        // does this too.
-        hdr.data_size = cmp::max(MIN_BUF_SIZE,
-                                 size_of::<dmi::Struct_dm_ioctl>() +
-                                 in_data.map_or(0, |x| x.len())) as u32;
-        let mut v: Vec<u8> = Vec::with_capacity(hdr.data_size as usize);
-
-        let hdr_slc = unsafe {
-            let len = hdr.data_start as usize;
-            let ptr = hdr as *mut dmi::Struct_dm_ioctl as *mut u8;
-            slice::from_raw_parts_mut(ptr, len)
-        };
-
-        v.extend_from_slice(hdr_slc);
-        if let Some(in_data) = in_data {
-            v.extend(in_data.iter().cloned());
-        }
-
-        // zero out the rest
-        let cap = v.capacity();
-        v.resize(cap, 0);
-
-        let op = iorw!(DM_IOCTL, ioctl, size_of::<dmi::Struct_dm_ioctl>()) as c_ulong;
-        loop {
-            if unsafe { convert_ioctl_res!(nix_ioctl(self.file.as_raw_fd(), op, v.as_mut_ptr())) }
-                   .is_err() {
-                let info = DeviceInfo::new(hdr.clone());
-                return Err(Error::with_chain(io::Error::last_os_error(),
-                                             ErrorKind::IoctlError(Box::new(info)))
-                                   .into());
-            }
-
-            let hdr = unsafe {
-                #[allow(cast_ptr_alignment)]
-                (v.as_mut_ptr() as *mut dmi::Struct_dm_ioctl)
-                    .as_mut()
-                    .expect("pointer to own structure v can not be NULL")
+            ioctl_result = unsafe {
+                convert_ioctl_res!(nix_ioctl(device_file.as_raw_fd(), op, v.as_mut_ptr()))
             };
 
-            if (hdr.flags & DmFlags::DM_BUFFER_FULL.bits()) == 0 {
-                break;
-            }
+        }
 
-            let len = v.len();
-            v.resize(len * 2, 0);
-            hdr.data_size = v.len() as u32;
+        if ioctl_result.is_err() {
+            let info = DeviceInfo::new(hdr.clone());
+            return Err(Error::with_chain(io::Error::last_os_error(),
+                                         ErrorKind::IoctlError(Box::new(info)))
+                               .into());
         }
 
         let hdr = unsafe {
@@ -144,619 +127,613 @@ impl DM {
                 .expect("pointer to own structure v can not be NULL")
         };
 
-        // hdr possibly modified so copy back
-        hdr_slc.clone_from_slice(&v[..hdr.data_start as usize]);
-
-        // Return header data section.
-        let new_data_off = cmp::max(hdr.data_start, hdr.data_size);
-        Ok(v[hdr.data_start as usize..new_data_off as usize].to_vec())
-    }
-
-    /// Devicemapper version information: Major, Minor, and patchlevel versions.
-    pub fn version(&self) -> DmResult<(u32, u32, u32)> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-
-        Self::initialize_hdr(&mut hdr, DmFlags::empty());
-
-        self.do_ioctl(dmi::DM_VERSION_CMD as u8, &mut hdr, None)?;
-
-        Ok((hdr.version[0], hdr.version[1], hdr.version[2]))
-    }
-
-    /// Remove all DM devices and tables. Use discouraged other than
-    /// for debugging.
-    ///
-    /// If DM_DEFERRED_REMOVE is set, the request will succeed for
-    /// in-use devices, and they will be removed when released.
-    ///
-    /// Valid flags: DM_DEFERRED_REMOVE
-    pub fn remove_all(&self, flags: DmFlags) -> DmResult<()> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-
-        let clean_flags = DmFlags::DM_DEFERRED_REMOVE & flags;
-
-        Self::initialize_hdr(&mut hdr, clean_flags);
-
-        self.do_ioctl(dmi::DM_REMOVE_ALL_CMD as u8, &mut hdr, None)?;
-
-        Ok(())
-    }
-
-    /// Returns a list of tuples containing DM device names, a Device, which
-    /// holds their major and minor device numbers, and on kernels that
-    /// support it, each device's last event_nr.
-    pub fn list_devices(&self) -> DmResult<Vec<(DmNameBuf, Device, Option<u32>)>> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-
-        Self::initialize_hdr(&mut hdr, DmFlags::empty());
-
-        let data_out = self.do_ioctl(dmi::DM_LIST_DEVICES_CMD as u8, &mut hdr, None)?;
-
-        let mut devs = Vec::new();
-        if !data_out.is_empty() {
-            let mut result = &data_out[..];
-
-            loop {
-                let device = unsafe {
-                    (result.as_ptr() as *const dmi::Struct_dm_name_list)
-                        .as_ref()
-                        .expect("pointer to own structure result can not be NULL")
-                };
-
-                let slc = slice_to_null(&result[size_of::<dmi::Struct_dm_name_list>()..])
-                    .expect("kernel data is well-formatted");
-                let dm_name = String::from_utf8_lossy(slc).into_owned();
-
-                // Get each device's event number after its name, if the kernel
-                // DM version supports it.
-                // Should match offset calc in kernel's
-                // drivers/md/dm-ioctl.c:list_devices
-                let event_nr = {
-                    match hdr.version[1] {
-                        0...36 => None,
-                        _ => {
-                            // offsetof "name" in Struct_dm_name_list.
-                            // TODO: Consider using pointer::offset_to when stable
-                            let mut offset = 12;
-                            offset += slc.len() + 1; // name + trailing NULL char
-                            let aligned_offset = align_to(offset, size_of::<u64>());
-                            let new_slc = &result[aligned_offset..];
-
-                            #[allow(cast_ptr_alignment)]
-                            let nr = unsafe { *(new_slc.as_ptr() as *const u32) };
-
-                            Some(nr)
-                        }
-                    }
-                };
-
-                devs.push((DmNameBuf::new(dm_name).expect("name obtained from kernel"),
-                           device.dev.into(),
-                           event_nr));
-
-                if device.next == 0 {
-                    break;
-                }
-
-                result = &result[device.next as usize..];
-            }
+        if (hdr.flags & DmFlags::DM_BUFFER_FULL.bits()) == 0 {
+            break;
         }
 
-        Ok(devs)
+        let len = v.len();
+        v.resize(len * 2, 0);
+        hdr.data_size = v.len() as u32;
     }
 
-    /// Create a DM device. It starts out in a "suspended" state.
-    ///
-    /// Valid flags: DM_READONLY, DM_PERSISTENT_DEV
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use devicemapper::{DM, DmFlags, DmName};
-    ///
-    /// let dm = DM::new().unwrap();
-    ///
-    /// // Setting a uuid is optional
-    /// let name = DmName::new("example-dev").expect("is valid DM name");
-    /// let dev = dm.device_create(name, None, DmFlags::empty()).unwrap();
-    /// ```
-    pub fn device_create(&self,
-                         name: &DmName,
-                         uuid: Option<&DmUuid>,
-                         flags: DmFlags)
-                         -> DmResult<DeviceInfo> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+    let hdr = unsafe {
+        #[allow(cast_ptr_alignment)]
+        (v.as_mut_ptr() as *mut dmi::Struct_dm_ioctl)
+            .as_mut()
+            .expect("pointer to own structure v can not be NULL")
+    };
 
-        let clean_flags = (DmFlags::DM_READONLY | DmFlags::DM_PERSISTENT_DEV) & flags;
+    // hdr possibly modified so copy back
+    hdr_slc.clone_from_slice(&v[..hdr.data_start as usize]);
 
-        Self::initialize_hdr(&mut hdr, clean_flags);
+    // Return header data section.
+    let new_data_off = cmp::max(hdr.data_start, hdr.data_size);
+    Ok(v[hdr.data_start as usize..new_data_off as usize].to_vec())
+}
 
-        Self::hdr_set_name(&mut hdr, name);
-        if let Some(uuid) = uuid {
-            Self::hdr_set_uuid(&mut hdr, uuid);
-        }
+/// Devicemapper version information: Major, Minor, and patchlevel versions.
+pub fn version() -> DmResult<(u32, u32, u32)> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
-        self.do_ioctl(dmi::DM_DEV_CREATE_CMD as u8, &mut hdr, None)?;
+    initialize_hdr(&mut hdr, DmFlags::empty());
 
-        Ok(DeviceInfo::new(hdr))
-    }
+    do_ioctl(dmi::DM_VERSION_CMD as u8, &mut hdr, None)?;
 
-    /// Remove a DM device and its mapping tables.
-    ///
-    /// If DM_DEFERRED_REMOVE is set, the request for an in-use
-    /// devices will succeed, and it will be removed when no longer
-    /// used.
-    ///
-    /// Valid flags: DM_DEFERRED_REMOVE
-    pub fn device_remove(&self, id: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+    Ok((hdr.version[0], hdr.version[1], hdr.version[2]))
+}
 
-        let clean_flags = DmFlags::DM_DEFERRED_REMOVE & flags;
+/// Remove all DM devices and tables. Use discouraged other than
+/// for debugging.
+///
+/// If DM_DEFERRED_REMOVE is set, the request will succeed for
+/// in-use devices, and they will be removed when released.
+///
+/// Valid flags: DM_DEFERRED_REMOVE
+pub fn remove_all(flags: DmFlags) -> DmResult<()> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
-        Self::initialize_hdr(&mut hdr, clean_flags);
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
-        };
+    let clean_flags = DmFlags::DM_DEFERRED_REMOVE & flags;
 
-        self.do_ioctl(dmi::DM_DEV_REMOVE_CMD as u8, &mut hdr, None)?;
+    initialize_hdr(&mut hdr, clean_flags);
 
-        Ok(DeviceInfo::new(hdr))
-    }
+    do_ioctl(dmi::DM_REMOVE_ALL_CMD as u8, &mut hdr, None)?;
 
-    /// Change a DM device's name OR set the device's uuid for the first time.
-    ///
-    /// Prerequisite: if new == DevId::Name(new_name), old_name != new_name
-    /// Prerequisite: if new == DevId::Uuid(uuid), device's current uuid
-    /// must be "".
-    /// Note: Possibly surprisingly, returned DeviceInfo's uuid or name field
-    /// contains the previous value, not the newly set value.
-    pub fn device_rename(&self, old_name: &DmName, new: &DevId) -> DmResult<DeviceInfo> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-        let mut data_in = match *new {
-            DevId::Name(name) => {
-                Self::initialize_hdr(&mut hdr, DmFlags::empty());
-                name.as_bytes().to_vec()
-            }
-            DevId::Uuid(uuid) => {
-                Self::initialize_hdr(&mut hdr, DmFlags::DM_UUID);
-                uuid.as_bytes().to_vec()
-            }
-        };
-        data_in.push(b'\0');
+    Ok(())
+}
 
-        Self::hdr_set_name(&mut hdr, old_name);
+/// Returns a list of tuples containing DM device names, a Device, which
+/// holds their major and minor device numbers, and on kernels that
+/// support it, each device's last event_nr.
+pub fn list_devices() -> DmResult<Vec<(DmNameBuf, Device, Option<u32>)>> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
-        self.do_ioctl(dmi::DM_DEV_RENAME_CMD as u8, &mut hdr, Some(&data_in))?;
+    initialize_hdr(&mut hdr, DmFlags::empty());
 
-        Ok(DeviceInfo::new(hdr))
-    }
+    let data_out = do_ioctl(dmi::DM_LIST_DEVICES_CMD as u8, &mut hdr, None)?;
 
-    /// Suspend or resume a DM device, depending on if DM_SUSPEND flag
-    /// is set or not.
-    ///
-    /// Resuming a DM device moves a table loaded into the "inactive"
-    /// slot by `table_load()` into the "active" slot.
-    ///
-    /// Will block until pending I/O is completed unless DM_NOFLUSH
-    /// flag is given. Will freeze filesystem unless DM_SKIP_LOCKFS
-    /// flags is given. Additional I/O to a suspended device will be
-    /// held until it is resumed.
-    ///
-    /// Valid flags: DM_SUSPEND, DM_NOFLUSH, DM_SKIP_LOCKFS
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use devicemapper::{DM, DevId, DmFlags, DmName};
-    /// let dm = DM::new().unwrap();
-    ///
-    /// let name = DmName::new("example-dev").expect("is valid DM name");
-    /// let id = DevId::Name(name);
-    /// dm.device_suspend(&id, DmFlags::DM_SUSPEND).unwrap();
-    /// ```
-    pub fn device_suspend(&self, id: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+    let mut devs = Vec::new();
+    if !data_out.is_empty() {
+        let mut result = &data_out[..];
 
-        let clean_flags = (DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH | DmFlags::DM_SKIP_LOCKFS) &
-                          flags;
-
-        Self::initialize_hdr(&mut hdr, clean_flags);
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
-        };
-
-        self.do_ioctl(dmi::DM_DEV_SUSPEND_CMD as u8, &mut hdr, None)?;
-
-        Ok(DeviceInfo::new(hdr))
-    }
-
-    /// Get DeviceInfo for a device. This is also returned by other
-    /// methods, but if just the DeviceInfo is desired then this just
-    /// gets it.
-    pub fn device_info(&self, id: &DevId) -> DmResult<DeviceInfo> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-
-        Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
-        };
-
-        self.do_ioctl(dmi::DM_DEV_STATUS_CMD as u8, &mut hdr, None)?;
-
-        Ok(DeviceInfo::new(hdr))
-    }
-
-    /// Wait for a device to report an event.
-    ///
-    /// Once an event occurs, this function behaves just like
-    /// `table_status`, see that function for more details.
-    ///
-    /// This interface is not very friendly to monitoring multiple devices.
-    /// Events are also exported via uevents, that method may be preferable.
-    #[allow(type_complexity)]
-    pub fn device_wait
-        (&self,
-         id: &DevId,
-         flags: DmFlags)
-         -> DmResult<(DeviceInfo, Vec<(Sectors, Sectors, TargetTypeBuf, String)>)> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-
-        let clean_flags = DmFlags::DM_QUERY_INACTIVE_TABLE & flags;
-
-        Self::initialize_hdr(&mut hdr, clean_flags);
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
-        };
-
-        let data_out = self.do_ioctl(dmi::DM_DEV_WAIT_CMD as u8, &mut hdr, None)?;
-
-        let status = DM::parse_table_status(hdr.target_count, &data_out);
-
-        Ok((DeviceInfo::new(hdr), status))
-
-    }
-
-    /// Load targets for a device into its inactive table slot.
-    ///
-    /// `targets` is an array of (sector_start, sector_length, type, params).
-    ///
-    /// `params` are target-specific, please see [Linux kernel documentation]
-    /// https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/ ->
-    /// Documentation/device-mapper
-    /// for more.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use devicemapper::{DM, DevId, DmName, Sectors, TargetTypeBuf};
-    /// let dm = DM::new().unwrap();
-    ///
-    /// // Create a 16MiB device (32768 512-byte sectors) that maps to /dev/sdb1
-    /// // starting 1MiB into sdb1
-    /// let table = vec![(
-    ///     Sectors(0),
-    ///     Sectors(32768),
-    ///     TargetTypeBuf::new("linear".into()).expect("valid"),
-    ///     "/dev/sdb1 2048".into()
-    /// )];
-    ///
-    /// let name = DmName::new("example-dev").expect("is valid DM name");
-    /// let id = DevId::Name(name);
-    /// dm.table_load(&id, &table).unwrap();
-    /// ```
-    pub fn table_load(&self,
-                      id: &DevId,
-                      targets: &[(Sectors, Sectors, TargetTypeBuf, String)])
-                      -> DmResult<DeviceInfo> {
-        let mut targs = Vec::new();
-
-        // Construct targets first, since we need to know how many & size
-        // before initializing the header.
-        for t in targets {
-            let mut targ: dmi::Struct_dm_target_spec = Default::default();
-            targ.sector_start = *t.0;
-            targ.length = *t.1;
-            targ.status = 0;
-
-            let dst: &mut [u8] =
-                unsafe { &mut *(&mut targ.target_type[..] as *mut [i8] as *mut [u8]) };
-            let bytes = t.2.as_bytes();
-            assert!(bytes.len() <= dst.len(),
-                    "TargetType max length = targ.target_type.len()");
-            dst[..bytes.len()].clone_from_slice(bytes);
-
-            let mut params = t.3.to_owned();
-            let params_len = params.len();
-            let pad_bytes = align_to(params_len + 1usize, 8usize) - params_len;
-            params.extend(vec!["\0"; pad_bytes]);
-
-            targ.next = (size_of::<dmi::Struct_dm_target_spec>() + params.len()) as u32;
-
-            targs.push((targ, params));
-        }
-
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-
-        Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
-        };
-
-        // io_ioctl() will set hdr.data_size but we must set target_count
-        hdr.target_count = targs.len() as u32;
-
-        // Flatten targets into a buf
-        let mut data_in = Vec::new();
-
-        for (targ, param) in targs {
-            unsafe {
-                let ptr = &targ as *const dmi::Struct_dm_target_spec as *mut u8;
-                let slc = slice::from_raw_parts(ptr, size_of::<dmi::Struct_dm_target_spec>());
-                data_in.extend_from_slice(slc);
-            }
-
-            data_in.extend(param.as_bytes());
-        }
-
-        self.do_ioctl(dmi::DM_TABLE_LOAD_CMD as u8, &mut hdr, Some(&data_in))?;
-
-        Ok(DeviceInfo::new(hdr))
-    }
-
-    /// Clear the "inactive" table for a device.
-    pub fn table_clear(&self, id: &DevId) -> DmResult<DeviceInfo> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-
-        Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
-        };
-
-        self.do_ioctl(dmi::DM_TABLE_CLEAR_CMD as u8, &mut hdr, None)?;
-
-        Ok(DeviceInfo::new(hdr))
-    }
-
-    /// Query DM for which devices are referenced by the "active"
-    /// table for this device.
-    ///
-    /// If DM_QUERY_INACTIVE_TABLE is set, instead return for the
-    /// inactive table.
-    ///
-    /// Valid flags: DM_QUERY_INACTIVE_TABLE
-    pub fn table_deps(&self, id: &DevId, flags: DmFlags) -> DmResult<Vec<Device>> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
-
-        let clean_flags = DmFlags::DM_QUERY_INACTIVE_TABLE & flags;
-
-        Self::initialize_hdr(&mut hdr, clean_flags);
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
-        };
-
-        let data_out = self.do_ioctl(dmi::DM_TABLE_DEPS_CMD as u8, &mut hdr, None)?;
-
-        if data_out.is_empty() {
-            Ok(vec![])
-        } else {
-            let result = &data_out[..];
-            let target_deps = unsafe {
-                (result.as_ptr() as *const dmi::Struct_dm_target_deps)
+        loop {
+            let device = unsafe {
+                (result.as_ptr() as *const dmi::Struct_dm_name_list)
                     .as_ref()
                     .expect("pointer to own structure result can not be NULL")
             };
 
-            let dev_slc = unsafe {
-                #[allow(cast_ptr_alignment)]
-                slice::from_raw_parts(result[size_of::<dmi::Struct_dm_target_deps>()..].as_ptr() as
-                                      *const u64,
-                                      target_deps.count as usize)
+            let slc = slice_to_null(&result[size_of::<dmi::Struct_dm_name_list>()..])
+                .expect("kernel data is well-formatted");
+            let dm_name = String::from_utf8_lossy(slc).into_owned();
+
+            // Get each device's event number after its name, if the kernel
+            // DM version supports it.
+            // Should match offset calc in kernel's
+            // drivers/md/dm-ioctl.c:list_devices
+            let event_nr = {
+                match hdr.version[1] {
+                    0...36 => None,
+                    _ => {
+                        // offsetof "name" in Struct_dm_name_list.
+                        // TODO: Consider using pointer::offset_to when stable
+                        let mut offset = 12;
+                        offset += slc.len() + 1; // name + trailing NULL char
+                        let aligned_offset = align_to(offset, size_of::<u64>());
+                        let new_slc = &result[aligned_offset..];
+
+                        #[allow(cast_ptr_alignment)]
+                        let nr = unsafe { *(new_slc.as_ptr() as *const u32) };
+
+                        Some(nr)
+                    }
+                }
             };
 
-            // Note: The DM target_deps struct reserves 64 bits for each entry
-            // but only 32 bits is used by kernel "huge" dev_t encoding.
-            Ok(dev_slc
-                   .iter()
-                   .map(|d| Device::from_kdev_t(*d as u32))
-                   .collect())
-        }
-    }
+            devs.push((DmNameBuf::new(dm_name).expect("name obtained from kernel"),
+                       device.dev.into(),
+                       event_nr));
 
-    /// Parse a device's table. The table value is in buf, count indicates the
-    /// expected number of lines.
-    /// Panics if there is an error parsing the table.
-    /// Trims trailing white space off final entry on each line. This
-    /// canonicalization makes checking identity of tables easier.
-    // Justification: If the ioctl succeeded, the data is correct and
-    // complete. An error in parsing can only result from a change in the
-    // kernel. We rely on DM's interface versioning system. Kernel changes
-    // will either be backwards-compatible, or will increment
-    // DM_VERSION_MAJOR.  Since calls made with a non-matching major version
-    // will fail, this protects against callers parsing unknown formats.
-    fn parse_table_status(count: u32,
-                          buf: &[u8])
-                          -> Vec<(Sectors, Sectors, TargetTypeBuf, String)> {
-        let mut targets = Vec::new();
-        if !buf.is_empty() {
-            let mut next_off = 0;
-
-            for _ in 0..count {
-                let result = &buf[next_off..];
-                let targ = unsafe {
-                    #[allow(cast_ptr_alignment)]
-                    (result.as_ptr() as *const dmi::Struct_dm_target_spec)
-                        .as_ref()
-                        .expect("assume all parsing succeeds")
-                };
-
-                let target_type = unsafe {
-                    let cast: &[u8; 16] = &*(&targ.target_type as *const [i8; 16] as
-                                             *const [u8; 16]);
-                    let slc = slice_to_null(cast).expect("assume all parsing succeeds");
-                    String::from_utf8_lossy(slc).into_owned()
-                };
-
-                let params = {
-                    let slc = slice_to_null(&result[size_of::<dmi::Struct_dm_target_spec>()..])
-                        .expect("assume all parsing succeeds");
-                    String::from_utf8_lossy(slc).trim_right().to_owned()
-                };
-
-                targets.push((Sectors(targ.sector_start),
-                              Sectors(targ.length),
-
-                              TargetTypeBuf::new(target_type).expect("< sizeof target_spec"),
-                              params));
-
-                next_off = targ.next as usize;
+            if device.next == 0 {
+                break;
             }
+
+            result = &result[device.next as usize..];
         }
-        targets
     }
 
-    /// Return the status of all targets for a device's "active"
-    /// table.
-    ///
-    /// Returns DeviceInfo and a Vec of (sector_start, sector_length, type, params).
-    ///
-    /// If DM_STATUS_TABLE flag is set, returns the current table value. Otherwise
-    /// returns target-specific status information.
-    ///
-    /// If DM_NOFLUSH is set, retrieving the target-specific status information for
-    /// targets with metadata will not cause a metadata write.
-    ///
-    /// If DM_QUERY_INACTIVE_TABLE is set, instead return the status of the
-    /// inactive table.
-    ///
-    /// Valid flags: DM_NOFLUSH, DM_STATUS_TABLE, DM_QUERY_INACTIVE_TABLE
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use devicemapper::{DM, DevId, DmFlags, DmName};
-    /// let dm = DM::new().unwrap();
-    ///
-    /// let name = DmName::new("example-dev").expect("is valid DM name");
-    /// let id = DevId::Name(name);
-    /// let res = dm.table_status(&id, DmFlags::DM_STATUS_TABLE).unwrap();
-    /// println!("{} {:?}", res.0.name(), res.1);
-    /// ```
-    #[allow(type_complexity)]
-    pub fn table_status
-        (&self,
-         id: &DevId,
-         flags: DmFlags)
-         -> DmResult<(DeviceInfo, Vec<(Sectors, Sectors, TargetTypeBuf, String)>)> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+    Ok(devs)
+}
 
-        let clean_flags = (DmFlags::DM_NOFLUSH | DmFlags::DM_STATUS_TABLE |
-                           DmFlags::DM_QUERY_INACTIVE_TABLE) & flags;
+/// Create a DM device. It starts out in a "suspended" state.
+///
+/// Valid flags: DM_READONLY, DM_PERSISTENT_DEV
+///
+/// # Example
+///
+/// ```no_run
+/// use devicemapper::{dm, DmFlags, DmName};
+///
+/// // Setting a uuid is optional
+/// let name = DmName::new("example-dev").expect("is valid DM name");
+/// let dev = dm::device_create(name, None, DmFlags::empty()).unwrap();
+/// ```
+pub fn device_create(name: &DmName, uuid: Option<&DmUuid>, flags: DmFlags) -> DmResult<DeviceInfo> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
-        Self::initialize_hdr(&mut hdr, clean_flags);
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
+    let clean_flags = (DmFlags::DM_READONLY | DmFlags::DM_PERSISTENT_DEV) & flags;
+
+    initialize_hdr(&mut hdr, clean_flags);
+
+    hdr_set_name(&mut hdr, name);
+    if let Some(uuid) = uuid {
+        hdr_set_uuid(&mut hdr, uuid);
+    }
+
+    do_ioctl(dmi::DM_DEV_CREATE_CMD as u8, &mut hdr, None)?;
+
+    Ok(DeviceInfo::new(hdr))
+}
+
+/// Remove a DM device and its mapping tables.
+///
+/// If DM_DEFERRED_REMOVE is set, the request for an in-use
+/// devices will succeed, and it will be removed when no longer
+/// used.
+///
+/// Valid flags: DM_DEFERRED_REMOVE
+pub fn device_remove(id: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    let clean_flags = DmFlags::DM_DEFERRED_REMOVE & flags;
+
+    initialize_hdr(&mut hdr, clean_flags);
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
+
+    do_ioctl(dmi::DM_DEV_REMOVE_CMD as u8, &mut hdr, None)?;
+
+    Ok(DeviceInfo::new(hdr))
+}
+
+/// Change a DM device's name OR set the device's uuid for the first time.
+///
+/// Prerequisite: if new == DevId::Name(new_name), old_name != new_name
+/// Prerequisite: if new == DevId::Uuid(uuid), device's current uuid
+/// must be "".
+/// Note: Possibly surprisingly, returned DeviceInfo's uuid or name field
+/// contains the previous value, not the newly set value.
+pub fn device_rename(old_name: &DmName, new: &DevId) -> DmResult<DeviceInfo> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+    let mut data_in = match *new {
+        DevId::Name(name) => {
+            initialize_hdr(&mut hdr, DmFlags::empty());
+            name.as_bytes().to_vec()
+        }
+        DevId::Uuid(uuid) => {
+            initialize_hdr(&mut hdr, DmFlags::DM_UUID);
+            uuid.as_bytes().to_vec()
+        }
+    };
+    data_in.push(b'\0');
+
+    hdr_set_name(&mut hdr, old_name);
+
+    do_ioctl(dmi::DM_DEV_RENAME_CMD as u8, &mut hdr, Some(&data_in))?;
+
+    Ok(DeviceInfo::new(hdr))
+}
+
+/// Suspend or resume a DM device, depending on if DM_SUSPEND flag
+/// is set or not.
+///
+/// Resuming a DM device moves a table loaded into the "inactive"
+/// slot by `table_load()` into the "active" slot.
+///
+/// Will block until pending I/O is completed unless DM_NOFLUSH
+/// flag is given. Will freeze filesystem unless DM_SKIP_LOCKFS
+/// flags is given. Additional I/O to a suspended device will be
+/// held until it is resumed.
+///
+/// Valid flags: DM_SUSPEND, DM_NOFLUSH, DM_SKIP_LOCKFS
+///
+/// # Example
+///
+/// ```no_run
+/// use devicemapper::{dm, DevId, DmFlags, DmName};
+///
+/// let name = DmName::new("example-dev").expect("is valid DM name");
+/// let id = DevId::Name(name);
+/// dm::device_suspend(&id, DmFlags::DM_SUSPEND).unwrap();
+/// ```
+pub fn device_suspend(id: &DevId, flags: DmFlags) -> DmResult<DeviceInfo> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    let clean_flags = (DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH | DmFlags::DM_SKIP_LOCKFS) & flags;
+
+    initialize_hdr(&mut hdr, clean_flags);
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
+
+    do_ioctl(dmi::DM_DEV_SUSPEND_CMD as u8, &mut hdr, None)?;
+
+    Ok(DeviceInfo::new(hdr))
+}
+
+/// Get DeviceInfo for a device. This is also returned by other
+/// methods, but if just the DeviceInfo is desired then this just
+/// gets it.
+pub fn device_info(id: &DevId) -> DmResult<DeviceInfo> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    initialize_hdr(&mut hdr, DmFlags::empty());
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
+
+    do_ioctl(dmi::DM_DEV_STATUS_CMD as u8, &mut hdr, None)?;
+
+    Ok(DeviceInfo::new(hdr))
+}
+
+/// Wait for a device to report an event.
+///
+/// Once an event occurs, this function behaves just like
+/// `table_status`, see that function for more details.
+///
+/// This interface is not very friendly to monitoring multiple devices.
+/// Events are also exported via uevents, that method may be preferable.
+#[allow(type_complexity)]
+pub fn device_wait(id: &DevId,
+                   flags: DmFlags)
+                   -> DmResult<(DeviceInfo, Vec<(Sectors, Sectors, TargetTypeBuf, String)>)> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    let clean_flags = DmFlags::DM_QUERY_INACTIVE_TABLE & flags;
+
+    initialize_hdr(&mut hdr, clean_flags);
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
+
+    let data_out = do_ioctl(dmi::DM_DEV_WAIT_CMD as u8, &mut hdr, None)?;
+
+    let status = parse_table_status(hdr.target_count, &data_out);
+
+    Ok((DeviceInfo::new(hdr), status))
+
+}
+
+/// Load targets for a device into its inactive table slot.
+///
+/// `targets` is an array of (sector_start, sector_length, type, params).
+///
+/// `params` are target-specific, please see [Linux kernel documentation]
+/// https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/ ->
+/// Documentation/device-mapper
+/// for more.
+///
+/// # Example
+///
+/// ```no_run
+/// use devicemapper::{dm, DevId, DmName, Sectors, TargetTypeBuf};
+///
+/// // Create a 16MiB device (32768 512-byte sectors) that maps to /dev/sdb1
+/// // starting 1MiB into sdb1
+/// let table = vec![(
+///     Sectors(0),
+///     Sectors(32768),
+///     TargetTypeBuf::new("linear".into()).expect("valid"),
+///     "/dev/sdb1 2048".into()
+/// )];
+///
+/// let name = DmName::new("example-dev").expect("is valid DM name");
+/// let id = DevId::Name(name);
+/// dm::table_load(&id, &table).unwrap();
+/// ```
+pub fn table_load(id: &DevId,
+                  targets: &[(Sectors, Sectors, TargetTypeBuf, String)])
+                  -> DmResult<DeviceInfo> {
+    let mut targs = Vec::new();
+
+    // Construct targets first, since we need to know how many & size
+    // before initializing the header.
+    for t in targets {
+        let mut targ: dmi::Struct_dm_target_spec = Default::default();
+        targ.sector_start = *t.0;
+        targ.length = *t.1;
+        targ.status = 0;
+
+        let dst: &mut [u8] = unsafe { &mut *(&mut targ.target_type[..] as *mut [i8] as *mut [u8]) };
+        let bytes = t.2.as_bytes();
+        assert!(bytes.len() <= dst.len(),
+                "TargetType max length = targ.target_type.len()");
+        dst[..bytes.len()].clone_from_slice(bytes);
+
+        let mut params = t.3.to_owned();
+        let params_len = params.len();
+        let pad_bytes = align_to(params_len + 1usize, 8usize) - params_len;
+        params.extend(vec!["\0"; pad_bytes]);
+
+        targ.next = (size_of::<dmi::Struct_dm_target_spec>() + params.len()) as u32;
+
+        targs.push((targ, params));
+    }
+
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    initialize_hdr(&mut hdr, DmFlags::empty());
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
+
+    // io_ioctl() will set hdr.data_size but we must set target_count
+    hdr.target_count = targs.len() as u32;
+
+    // Flatten targets into a buf
+    let mut data_in = Vec::new();
+
+    for (targ, param) in targs {
+        unsafe {
+            let ptr = &targ as *const dmi::Struct_dm_target_spec as *mut u8;
+            let slc = slice::from_raw_parts(ptr, size_of::<dmi::Struct_dm_target_spec>());
+            data_in.extend_from_slice(slc);
+        }
+
+        data_in.extend(param.as_bytes());
+    }
+
+    do_ioctl(dmi::DM_TABLE_LOAD_CMD as u8, &mut hdr, Some(&data_in))?;
+
+    Ok(DeviceInfo::new(hdr))
+}
+
+/// Clear the "inactive" table for a device.
+pub fn table_clear(id: &DevId) -> DmResult<DeviceInfo> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    initialize_hdr(&mut hdr, DmFlags::empty());
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
+
+    do_ioctl(dmi::DM_TABLE_CLEAR_CMD as u8, &mut hdr, None)?;
+
+    Ok(DeviceInfo::new(hdr))
+}
+
+/// Query DM for which devices are referenced by the "active"
+/// table for this device.
+///
+/// If DM_QUERY_INACTIVE_TABLE is set, instead return for the
+/// inactive table.
+///
+/// Valid flags: DM_QUERY_INACTIVE_TABLE
+pub fn table_deps(id: &DevId, flags: DmFlags) -> DmResult<Vec<Device>> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    let clean_flags = DmFlags::DM_QUERY_INACTIVE_TABLE & flags;
+
+    initialize_hdr(&mut hdr, clean_flags);
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
+
+    let data_out = do_ioctl(dmi::DM_TABLE_DEPS_CMD as u8, &mut hdr, None)?;
+
+    if data_out.is_empty() {
+        Ok(vec![])
+    } else {
+        let result = &data_out[..];
+        let target_deps = unsafe {
+            (result.as_ptr() as *const dmi::Struct_dm_target_deps)
+                .as_ref()
+                .expect("pointer to own structure result can not be NULL")
         };
 
-        let data_out = self.do_ioctl(dmi::DM_TABLE_STATUS_CMD as u8, &mut hdr, None)?;
+        let dev_slc = unsafe {
+            #[allow(cast_ptr_alignment)]
+            slice::from_raw_parts(result[size_of::<dmi::Struct_dm_target_deps>()..].as_ptr() as
+                                  *const u64,
+                                  target_deps.count as usize)
+        };
 
-        let status = DM::parse_table_status(hdr.target_count, &data_out);
-
-        Ok((DeviceInfo::new(hdr), status))
+        // Note: The DM target_deps struct reserves 64 bits for each entry
+        // but only 32 bits is used by kernel "huge" dev_t encoding.
+        Ok(dev_slc
+               .iter()
+               .map(|d| Device::from_kdev_t(*d as u32))
+               .collect())
     }
+}
 
-    /// Returns a list of each loaded target type with its name, and
-    /// version broken into major, minor, and patchlevel.
-    pub fn list_versions(&self) -> DmResult<Vec<(String, u32, u32, u32)>> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+/// Parse a device's table. The table value is in buf, count indicates the
+/// expected number of lines.
+/// Panics if there is an error parsing the table.
+/// Trims trailing white space off final entry on each line. This
+/// canonicalization makes checking identity of tables easier.
+// Justification: If the ioctl succeeded, the data is correct and
+// complete. An error in parsing can only result from a change in the
+// kernel. We rely on DM's interface versioning system. Kernel changes
+// will either be backwards-compatible, or will increment
+// DM_VERSION_MAJOR.  Since calls made with a non-matching major version
+// will fail, this protects against callers parsing unknown formats.
+fn parse_table_status(count: u32, buf: &[u8]) -> Vec<(Sectors, Sectors, TargetTypeBuf, String)> {
+    let mut targets = Vec::new();
+    if !buf.is_empty() {
+        let mut next_off = 0;
 
-        Self::initialize_hdr(&mut hdr, DmFlags::empty());
+        for _ in 0..count {
+            let result = &buf[next_off..];
+            let targ = unsafe {
+                #[allow(cast_ptr_alignment)]
+                (result.as_ptr() as *const dmi::Struct_dm_target_spec)
+                    .as_ref()
+                    .expect("assume all parsing succeeds")
+            };
 
-        let data_out = self.do_ioctl(dmi::DM_LIST_VERSIONS_CMD as u8, &mut hdr, None)?;
+            let target_type = unsafe {
+                let cast: &[u8; 16] = &*(&targ.target_type as *const [i8; 16] as *const [u8; 16]);
+                let slc = slice_to_null(cast).expect("assume all parsing succeeds");
+                String::from_utf8_lossy(slc).into_owned()
+            };
 
-        let mut targets = Vec::new();
-        if !data_out.is_empty() {
-            let mut result = &data_out[..];
+            let params = {
+                let slc = slice_to_null(&result[size_of::<dmi::Struct_dm_target_spec>()..])
+                    .expect("assume all parsing succeeds");
+                String::from_utf8_lossy(slc).trim_right().to_owned()
+            };
 
-            loop {
-                let tver = unsafe {
-                    (result.as_ptr() as *const dmi::Struct_dm_target_versions)
-                        .as_ref()
-                        .expect("pointer to own structure result can not be NULL")
-                };
+            targets.push((Sectors(targ.sector_start),
+                          Sectors(targ.length),
 
-                let name_slc = slice_to_null(&result
-                                                  [size_of::<dmi::Struct_dm_target_versions>()..])
-                        .expect("kernel data is well-formatted");
-                let name = String::from_utf8_lossy(name_slc).into_owned();
-                targets.push((name, tver.version[0], tver.version[1], tver.version[2]));
+                          TargetTypeBuf::new(target_type).expect("< sizeof target_spec"),
+                          params));
 
-                if tver.next == 0 {
-                    break;
-                }
+            next_off = targ.next as usize;
+        }
+    }
+    targets
+}
 
-                result = &result[tver.next as usize..];
+/// Return the status of all targets for a device's "active"
+/// table.
+///
+/// Returns DeviceInfo and a Vec of (sector_start, sector_length, type, params).
+///
+/// If DM_STATUS_TABLE flag is set, returns the current table value. Otherwise
+/// returns target-specific status information.
+///
+/// If DM_NOFLUSH is set, retrieving the target-specific status information for
+/// targets with metadata will not cause a metadata write.
+///
+/// If DM_QUERY_INACTIVE_TABLE is set, instead return the status of the
+/// inactive table.
+///
+/// Valid flags: DM_NOFLUSH, DM_STATUS_TABLE, DM_QUERY_INACTIVE_TABLE
+///
+/// # Example
+///
+/// ```no_run
+/// use devicemapper::{dm, DevId, DmFlags, DmName};
+///
+/// let name = DmName::new("example-dev").expect("is valid DM name");
+/// let id = DevId::Name(name);
+/// let res = dm::table_status(&id, DmFlags::DM_STATUS_TABLE).unwrap();
+/// println!("{} {:?}", res.0.name(), res.1);
+/// ```
+#[allow(type_complexity)]
+pub fn table_status(id: &DevId,
+                    flags: DmFlags)
+                    -> DmResult<(DeviceInfo, Vec<(Sectors, Sectors, TargetTypeBuf, String)>)> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    let clean_flags = (DmFlags::DM_NOFLUSH | DmFlags::DM_STATUS_TABLE |
+                       DmFlags::DM_QUERY_INACTIVE_TABLE) & flags;
+
+    initialize_hdr(&mut hdr, clean_flags);
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
+
+    let data_out = do_ioctl(dmi::DM_TABLE_STATUS_CMD as u8, &mut hdr, None)?;
+
+    let status = parse_table_status(hdr.target_count, &data_out);
+
+    Ok((DeviceInfo::new(hdr), status))
+}
+
+/// Returns a list of each loaded target type with its name, and
+/// version broken into major, minor, and patchlevel.
+pub fn list_versions() -> DmResult<Vec<(String, u32, u32, u32)>> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+
+    initialize_hdr(&mut hdr, DmFlags::empty());
+
+    let data_out = do_ioctl(dmi::DM_LIST_VERSIONS_CMD as u8, &mut hdr, None)?;
+
+    let mut targets = Vec::new();
+    if !data_out.is_empty() {
+        let mut result = &data_out[..];
+
+        loop {
+            let tver = unsafe {
+                (result.as_ptr() as *const dmi::Struct_dm_target_versions)
+                    .as_ref()
+                    .expect("pointer to own structure result can not be NULL")
+            };
+
+            let name_slc = slice_to_null(&result[size_of::<dmi::Struct_dm_target_versions>()..])
+                .expect("kernel data is well-formatted");
+            let name = String::from_utf8_lossy(name_slc).into_owned();
+            targets.push((name, tver.version[0], tver.version[1], tver.version[2]));
+
+            if tver.next == 0 {
+                break;
             }
+
+            result = &result[tver.next as usize..];
         }
-
-        Ok(targets)
     }
 
-    /// Send a message to the device specified by id and the sector
-    /// specified by sector. If sending to the whole device, set sector to
-    /// None.
-    pub fn target_msg(&self,
-                      id: &DevId,
-                      sector: Option<Sectors>,
-                      msg: &str)
-                      -> DmResult<(DeviceInfo, Option<String>)> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+    Ok(targets)
+}
 
-        Self::initialize_hdr(&mut hdr, DmFlags::empty());
-        match *id {
-            DevId::Name(name) => Self::hdr_set_name(&mut hdr, name),
-            DevId::Uuid(uuid) => Self::hdr_set_uuid(&mut hdr, uuid),
-        };
+/// Send a message to the device specified by id and the sector
+/// specified by sector. If sending to the whole device, set sector to
+/// None.
+pub fn target_msg(id: &DevId,
+                  sector: Option<Sectors>,
+                  msg: &str)
+                  -> DmResult<(DeviceInfo, Option<String>)> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
-        let mut msg_struct: dmi::Struct_dm_target_msg = Default::default();
-        msg_struct.sector = *sector.unwrap_or_default();
-        let mut data_in = unsafe {
-            let ptr = &msg_struct as *const dmi::Struct_dm_target_msg as *mut u8;
-            slice::from_raw_parts(ptr, size_of::<dmi::Struct_dm_target_msg>()).to_vec()
-        };
+    initialize_hdr(&mut hdr, DmFlags::empty());
+    match *id {
+        DevId::Name(name) => hdr_set_name(&mut hdr, name),
+        DevId::Uuid(uuid) => hdr_set_uuid(&mut hdr, uuid),
+    };
 
-        data_in.extend(msg.as_bytes());
-        data_in.push(b'\0');
+    let mut msg_struct: dmi::Struct_dm_target_msg = Default::default();
+    msg_struct.sector = *sector.unwrap_or_default();
+    let mut data_in = unsafe {
+        let ptr = &msg_struct as *const dmi::Struct_dm_target_msg as *mut u8;
+        slice::from_raw_parts(ptr, size_of::<dmi::Struct_dm_target_msg>()).to_vec()
+    };
 
-        let data_out = self.do_ioctl(dmi::DM_TARGET_MSG_CMD as u8, &mut hdr, Some(&data_in))?;
+    data_in.extend(msg.as_bytes());
+    data_in.push(b'\0');
 
-        let output = if (hdr.flags & DmFlags::DM_DATA_OUT.bits()) > 0 {
-            Some(String::from_utf8_lossy(&data_out[..data_out.len() - 1]).into_owned())
-        } else {
-            None
-        };
-        Ok((DeviceInfo::new(hdr), output))
-    }
+    let data_out = do_ioctl(dmi::DM_TARGET_MSG_CMD as u8, &mut hdr, Some(&data_in))?;
 
-    /// If DM is being used to poll for events, once it indicates readiness it
-    /// will continue to do so until we rearm it, which is what this method
-    /// does.
-    pub fn arm_poll(&self) -> DmResult<DeviceInfo> {
-        let mut hdr: dmi::Struct_dm_ioctl = Default::default();
+    let output = if (hdr.flags & DmFlags::DM_DATA_OUT.bits()) > 0 {
+        Some(String::from_utf8_lossy(&data_out[..data_out.len() - 1]).into_owned())
+    } else {
+        None
+    };
+    Ok((DeviceInfo::new(hdr), output))
+}
 
-        Self::initialize_hdr(&mut hdr, DmFlags::empty());
+/// If DM is being used to poll for events, once it indicates readiness it
+/// will continue to do so until we rearm it, which is what this method
+/// does.
+pub fn arm_poll() -> DmResult<DeviceInfo> {
+    let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
-        self.do_ioctl(dmi::DM_DEV_ARM_POLL_CMD as u8, &mut hdr, None)?;
+    initialize_hdr(&mut hdr, DmFlags::empty());
 
-        Ok(DeviceInfo::new(hdr))
-    }
+    do_ioctl(dmi::DM_DEV_ARM_POLL_CMD as u8, &mut hdr, None)?;
+
+    Ok(DeviceInfo::new(hdr))
 }
 
 #[cfg(test)]
@@ -769,131 +746,111 @@ mod tests {
     #[test]
     /// Test that some version can be obtained.
     fn sudo_test_version() {
-        assert!(DM::new().unwrap().version().is_ok());
+        assert!(version().is_ok());
     }
 
     #[test]
     /// Test that versions for some targets can be obtained.
     fn sudo_test_versions() {
-        assert!(!DM::new().unwrap().list_versions().unwrap().is_empty());
+        assert!(!list_versions().unwrap().is_empty());
     }
 
     #[test]
     /// Verify that if no devices have been created the list is empty.
     fn sudo_test_list_devices_empty() {
-        assert!(DM::new().unwrap().list_devices().unwrap().is_empty());
+        assert!(list_devices().unwrap().is_empty());
     }
 
     #[test]
     /// Verify that if one device has been created, it will be the only device
     /// listed.
     fn sudo_test_list_devices() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
-        dm.device_create(name, None, DmFlags::empty()).unwrap();
+        device_create(name, None, DmFlags::empty()).unwrap();
 
-        let devices = dm.list_devices().unwrap();
+        let devices = list_devices().unwrap();
 
         assert_eq!(devices.iter().map(|x| x.0.as_ref()).collect::<Vec<_>>(),
                    vec![name]);
         assert_eq!(devices[0].2.unwrap_or(0), 0);
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
     /// Test that device creation gives a device with the expected name.
     fn sudo_test_create() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
-        let result = dm.device_create(name, None, DmFlags::empty()).unwrap();
+        let result = device_create(name, None, DmFlags::empty()).unwrap();
         assert_eq!(result.name(), name);
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
     /// Verify that creation with a UUID results in correct name and UUID.
     fn sudo_test_create_uuid() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
         let uuid = DmUuid::new("example-363333333333333").expect("is valid DM uuid");
-        let result = dm.device_create(name, Some(uuid), DmFlags::empty())
-            .unwrap();
+        let result = device_create(name, Some(uuid), DmFlags::empty()).unwrap();
         assert_eq!(result.name(), name);
         assert_eq!(result.uuid().unwrap(), uuid);
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
     /// Verify that resetting uuid fails.
     fn sudo_test_rename_uuid() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
         let uuid = DmUuid::new("example-363333333333333").expect("is valid DM uuid");
-        dm.device_create(name, Some(uuid), DmFlags::empty())
-            .unwrap();
+        device_create(name, Some(uuid), DmFlags::empty()).unwrap();
 
         let new_uuid = DmUuid::new("example-9999999999").expect("is valid DM uuid");
-        assert!(match dm.device_rename(name, &DevId::Uuid(new_uuid)) {
+        assert!(match device_rename(name, &DevId::Uuid(new_uuid)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
     /// Verify that resetting uuid to same uuid fails.
     fn sudo_test_rename_uuid_id() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
         let uuid = DmUuid::new("example-363333333333333").expect("is valid DM uuid");
-        dm.device_create(name, Some(uuid), DmFlags::empty())
-            .unwrap();
-        assert!(match dm.device_rename(name, &DevId::Uuid(uuid)) {
+        device_create(name, Some(uuid), DmFlags::empty()).unwrap();
+        assert!(match device_rename(name, &DevId::Uuid(uuid)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
     /// Verify that setting a new uuid succeeds.
     /// Note that the uuid is not set in the returned dev_info.
     fn sudo_test_set_uuid() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
-        dm.device_create(name, None, DmFlags::empty()).unwrap();
+        device_create(name, None, DmFlags::empty()).unwrap();
 
         let uuid = DmUuid::new("example-363333333333333").expect("is valid DM uuid");
-        let result = dm.device_rename(name, &DevId::Uuid(uuid)).unwrap();
+        let result = device_rename(name, &DevId::Uuid(uuid)).unwrap();
         assert_eq!(result.uuid(), None);
-        assert_eq!(dm.device_info(&DevId::Name(name))
-                       .unwrap()
-                       .uuid()
-                       .unwrap(),
+        assert_eq!(device_info(&DevId::Name(name)).unwrap().uuid().unwrap(),
                    uuid);
-        assert!(dm.device_info(&DevId::Uuid(uuid)).is_ok());
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        assert!(device_info(&DevId::Uuid(uuid)).is_ok());
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
     /// Test that device rename to same name fails.
     /// This is unfortunate, but appears to be true.
     fn sudo_test_rename_id() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
-        dm.device_create(name, None, DmFlags::empty()).unwrap();
-        assert!(match dm.device_rename(name, &DevId::Name(name)) {
+        device_create(name, None, DmFlags::empty()).unwrap();
+        assert!(match device_rename(name, &DevId::Name(name)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
@@ -901,44 +858,38 @@ mod tests {
     /// Verify that the only device in the list of devices is a device with
     /// the new name.
     fn sudo_test_rename() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
-        dm.device_create(name, None, DmFlags::empty()).unwrap();
+        device_create(name, None, DmFlags::empty()).unwrap();
 
         let new_name = DmName::new("example-dev-2").expect("is valid DM name");
-        dm.device_rename(name, &DevId::Name(new_name)).unwrap();
+        device_rename(name, &DevId::Name(new_name)).unwrap();
 
-        assert!(match dm.device_info(&DevId::Name(name)) {
+        assert!(match device_info(&DevId::Name(name)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        assert!(dm.device_info(&DevId::Name(new_name)).is_ok());
+        assert!(device_info(&DevId::Name(new_name)).is_ok());
 
-        let devices = dm.list_devices().unwrap();
+        let devices = list_devices().unwrap();
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].0.as_ref(), new_name);
 
         let third_name = DmName::new("example-dev-3").expect("is valid DM name");
-        dm.device_create(third_name, None, DmFlags::empty())
-            .unwrap();
-        assert!(match dm.device_rename(new_name, &DevId::Name(third_name)) {
+        device_create(third_name, None, DmFlags::empty()).unwrap();
+        assert!(match device_rename(new_name, &DevId::Name(third_name)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        dm.device_remove(&DevId::Name(third_name), DmFlags::empty())
-            .unwrap();
-        dm.device_remove(&DevId::Name(new_name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(third_name), DmFlags::empty()).unwrap();
+        device_remove(&DevId::Name(new_name), DmFlags::empty()).unwrap();
     }
 
     #[test]
     /// Renaming a device that does not exist yields an error.
     fn sudo_test_rename_non_existant() {
         let new_name = DmName::new("new_name").expect("is valid DM name");
-        assert!(match DM::new()
-                          .unwrap()
-                          .device_rename(DmName::new("old_name").expect("is valid DM name"),
-                                         &DevId::Name(&new_name)) {
+        assert!(match device_rename(DmName::new("old_name").expect("is valid DM name"),
+                                    &DevId::Name(&new_name)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
@@ -947,9 +898,7 @@ mod tests {
     #[test]
     /// Removing a device that does not exist yields an error, unfortunately.
     fn sudo_test_remove_non_existant() {
-        assert!(match DM::new()
-                    .unwrap()
-                    .device_remove(&DevId::Name(DmName::new("junk").expect("is valid DM name")),
+        assert!(match device_remove(&DevId::Name(DmName::new("junk").expect("is valid DM name")),
                                    DmFlags::empty()) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
@@ -959,24 +908,19 @@ mod tests {
     #[test]
     /// A newly created device has no deps.
     fn sudo_test_empty_deps() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
-        dm.device_create(name, None, DmFlags::empty()).unwrap();
+        device_create(name, None, DmFlags::empty()).unwrap();
 
-        let deps = dm.table_deps(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        let deps = table_deps(&DevId::Name(name), DmFlags::empty()).unwrap();
         assert!(deps.is_empty());
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
     /// Table status on a non-existant name should return an error.
     fn sudo_test_table_status_non_existant() {
-        assert!(match DM::new()
-                    .unwrap()
-                    .table_status(&DevId::Name(DmName::new("junk").expect("is valid DM name")),
-                                  DmFlags::empty()) {
+        assert!(match table_status(&DevId::Name(DmName::new("junk").expect("is valid DM name")),
+                                   DmFlags::empty()) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
@@ -986,9 +930,7 @@ mod tests {
     /// Table status on a non-existant name with TABLE_STATUS flag errors.
     fn sudo_test_table_status_non_existant_table() {
         let name = DmName::new("junk").expect("is valid DM name");
-        assert!(match DM::new()
-                          .unwrap()
-                          .table_status(&DevId::Name(name), DmFlags::DM_STATUS_TABLE) {
+        assert!(match table_status(&DevId::Name(name), DmFlags::DM_STATUS_TABLE) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
@@ -1000,18 +942,14 @@ mod tests {
     /// be empty.
     /// The UUID of the returned info should be the device's UUID.
     fn sudo_test_table_status() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
         let uuid = DmUuid::new("uuid").expect("is valid DM UUID");
-        dm.device_create(name, Some(uuid), DmFlags::empty())
-            .unwrap();
+        device_create(name, Some(uuid), DmFlags::empty()).unwrap();
 
-        let status = dm.table_status(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        let status = table_status(&DevId::Name(name), DmFlags::empty()).unwrap();
         assert!(status.1.is_empty());
         assert_eq!(status.0.uuid(), Some(uuid));
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 
     #[test]
@@ -1019,7 +957,7 @@ mod tests {
     /// by name returns an error.
     fn sudo_status_no_name() {
         let name = DmName::new("example_dev").expect("is valid DM name");
-        assert!(match DM::new().unwrap().device_info(&DevId::Name(name)) {
+        assert!(match device_info(&DevId::Name(name)) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
@@ -1029,32 +967,29 @@ mod tests {
     /// Verify that creating a device with the same name twice fails.
     /// Verify that creating a device with the same uuid twice fails.
     fn sudo_test_double_creation() {
-        let dm = DM::new().unwrap();
         let name = DmName::new("example-dev").expect("is valid DM name");
         let uuid = DmUuid::new("uuid").expect("is valid DM UUID");
 
         let name_alt = DmName::new("name-alt").expect("is valid DM name");
         let uuid_alt = DmUuid::new("uuid-alt").expect("is valid DM UUID");
 
-        dm.device_create(name, Some(uuid), DmFlags::empty())
-            .unwrap();
-        assert!(match dm.device_create(name, Some(uuid), DmFlags::empty()) {
+        device_create(name, Some(uuid), DmFlags::empty()).unwrap();
+        assert!(match device_create(name, Some(uuid), DmFlags::empty()) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        assert!(match dm.device_create(name, None, DmFlags::empty()) {
+        assert!(match device_create(name, None, DmFlags::empty()) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        assert!(match dm.device_create(name, Some(uuid_alt), DmFlags::empty()) {
+        assert!(match device_create(name, Some(uuid_alt), DmFlags::empty()) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        assert!(match dm.device_create(name_alt, Some(uuid), DmFlags::empty()) {
+        assert!(match device_create(name_alt, Some(uuid), DmFlags::empty()) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
-        dm.device_remove(&DevId::Name(name), DmFlags::empty())
-            .unwrap();
+        device_remove(&DevId::Name(name), DmFlags::empty()).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@ mod result;
 mod deviceinfo;
 /// contains device major/minor and associated functions
 mod device;
-/// core lower level API
-mod dm;
+/// Core lower level API
+pub mod dm;
 /// DM flags
 mod dm_flags;
 /// functionality shared between devices
@@ -135,7 +135,6 @@ pub use cachedev::{CacheDev, CacheDevPerformance, CacheDevStatus, CacheDevUsage,
                    CacheDevWorkingStatus, MAX_CACHE_BLOCK_SIZE, MIN_CACHE_BLOCK_SIZE};
 pub use consts::{IEC, SECTOR_SIZE};
 pub use device::{Device, devnode_to_devno};
-pub use dm::DM;
 pub use dm_flags::DmFlags;
 pub use lineardev::{FlakeyTargetParams, LinearDev, LinearDevTargetParams, LinearDevTargetTable,
                     LinearTargetParams};

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::DM;
+use super::dm;
 use super::dm_flags::DmFlags;
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, TargetLine, TargetParams, TargetTable, device_create, device_exists,
@@ -405,8 +405,8 @@ impl DmDevice<LinearDevTargetTable> for LinearDev {
         table!(self)
     }
 
-    fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+    fn teardown(self) -> DmResult<()> {
+        dm::device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
 
@@ -436,22 +436,21 @@ impl LinearDev {
     /// the existence of the requested device". Of course, a linear device
     /// is usually expected to hold data, so it is important to get the
     /// mapping just right.
-    pub fn setup(dm: &DM,
-                 name: &DmName,
+    pub fn setup(name: &DmName,
                  uuid: Option<&DmUuid>,
                  table: Vec<TargetLine<LinearDevTargetParams>>)
                  -> DmResult<LinearDev> {
         let table = LinearDevTargetTable::new(table);
-        let dev = if device_exists(dm, name)? {
-            let dev_info = dm.device_info(&DevId::Name(name))?;
+        let dev = if device_exists(name)? {
+            let dev_info = dm::device_info(&DevId::Name(name))?;
             let dev = LinearDev {
                 dev_info: Box::new(dev_info),
                 table,
             };
-            device_match(dm, &dev, uuid)?;
+            device_match(&dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table)?;
+            let dev_info = device_create(name, uuid, &table)?;
             LinearDev {
                 dev_info: Box::new(dev_info),
                 table,
@@ -466,24 +465,21 @@ impl LinearDev {
     /// segments are compatible with the device's existing segments.
     /// If they are not, this function will still succeed, but some kind of
     /// data corruption will be the inevitable result.
-    pub fn set_table(&mut self,
-                     dm: &DM,
-                     table: Vec<TargetLine<LinearDevTargetParams>>)
-                     -> DmResult<()> {
+    pub fn set_table(&mut self, table: Vec<TargetLine<LinearDevTargetParams>>) -> DmResult<()> {
         let table = LinearDevTargetTable::new(table);
-        self.suspend(dm, false)?;
-        self.table_load(dm, &table)?;
+        self.suspend(false)?;
+        self.table_load(&table)?;
         self.table = table;
         Ok(())
     }
 
     /// Set the name for this LinearDev.
-    pub fn set_name(&mut self, dm: &DM, name: &DmName) -> DmResult<()> {
+    pub fn set_name(&mut self, name: &DmName) -> DmResult<()> {
         if self.name() == name {
             return Ok(());
         }
-        dm.device_rename(self.name(), &DevId::Name(name))?;
-        self.dev_info = Box::new(dm.device_info(&DevId::Name(name))?);
+        dm::device_rename(self.name(), &DevId::Name(name))?;
+        self.dev_info = Box::new(dm::device_info(&DevId::Name(name))?);
         Ok(())
     }
 }
@@ -501,73 +497,66 @@ mod tests {
 
     /// Verify that a new linear dev with 0 segments fails.
     fn test_empty(_paths: &[&Path]) -> () {
-        assert!(LinearDev::setup(&DM::new().unwrap(),
-                                 DmName::new("new").expect("valid format"),
-                                 None,
-                                 vec![])
-                        .is_err());
+        assert!(LinearDev::setup(DmName::new("new").expect("valid format"), None, vec![]).is_err());
     }
 
     /// Verify that setting an empty table on an existing DM device fails.
     fn test_empty_table_set(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let mut ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
+        let mut ld = LinearDev::setup(DmName::new(name).expect("valid format"), None, table)
             .unwrap();
 
-        assert!(ld.set_table(&dm, vec![]).is_err());
-        ld.resume(&dm).unwrap();
-        ld.teardown(&dm).unwrap();
+        assert!(ld.set_table(vec![]).is_err());
+        ld.resume().unwrap();
+        ld.teardown().unwrap();
     }
 
     /// Verify that id rename succeeds.
     fn test_rename_id(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let mut ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
+        let mut ld = LinearDev::setup(DmName::new(name).expect("valid format"), None, table)
             .unwrap();
 
-        ld.set_name(&dm, DmName::new(name).expect("valid format"))
+        ld.set_name(DmName::new(name).expect("valid format"))
             .unwrap();
         assert_eq!(ld.name(), DmName::new(name).expect("valid format"));
 
-        ld.teardown(&dm).unwrap();
+        ld.teardown().unwrap();
     }
 
     /// Verify that after a rename, the device has the new name.
     fn test_rename(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let mut ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
+        let mut ld = LinearDev::setup(DmName::new(name).expect("valid format"), None, table)
             .unwrap();
 
         let new_name = "new_name";
-        ld.set_name(&dm, DmName::new(new_name).expect("valid format"))
+        ld.set_name(DmName::new(new_name).expect("valid format"))
             .unwrap();
         assert_eq!(ld.name(), DmName::new(new_name).expect("valid format"));
 
-        ld.teardown(&dm).unwrap();
+        ld.teardown().unwrap();
     }
 
     /// Verify that passing the same segments two times gets two segments.
@@ -577,7 +566,6 @@ mod tests {
     fn test_duplicate_segments(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
@@ -589,10 +577,9 @@ mod tests {
                                          LinearDevTargetParams::Linear(params))];
         let range: Sectors = table.iter().map(|s| s.length).sum();
         let count = table.len();
-        let ld = LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
-            .unwrap();
+        let ld = LinearDev::setup(DmName::new(name).expect("valid format"), None, table).unwrap();
 
-        let table = LinearDev::read_kernel_table(&dm, &DevId::Name(ld.name()))
+        let table = LinearDev::read_kernel_table(&DevId::Name(ld.name()))
             .unwrap()
             .table;
         assert_eq!(table.len(), count);
@@ -612,7 +599,7 @@ mod tests {
                            .sectors(),
                    range);
 
-        ld.teardown(&dm).unwrap();
+        ld.teardown().unwrap();
     }
 
     /// Use five segments, each distinct. If parsing works correctly,
@@ -620,7 +607,6 @@ mod tests {
     fn test_several_segments(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let table = (0..5)
@@ -631,17 +617,16 @@ mod tests {
                                                                                       Sectors(n))))
                  })
             .collect::<Vec<_>>();
-        let ld = LinearDev::setup(&dm,
-                                  DmName::new(name).expect("valid format"),
+        let ld = LinearDev::setup(DmName::new(name).expect("valid format"),
                                   None,
                                   table.clone())
                 .unwrap();
 
-        let loaded_table = LinearDev::read_kernel_table(&dm, &DevId::Name(ld.name())).unwrap();
+        let loaded_table = LinearDev::read_kernel_table(&DevId::Name(ld.name())).unwrap();
         assert!(LinearDev::equivalent_tables(&LinearDevTargetTable::new(table), &loaded_table)
                     .unwrap());
 
-        ld.teardown(&dm).unwrap();
+        ld.teardown().unwrap();
     }
 
     /// Verify that constructing a second dev with the same name succeeds
@@ -649,15 +634,13 @@ mod tests {
     fn test_same_name(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
         let name = "name";
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let ld = LinearDev::setup(&dm,
-                                  DmName::new(name).expect("valid format"),
+        let ld = LinearDev::setup(DmName::new(name).expect("valid format"),
                                   None,
                                   table.clone())
                 .unwrap();
@@ -665,57 +648,49 @@ mod tests {
         let table2 = vec![TargetLine::new(Sectors(0),
                                           Sectors(1),
                                           LinearDevTargetParams::Linear(params2))];
-        assert!(LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table2)
-                    .is_err());
-        assert!(LinearDev::setup(&dm, DmName::new(name).expect("valid format"), None, table)
-                    .is_ok());
-        ld.teardown(&dm).unwrap();
+        assert!(LinearDev::setup(DmName::new(name).expect("valid format"), None, table2).is_err());
+        assert!(LinearDev::setup(DmName::new(name).expect("valid format"), None, table).is_ok());
+        ld.teardown().unwrap();
     }
 
     /// Verify constructing a second linear dev with the same segment succeeds.
     fn test_same_segment(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let ld = LinearDev::setup(&dm,
-                                  DmName::new("name").expect("valid format"),
+        let ld = LinearDev::setup(DmName::new("name").expect("valid format"),
                                   None,
                                   table.clone())
                 .unwrap();
-        let ld2 = LinearDev::setup(&dm,
-                                   DmName::new("ersatz").expect("valid format"),
-                                   None,
-                                   table);
+        let ld2 = LinearDev::setup(DmName::new("ersatz").expect("valid format"), None, table);
         assert!(ld2.is_ok());
 
-        ld2.unwrap().teardown(&dm).unwrap();
-        ld.teardown(&dm).unwrap();
+        ld2.unwrap().teardown().unwrap();
+        ld.teardown().unwrap();
     }
 
     /// Verify that suspending and immediately resuming doesn't fail.
     fn test_suspend(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
         let dev = Device::from(devnode_to_devno(&paths[0]).unwrap().unwrap());
         let params = LinearTargetParams::new(dev, Sectors(0));
         let table = vec![TargetLine::new(Sectors(0),
                                          Sectors(1),
                                          LinearDevTargetParams::Linear(params))];
-        let mut ld = LinearDev::setup(&dm, DmName::new("name").expect("valid format"), None, table)
+        let mut ld = LinearDev::setup(DmName::new("name").expect("valid format"), None, table)
             .unwrap();
 
-        ld.suspend(&dm, false).unwrap();
-        ld.suspend(&dm, false).unwrap();
-        ld.resume(&dm).unwrap();
-        ld.resume(&dm).unwrap();
+        ld.suspend(false).unwrap();
+        ld.suspend(false).unwrap();
+        ld.resume().unwrap();
+        ld.resume().unwrap();
 
-        ld.teardown(&dm).unwrap();
+        ld.teardown().unwrap();
     }
 
     #[test]

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -11,7 +11,8 @@ use std::str::FromStr;
 
 use super::device::{Device, devnode_to_devno};
 use super::deviceinfo::DeviceInfo;
-use super::dm::DM;
+use super::dm;
+
 use super::dm_flags::DmFlags;
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::types::{DevId, DmName, DmUuid, Sectors, TargetTypeBuf};
@@ -72,8 +73,8 @@ pub trait DmDevice<T: TargetTable> {
     fn equivalent_tables(left: &T, right: &T) -> DmResult<bool>;
 
     /// Read the devicemapper table
-    fn read_kernel_table(dm: &DM, id: &DevId) -> DmResult<T> {
-        let (_, table) = dm.table_status(id, DmFlags::DM_STATUS_TABLE)?;
+    fn read_kernel_table(id: &DevId) -> DmResult<T> {
+        let (_, table) = dm::table_status(id, DmFlags::DM_STATUS_TABLE)?;
         T::from_raw_table(&table)
     }
 
@@ -81,8 +82,8 @@ pub trait DmDevice<T: TargetTable> {
     fn name(&self) -> &DmName;
 
     /// Resume I/O on the device.
-    fn resume(&mut self, dm: &DM) -> DmResult<()> {
-        dm.device_suspend(&DevId::Name(self.name()), DmFlags::empty())?;
+    fn resume(&mut self) -> DmResult<()> {
+        dm::device_suspend(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
 
@@ -90,13 +91,13 @@ pub trait DmDevice<T: TargetTable> {
     fn size(&self) -> Sectors;
 
     /// Suspend I/O on the device. If flush is true, flush the device first.
-    fn suspend(&mut self, dm: &DM, flush: bool) -> DmResult<()> {
+    fn suspend(&mut self, flush: bool) -> DmResult<()> {
         let flags = if flush {
             DmFlags::DM_SUSPEND
         } else {
             DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH
         };
-        dm.device_suspend(&DevId::Name(self.name()), flags)?;
+        dm::device_suspend(&DevId::Name(self.name()), flags)?;
         Ok(())
     }
 
@@ -104,13 +105,13 @@ pub trait DmDevice<T: TargetTable> {
     fn table(&self) -> &T;
 
     /// Load a table
-    fn table_load(&self, dm: &DM, table: &T) -> DmResult<()> {
-        dm.table_load(&DevId::Name(self.name()), &table.to_raw_table())?;
+    fn table_load(&self, table: &T) -> DmResult<()> {
+        dm::table_load(&DevId::Name(self.name()), &table.to_raw_table())?;
         Ok(())
     }
 
     /// Erase the kernel's memory of this device.
-    fn teardown(self, dm: &DM) -> DmResult<()>;
+    fn teardown(self) -> DmResult<()>;
 
     /// The device's UUID, if available.
     /// Note that the UUID is not any standard UUID format.
@@ -118,38 +119,36 @@ pub trait DmDevice<T: TargetTable> {
 }
 
 /// Send a message that expects no reply to target device.
-pub fn message<T: TargetTable, D: DmDevice<T>>(dm: &DM, target: &D, msg: &str) -> DmResult<()> {
-    dm.target_msg(&DevId::Name(target.name()), None, msg)?;
+pub fn message<T: TargetTable, D: DmDevice<T>>(target: &D, msg: &str) -> DmResult<()> {
+    dm::target_msg(&DevId::Name(target.name()), None, msg)?;
     Ok(())
 }
 
 /// Create a device, load a table, and resume it.
-pub fn device_create<T: TargetTable>(dm: &DM,
-                                     name: &DmName,
+pub fn device_create<T: TargetTable>(name: &DmName,
                                      uuid: Option<&DmUuid>,
                                      table: &T)
                                      -> DmResult<DeviceInfo> {
-    dm.device_create(name, uuid, DmFlags::empty())?;
+    dm::device_create(name, uuid, DmFlags::empty())?;
 
     let id = DevId::Name(name);
-    let dev_info = match dm.table_load(&id, &table.to_raw_table()) {
+    let dev_info = match dm::table_load(&id, &table.to_raw_table()) {
         Err(e) => {
-            dm.device_remove(&id, DmFlags::empty())?;
+            dm::device_remove(&id, DmFlags::empty())?;
             return Err(e);
         }
         Ok(dev_info) => dev_info,
     };
-    dm.device_suspend(&id, DmFlags::empty())?;
+    dm::device_suspend(&id, DmFlags::empty())?;
 
     Ok(dev_info)
 }
 
 /// Verify that kernel data matches arguments passed.
-pub fn device_match<T: TargetTable, D: DmDevice<T>>(dm: &DM,
-                                                    dev: &D,
+pub fn device_match<T: TargetTable, D: DmDevice<T>>(dev: &D,
                                                     uuid: Option<&DmUuid>)
                                                     -> DmResult<()> {
-    let kernel_table = D::read_kernel_table(dm, &DevId::Name(dev.name()))?;
+    let kernel_table = D::read_kernel_table(&DevId::Name(dev.name()))?;
     let device_table = dev.table();
     if !D::equivalent_tables(&kernel_table, device_table)? {
         let err_msg = format!("Specified new table \"{:?}\" does not match kernel table \"{:?}\"",
@@ -170,10 +169,10 @@ pub fn device_match<T: TargetTable, D: DmDevice<T>>(dm: &DM,
 }
 
 /// Check if a device of the given name exists.
-pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
+pub fn device_exists(name: &DmName) -> DmResult<bool> {
     // TODO: Why do we have to call .as_ref() here instead of relying on deref
     // coercion?
-    Ok(dm.list_devices()
+    Ok(dm::list_devices()
            .map(|l| l.iter().any(|&(ref n, _, _)| n.as_ref() == name))?)
 }
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
-use super::dm::DM;
+use super::dm;
 use super::dm_flags::DmFlags;
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{DmDevice, TargetLine, TargetParams, TargetTable, device_create, device_exists,
@@ -159,8 +159,8 @@ impl DmDevice<ThinDevTargetTable> for ThinDev {
         table!(self)
     }
 
-    fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+    fn teardown(self) -> DmResult<()> {
+        dm::device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
         Ok(())
     }
 
@@ -206,24 +206,23 @@ impl ThinDev {
     /// If the specified thin_id is already in use by the thin pool an error
     /// is returned. If the device is already among the list of devices that
     /// dm is aware of, return an error.
-    pub fn new(dm: &DM,
-               name: &DmName,
+    pub fn new(name: &DmName,
                uuid: Option<&DmUuid>,
                length: Sectors,
                thin_pool: &ThinPoolDev,
                thin_id: ThinDevId)
                -> DmResult<ThinDev> {
 
-        message(dm, thin_pool, &format!("create_thin {}", thin_id))?;
+        message(thin_pool, &format!("create_thin {}", thin_id))?;
 
-        if device_exists(dm, name)? {
+        if device_exists(name)? {
             let err_msg = "Uncreated device should not be known to kernel";
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg.into()));
         }
 
         let thin_pool_device = thin_pool.device();
         let table = ThinDev::gen_default_table(length, thin_pool_device, thin_id);
-        let dev_info = device_create(dm, name, uuid, &table)?;
+        let dev_info = device_create(name, uuid, &table)?;
 
         Ok(ThinDev {
                dev_info: Box::new(dev_info),
@@ -240,8 +239,7 @@ impl ThinDev {
     ///
     /// If the device has no thin id already registered with the thin pool
     /// an error is returned.
-    pub fn setup(dm: &DM,
-                 name: &DmName,
+    pub fn setup(name: &DmName,
                  uuid: Option<&DmUuid>,
                  length: Sectors,
                  thin_pool: &ThinPoolDev,
@@ -250,16 +248,16 @@ impl ThinDev {
 
         let thin_pool_device = thin_pool.device();
         let table = ThinDev::gen_default_table(length, thin_pool_device, thin_id);
-        let dev = if device_exists(dm, name)? {
-            let dev_info = dm.device_info(&DevId::Name(name))?;
+        let dev = if device_exists(name)? {
+            let dev_info = dm::device_info(&DevId::Name(name))?;
             let dev = ThinDev {
                 dev_info: Box::new(dev_info),
                 table,
             };
-            device_match(dm, &dev, uuid)?;
+            device_match(&dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table)?;
+            let dev_info = device_create(name, uuid, &table)?;
             ThinDev {
                 dev_info: Box::new(dev_info),
                 table,
@@ -274,22 +272,20 @@ impl ThinDev {
     /// no need to track any connection between the source and the
     /// snapshot.
     pub fn snapshot(&self,
-                    dm: &DM,
                     snapshot_name: &DmName,
                     snapshot_uuid: Option<&DmUuid>,
                     thin_pool: &ThinPoolDev,
                     snapshot_thin_id: ThinDevId)
                     -> DmResult<ThinDev> {
         let source_id = DevId::Name(self.name());
-        dm.device_suspend(&source_id, DmFlags::DM_SUSPEND)?;
-        message(dm,
-                thin_pool,
+        dm::device_suspend(&source_id, DmFlags::DM_SUSPEND)?;
+        message(thin_pool,
                 &format!("create_snap {} {}",
                          snapshot_thin_id,
                          self.table.table.params.thin_id))?;
-        dm.device_suspend(&source_id, DmFlags::empty())?;
+        dm::device_suspend(&source_id, DmFlags::empty())?;
         let table = ThinDev::gen_default_table(self.size(), thin_pool.device(), snapshot_thin_id);
-        let dev_info = Box::new(device_create(dm, snapshot_name, snapshot_uuid, &table)?);
+        let dev_info = Box::new(device_create(snapshot_name, snapshot_uuid, &table)?);
         Ok(ThinDev { dev_info, table })
     }
 
@@ -315,8 +311,8 @@ impl ThinDev {
     }
 
     /// Get the current status of the thin device.
-    pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
-        let (_, table) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
+    pub fn status(&self) -> DmResult<ThinStatus> {
+        let (_, table) = dm::table_status(&DevId::Name(self.name()), DmFlags::empty())?;
 
         assert_eq!(table.len(),
                    1,
@@ -348,11 +344,11 @@ impl ThinDev {
     }
 
     /// Set the table for the thin device's target
-    pub fn set_table(&mut self, dm: &DM, table: TargetLine<ThinTargetParams>) -> DmResult<()> {
+    pub fn set_table(&mut self, table: TargetLine<ThinTargetParams>) -> DmResult<()> {
         let table = ThinDevTargetTable::new(table.start, table.length, table.params);
-        self.suspend(dm, false)?;
-        self.table_load(dm, &table)?;
-        self.resume(dm)?;
+        self.suspend(false)?;
+        self.table_load(&table)?;
+        self.resume()?;
 
         self.table = table;
         Ok(())
@@ -360,10 +356,10 @@ impl ThinDev {
 
     /// Tear down the DM device, and also delete resources associated
     /// with its thin id from the thinpool.
-    pub fn destroy(self, dm: &DM, thin_pool: &ThinPoolDev) -> DmResult<()> {
+    pub fn destroy(self, thin_pool: &ThinPoolDev) -> DmResult<()> {
         let thin_id = self.table.table.params.thin_id;
-        self.teardown(dm)?;
-        message(dm, thin_pool, &format!("delete {}", thin_id))?;
+        self.teardown()?;
+        message(thin_pool, &format!("delete {}", thin_id))?;
         Ok(())
     }
 }
@@ -396,17 +392,16 @@ mod tests {
     fn test_zero_size(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
-        let tp = minimal_thinpool(&dm, paths[0]);
 
-        assert!(ThinDev::new(&dm,
-                             &DmName::new("name").expect("is valid DM name"),
+        let tp = minimal_thinpool(paths[0]);
+
+        assert!(ThinDev::new(&DmName::new("name").expect("is valid DM name"),
                              None,
                              Sectors(0),
                              &tp,
                              ThinDevId::new_u64(0).expect("is below limit"))
                         .is_err());
-        tp.teardown(&dm).unwrap();
+        tp.teardown().unwrap();
     }
 
     /// Verify that setting up a thin device without first calling new()
@@ -416,12 +411,10 @@ mod tests {
     fn test_setup_without_new(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
-        let tp = minimal_thinpool(&dm, paths[0]);
+        let tp = minimal_thinpool(paths[0]);
 
         let td_size = MIN_THIN_DEV_SIZE;
-        assert!(match ThinDev::setup(&dm,
-                                     &DmName::new("name").expect("is valid DM name"),
+        assert!(match ThinDev::setup(&DmName::new("name").expect("is valid DM name"),
                                      None,
                                      td_size,
                                      &tp,
@@ -430,7 +423,7 @@ mod tests {
                     _ => false,
                 });
 
-        tp.teardown(&dm).unwrap();
+        tp.teardown().unwrap();
     }
 
     /// Verify success when constructing a new ThinDev. Check that the
@@ -444,22 +437,21 @@ mod tests {
     fn test_basic(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
 
-        let dm = DM::new().unwrap();
-        let tp = minimal_thinpool(&dm, paths[0]);
+        let tp = minimal_thinpool(paths[0]);
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
         let id = DmName::new("name").expect("is valid DM name");
 
         let td_size = MIN_THIN_DEV_SIZE;
-        let td = ThinDev::new(&dm, &id, None, td_size, &tp, thin_id).unwrap();
+        let td = ThinDev::new(&id, None, td_size, &tp, thin_id).unwrap();
 
-        let table = ThinDev::read_kernel_table(&dm, &DevId::Name(td.name()))
+        let table = ThinDev::read_kernel_table(&DevId::Name(td.name()))
             .unwrap()
             .table;
 
         assert_eq!(table.params.pool, tp.device());
         assert_eq!(table.params.thin_id, thin_id);
 
-        assert!(match td.status(&dm).unwrap() {
+        assert!(match td.status().unwrap() {
                     ThinStatus::Fail => false,
                     _ => true,
                 });
@@ -471,31 +463,31 @@ mod tests {
                    td_size.bytes());
 
         // New thindev w/ same id fails.
-        assert!(match ThinDev::new(&dm, &id, None, td_size, &tp, thin_id) {
+        assert!(match ThinDev::new(&id, None, td_size, &tp, thin_id) {
                     Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                     _ => false,
                 });
 
         // Verify that the device of that name does exist.
-        assert!(device_exists(&dm, id).unwrap());
+        assert!(device_exists(id).unwrap());
 
         // Setting up the just created thin dev succeeds.
-        assert!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).is_ok());
+        assert!(ThinDev::setup(&id, None, td_size, &tp, thin_id).is_ok());
 
         // Setting up the just created thin dev once more succeeds.
-        assert!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).is_ok());
+        assert!(ThinDev::setup(&id, None, td_size, &tp, thin_id).is_ok());
 
         // Teardown the thindev, then set it back up.
-        td.teardown(&dm).unwrap();
-        let mut td = ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).unwrap();
+        td.teardown().unwrap();
+        let mut td = ThinDev::setup(&id, None, td_size, &tp, thin_id).unwrap();
 
-        td.suspend(&dm, false).unwrap();
-        td.suspend(&dm, false).unwrap();
-        td.resume(&dm).unwrap();
-        td.resume(&dm).unwrap();
+        td.suspend(false).unwrap();
+        td.suspend(false).unwrap();
+        td.resume().unwrap();
+        td.resume().unwrap();
 
-        td.destroy(&dm, &tp).unwrap();
-        tp.teardown(&dm).unwrap();
+        td.destroy(&tp).unwrap();
+        tp.teardown().unwrap();
     }
 
     /// Verify success when taking a snapshot of a ThinDev.  Check that
@@ -504,10 +496,9 @@ mod tests {
     fn test_snapshot(paths: &[&Path]) -> () {
         assert!(paths.len() >= 1);
         let td_size = MIN_THIN_DEV_SIZE;
-        let dm = DM::new().unwrap();
-        let tp = minimal_thinpool(&dm, paths[0]);
+        let tp = minimal_thinpool(paths[0]);
 
-        let orig_data_usage = match tp.status(&dm).unwrap() {
+        let orig_data_usage = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -517,9 +508,9 @@ mod tests {
         // Create new ThinDev as source for snapshot
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
         let thin_name = DmName::new("name").expect("is valid DM name");
-        let td = ThinDev::new(&dm, &thin_name, None, td_size, &tp, thin_id).unwrap();
+        let td = ThinDev::new(&thin_name, None, td_size, &tp, thin_id).unwrap();
 
-        let data_usage_1 = match tp.status(&dm).unwrap() {
+        let data_usage_1 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -529,9 +520,9 @@ mod tests {
         // Create a snapshot of the source
         let ss_id = ThinDevId::new_u64(1).expect("is below limit");
         let ss_name = DmName::new("snap_name").expect("is valid DM name");
-        let ss = td.snapshot(&dm, ss_name, None, &tp, ss_id).unwrap();
+        let ss = td.snapshot(ss_name, None, &tp, ss_id).unwrap();
 
-        let data_usage_2 = match tp.status(&dm).unwrap() {
+        let data_usage_2 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -541,9 +532,9 @@ mod tests {
         // Verify the source and the snapshot are the same size.
         assert_eq!(td.size(), ss.size());
 
-        ss.destroy(&dm, &tp).unwrap();
-        td.destroy(&dm, &tp).unwrap();
-        tp.teardown(&dm).unwrap();
+        ss.destroy(&tp).unwrap();
+        td.destroy(&tp).unwrap();
+        tp.teardown().unwrap();
     }
 
     /// Verify no failures when creating a thindev from a pool, mounting a
@@ -552,14 +543,13 @@ mod tests {
     fn test_filesystem(paths: &[&Path]) -> () {
         assert!(paths.len() > 0);
 
-        let dm = DM::new().unwrap();
-        let tp = minimal_thinpool(&dm, paths[0]);
+        let tp = minimal_thinpool(paths[0]);
 
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
         let thin_name = DmName::new("name").expect("is valid DM name");
-        let td = ThinDev::new(&dm, &thin_name, None, tp.size(), &tp, thin_id).unwrap();
+        let td = ThinDev::new(&thin_name, None, tp.size(), &tp, thin_id).unwrap();
 
-        let orig_data_usage = match tp.status(&dm).unwrap() {
+        let orig_data_usage = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -572,7 +562,7 @@ mod tests {
             .status()
             .unwrap();
 
-        let data_usage_1 = match tp.status(&dm).unwrap() {
+        let data_usage_1 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -598,14 +588,14 @@ mod tests {
         }
         umount2(tmp_dir.path(), MntFlags::MNT_DETACH).unwrap();
 
-        let data_usage_2 = match tp.status(&dm).unwrap() {
+        let data_usage_2 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
         assert!(data_usage_2 > data_usage_1);
 
-        td.destroy(&dm, &tp).unwrap();
-        tp.teardown(&dm).unwrap();
+        td.destroy(&tp).unwrap();
+        tp.teardown().unwrap();
     }
 
     /// Verify reasonable usage behavior when taking a snapshot of a thindev
@@ -619,14 +609,13 @@ mod tests {
     fn test_snapshot_usage(paths: &[&Path]) -> () {
         assert!(paths.len() > 0);
 
-        let dm = DM::new().unwrap();
-        let tp = minimal_thinpool(&dm, paths[0]);
+        let tp = minimal_thinpool(paths[0]);
 
         let thin_id = ThinDevId::new_u64(0).expect("is below limit");
         let thin_name = DmName::new("name").expect("is valid DM name");
-        let td = ThinDev::new(&dm, &thin_name, None, Sectors(2 * IEC::Mi), &tp, thin_id).unwrap();
+        let td = ThinDev::new(&thin_name, None, Sectors(2 * IEC::Mi), &tp, thin_id).unwrap();
 
-        let orig_data_usage = match tp.status(&dm).unwrap() {
+        let orig_data_usage = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -639,7 +628,7 @@ mod tests {
             .status()
             .unwrap();
 
-        let data_usage_1 = match tp.status(&dm).unwrap() {
+        let data_usage_1 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -649,10 +638,9 @@ mod tests {
         let ss_id = ThinDevId::new_u64(1).expect("is below limit");
         let ss_name = DmName::new("snap_name").expect("is valid DM name");
         let ss_uuid = DmUuid::new("snap_uuid").expect("is valid DM uuid");
-        let ss = td.snapshot(&dm, ss_name, Some(ss_uuid), &tp, ss_id)
-            .unwrap();
+        let ss = td.snapshot(ss_name, Some(ss_uuid), &tp, ss_id).unwrap();
 
-        let data_usage_2 = match tp.status(&dm).unwrap() {
+        let data_usage_2 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -668,7 +656,7 @@ mod tests {
         // Setting the uuid of the snapshot filesystem bumps the usage,
         // but does not increase the usage quite as much as establishing
         // the origin.
-        let data_usage_3 = match tp.status(&dm).unwrap() {
+        let data_usage_3 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -678,9 +666,9 @@ mod tests {
 
         let thin_id = ThinDevId::new_u64(2).expect("is below limit");
         let thin_name = DmName::new("name1").expect("is valid DM name");
-        let td1 = ThinDev::new(&dm, &thin_name, None, Sectors(2 * IEC::Gi), &tp, thin_id).unwrap();
+        let td1 = ThinDev::new(&thin_name, None, Sectors(2 * IEC::Gi), &tp, thin_id).unwrap();
 
-        let data_usage_4 = match tp.status(&dm).unwrap() {
+        let data_usage_4 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
@@ -693,16 +681,16 @@ mod tests {
             .status()
             .unwrap();
 
-        let data_usage_5 = match tp.status(&dm).unwrap() {
+        let data_usage_5 = match tp.status().unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
         };
         assert!(data_usage_5 - data_usage_4 > 32usize * data_usage_1);
 
-        ss.destroy(&dm, &tp).unwrap();
-        td1.destroy(&dm, &tp).unwrap();
-        td.destroy(&dm, &tp).unwrap();
-        tp.teardown(&dm).unwrap();
+        ss.destroy(&tp).unwrap();
+        td1.destroy(&tp).unwrap();
+        td.destroy(&tp).unwrap();
+        tp.teardown().unwrap();
     }
 
 


### PR DESCRIPTION
This change eliminates the need for struct DM, in favor of just opening
/dev/mapper/control for each ioctl call.  Previous stratisd changes have
introduced a singleton to allow code to fetch a reference as needed to
remove passing the dm structure reference around as much.  This change takes
it one last step by simply removing the structure all together and thus
removing the need for the singleton and passing the structure reference
around in the remaining places.  This change results in a significant
simplification to the public device mapper API design and reduces
public facing API coupling.

Signed-off-by: Tony Asleson <tasleson@redhat.com>