### PR TITLE
Add DmOptions builder

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -450,7 +450,7 @@ impl DmDevice<CacheDevTargetTable> for CacheDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), &DmOptions::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         self.cache_dev.teardown(dm)?;
         self.origin_dev.teardown(dm)?;
         self.meta_dev.teardown(dm)?;
@@ -629,7 +629,7 @@ impl CacheDev {
     // Note: This method is not entirely complete. In particular, *_args values
     // may require more or better checking or processing.
     pub fn status(&self, dm: &DM) -> DmResult<CacheDevStatus> {
-        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::empty())?;
+        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
 
         assert_eq!(
             status.len(),

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::DM;
-use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::lineardev::{LinearDev, LinearDevTargetParams};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{device_create, device_exists, device_match, parse_device, DmDevice,
@@ -450,7 +450,7 @@ impl DmDevice<CacheDevTargetTable> for CacheDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::empty())?;
         self.cache_dev.teardown(dm)?;
         self.origin_dev.teardown(dm)?;
         self.meta_dev.teardown(dm)?;
@@ -629,7 +629,7 @@ impl CacheDev {
     // Note: This method is not entirely complete. In particular, *_args values
     // may require more or better checking or processing.
     pub fn status(&self, dm: &DM) -> DmResult<CacheDevStatus> {
-        let (_, status) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
+        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::empty())?;
 
         assert_eq!(
             status.len(),

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -274,7 +274,7 @@ impl DM {
     ///
     /// // Setting a uuid is optional
     /// let name = DmName::new("example-dev").expect("is valid DM name");
-    /// let dev = dm.device_create(name, None, &DmOptions::empty()).unwrap();
+    /// let dev = dm.device_create(name, None, &DmOptions::new()).unwrap();
     /// ```
     pub fn device_create(
         &self,
@@ -745,7 +745,7 @@ mod tests {
     fn sudo_test_list_devices() {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
-        dm.device_create(&name, None, &DmOptions::empty()).unwrap();
+        dm.device_create(&name, None, &DmOptions::new()).unwrap();
 
         let devices = dm.list_devices().unwrap();
 
@@ -754,7 +754,7 @@ mod tests {
             vec![&*name]
         );
         assert_eq!(devices[0].2.unwrap_or(0), 0);
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -763,9 +763,9 @@ mod tests {
     fn sudo_test_create() {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
-        let result = dm.device_create(&name, None, &DmOptions::empty()).unwrap();
+        let result = dm.device_create(&name, None, &DmOptions::new()).unwrap();
         assert_eq!(result.name(), &*name);
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -775,11 +775,11 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
         let uuid = test_uuid("example-363333333333333").expect("is valid DM uuid");
-        let result = dm.device_create(&name, Some(&uuid), &DmOptions::empty())
+        let result = dm.device_create(&name, Some(&uuid), &DmOptions::new())
             .unwrap();
         assert_eq!(result.name(), &*name);
         assert_eq!(result.uuid().unwrap(), &*uuid);
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -789,7 +789,7 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
         let uuid = test_uuid("example-363333333333333").expect("is valid DM uuid");
-        dm.device_create(&name, Some(&uuid), &DmOptions::empty())
+        dm.device_create(&name, Some(&uuid), &DmOptions::new())
             .unwrap();
 
         let new_uuid = test_uuid("example-9999999999").expect("is valid DM uuid");
@@ -797,7 +797,7 @@ mod tests {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
         });
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -807,13 +807,13 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
         let uuid = test_uuid("example-363333333333333").expect("is valid DM uuid");
-        dm.device_create(&name, Some(&uuid), &DmOptions::empty())
+        dm.device_create(&name, Some(&uuid), &DmOptions::new())
             .unwrap();
         assert!(match dm.device_rename(&name, &DevId::Uuid(&uuid)) {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
         });
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -823,7 +823,7 @@ mod tests {
     fn sudo_test_set_uuid() {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
-        dm.device_create(&name, None, &DmOptions::empty()).unwrap();
+        dm.device_create(&name, None, &DmOptions::new()).unwrap();
 
         let uuid = test_uuid("example-363333333333333").expect("is valid DM uuid");
         let result = dm.device_rename(&name, &DevId::Uuid(&uuid)).unwrap();
@@ -833,7 +833,7 @@ mod tests {
             &*uuid
         );
         assert!(dm.device_info(&DevId::Uuid(&uuid)).is_ok());
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -843,12 +843,12 @@ mod tests {
     fn sudo_test_rename_id() {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
-        dm.device_create(&name, None, &DmOptions::empty()).unwrap();
+        dm.device_create(&name, None, &DmOptions::new()).unwrap();
         assert!(match dm.device_rename(&name, &DevId::Name(&name)) {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
         });
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -859,7 +859,7 @@ mod tests {
     fn sudo_test_rename() {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
-        dm.device_create(&name, None, &DmOptions::empty()).unwrap();
+        dm.device_create(&name, None, &DmOptions::new()).unwrap();
 
         let new_name = test_name("example-dev-2").expect("is valid DM name");
         dm.device_rename(&name, &DevId::Name(&new_name)).unwrap();
@@ -875,7 +875,7 @@ mod tests {
         assert_eq!(devices[0].0.as_ref(), &*new_name);
 
         let third_name = test_name("example-dev-3").expect("is valid DM name");
-        dm.device_create(&third_name, None, &DmOptions::empty())
+        dm.device_create(&third_name, None, &DmOptions::new())
             .unwrap();
         assert!(
             match dm.device_rename(&new_name, &DevId::Name(&third_name)) {
@@ -883,9 +883,9 @@ mod tests {
                 _ => false,
             }
         );
-        dm.device_remove(&DevId::Name(&third_name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&third_name), &DmOptions::new())
             .unwrap();
-        dm.device_remove(&DevId::Name(&new_name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&new_name), &DmOptions::new())
             .unwrap();
     }
 
@@ -907,7 +907,7 @@ mod tests {
     fn sudo_test_remove_non_existant() {
         assert!(match DM::new().unwrap().device_remove(
             &DevId::Name(&test_name("junk").expect("is valid DM name")),
-            &DmOptions::empty()
+            &DmOptions::new()
         ) {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
@@ -919,12 +919,12 @@ mod tests {
     fn sudo_test_empty_deps() {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
-        dm.device_create(&name, None, &DmOptions::empty()).unwrap();
+        dm.device_create(&name, None, &DmOptions::new()).unwrap();
 
-        let deps = dm.table_deps(&DevId::Name(&name), &DmOptions::empty())
+        let deps = dm.table_deps(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
         assert!(deps.is_empty());
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -933,7 +933,7 @@ mod tests {
     fn sudo_test_table_status_non_existant() {
         assert!(match DM::new().unwrap().table_status(
             &DevId::Name(&test_name("junk").expect("is valid DM name")),
-            &DmOptions::empty()
+            &DmOptions::new()
         ) {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
@@ -962,14 +962,14 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
         let uuid = test_uuid("uuid").expect("is valid DM UUID");
-        dm.device_create(&name, Some(&uuid), &DmOptions::empty())
+        dm.device_create(&name, Some(&uuid), &DmOptions::new())
             .unwrap();
 
-        let status = dm.table_status(&DevId::Name(&name), &DmOptions::empty())
+        let status = dm.table_status(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
         assert!(status.1.is_empty());
         assert_eq!(status.0.uuid(), Some(&*uuid));
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 
@@ -995,31 +995,31 @@ mod tests {
         let name_alt = test_name("name-alt").expect("is valid DM name");
         let uuid_alt = test_uuid("uuid-alt").expect("is valid DM UUID");
 
-        dm.device_create(&name, Some(&uuid), &DmOptions::empty())
+        dm.device_create(&name, Some(&uuid), &DmOptions::new())
             .unwrap();
         assert!(
-            match dm.device_create(&name, Some(&uuid), &DmOptions::empty()) {
+            match dm.device_create(&name, Some(&uuid), &DmOptions::new()) {
                 Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                 _ => false,
             }
         );
-        assert!(match dm.device_create(&name, None, &DmOptions::empty()) {
+        assert!(match dm.device_create(&name, None, &DmOptions::new()) {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
         });
         assert!(
-            match dm.device_create(&name, Some(&uuid_alt), &DmOptions::empty()) {
+            match dm.device_create(&name, Some(&uuid_alt), &DmOptions::new()) {
                 Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                 _ => false,
             }
         );
         assert!(
-            match dm.device_create(&name_alt, Some(&uuid), &DmOptions::empty()) {
+            match dm.device_create(&name_alt, Some(&uuid), &DmOptions::new()) {
                 Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
                 _ => false,
             }
         );
-        dm.device_remove(&DevId::Name(&name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
 }

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -56,8 +56,8 @@ impl DmOptions {
 
         hdr.data_start = size_of::<dmi::Struct_dm_ioctl>() as u32;
 
-        if let Some(id) = id {
-            match *id {
+        if let Some(ref id) = id {
+            match id {
                 DevId::Name(name) => DM::hdr_set_name(&mut hdr, name),
                 DevId::Uuid(uuid) => DM::hdr_set_uuid(&mut hdr, uuid),
             };

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -321,7 +321,7 @@ impl DM {
         let mut data_in = match *new {
             DevId::Name(name) => name.as_bytes().to_vec(),
             DevId::Uuid(uuid) => {
-                options = options.set_flags(DmFlags::DM_UUID);
+                options.set_flags(DmFlags::DM_UUID);
                 uuid.as_bytes().to_vec()
             }
         };

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -79,8 +79,8 @@ impl DM {
         options: &DmOptions,
         allowable_flags: DmFlags,
     ) -> dmi::Struct_dm_ioctl {
-        let clean_flags = allowable_flags & options.get_flags();
-        let event_nr = options.get_event_nr();
+        let clean_flags = allowable_flags & options.flags();
+        let event_nr = options.event_nr();
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         Self::initialize_hdr_options(&mut hdr, clean_flags, event_nr);

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -59,7 +59,7 @@ impl DM {
         allowable_flags: DmFlags,
     ) -> dmi::Struct_dm_ioctl {
         let clean_flags = allowable_flags & options.flags();
-        let event_nr = options.event_nr();
+        let event_nr = (options.cookie().bits() as u32) << 16;
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         hdr.version[0] = DM_VERSION_MAJOR;

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -44,7 +44,7 @@ impl DmOptions {
     /// Generate a header to be used for IOCTL.
     fn hdr(&self, id: Option<&DevId>, allowable_flags: DmFlags) -> dmi::Struct_dm_ioctl {
         let clean_flags = allowable_flags & self.flags();
-        let event_nr = (self.cookie().bits() as u32) << 16;
+        let event_nr = u32::from(self.cookie().bits()) << 16;
         let mut hdr: dmi::Struct_dm_ioctl = Default::default();
 
         hdr.version[0] = DM_VERSION_MAJOR;

--- a/src/dm_flags.rs
+++ b/src/dm_flags.rs
@@ -48,3 +48,29 @@ bitflags! {
         const DM_INTERNAL_SUSPEND     = (1 << 18);
     }
 }
+
+bitflags! {
+    /// Flags used by devicemapper, see:
+    /// https://sourceware.org/git/?p=lvm2.git;a=blob;f=libdm/libdevmapper.h#l3627
+    /// for complete information about the meaning of the flags.
+    #[derive(Default)]
+    pub struct DmCookie: dmi::__u16 {
+        #[allow(identity_op)]
+        /// Disables basic device-mapper udev rules that create symlinks in /dev/<DM_DIR>
+        /// directory.
+        const DM_UDEV_DISABLE_DM_RULES_FLAG = (1 << 0);
+        /// Disable subsystem udev rules, but allow general DM udev rules to run.
+        const DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG = (1 << 1);
+        /// Disable dm udev rules which create symlinks in /dev/disk/* directory.
+        const DM_UDEV_DISABLE_DISK_RULES_FLAG = (1 << 2);
+        /// Disable all rules that are not general dm nor subsystem related.
+        const DM_UDEV_DISABLE_OTHER_RULES_FLAG = (1 << 3);
+        /// Instruct udev rules to give lower priority to the device.
+        const DM_UDEV_LOW_PRIORITY_FLAG = (1 << 4);
+        /// Disable libdevmapper's node management.
+        const DM_UDEV_DISABLE_LIBRARY_FALLBACK = (1 << 5);
+        /// Automatically appended to all IOCTL calls issues by libdevmapper for generating
+        /// udev uevents.
+        const DM_UDEV_PRIMARY_SOURCE_FLAG = (1 << 6);
+    }
+}

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -19,11 +19,6 @@ impl DmOptions {
         }
     }
 
-    /// Synonym for new()
-    pub fn empty() -> DmOptions {
-        DmOptions::new()
-    }
-
     /// Set the DmFlags value for option.  Note this call is not additive in that it sets (replaces)
     /// entire flag value in one call.  Thus if you want to incrementally add additional flags you
     /// need to retrieve current and '|' with new.

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -25,7 +25,17 @@ impl DmOptions {
         DmOptions::new()
     }
 
-    /// Set the DmFlags value for option
+    /// Set the DmFlags value for option.  Note this call is not additive in that it sets (replaces)
+    /// entire flag value in one call.  Thus if you want to incrementally add additional flags you
+    /// need to retrieve current and '|' with new.
+    ///
+    /// ```no_run
+    /// use DmOptions;
+    ///
+    /// let mut options = DmOptions::new();
+    /// options = options.set_flags(DmFlags::DM_READONLY);
+    /// options = options
+    ///               .set_flags(DmFlags::DM_PERSISTENT_DEV | options.flags());
     pub fn set_flags(mut self, flags: DmFlags) -> DmOptions {
         self.flags = flags;
         self

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -4,7 +4,7 @@
 use super::dm_flags::{DmCookie, DmFlags};
 
 /// Encapsulates options for device mapper calls
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct DmOptions {
     flags: DmFlags,
     cookie: DmCookie,
@@ -36,7 +36,7 @@ impl DmOptions {
     /// options.set_flags(DmFlags::DM_READONLY);
     /// let flags = DmFlags::DM_PERSISTENT_DEV | options.flags();
     /// options.set_flags(flags);
-    pub fn set_flags<'a>(&'a mut self, flags: DmFlags) -> &'a mut DmOptions {
+    pub fn set_flags(&mut self, flags: DmFlags) -> &mut DmOptions {
         self.flags = flags;
         self
     }
@@ -55,7 +55,7 @@ impl DmOptions {
     ///
     /// let new_cookie = options.cookie() | DmCookie::DM_UDEV_DISABLE_DM_RULES_FLAG;
     /// options.set_cookie(new_cookie);
-    pub fn set_cookie<'a>(&'a mut self, cookie: DmCookie) -> &'a mut DmOptions {
+    pub fn set_cookie(&mut self, cookie: DmCookie) -> &mut DmOptions {
         self.cookie = cookie;
         self
     }

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -31,6 +31,7 @@ impl DmOptions {
     /// options.set_flags(DmFlags::DM_READONLY);
     /// let flags = DmFlags::DM_PERSISTENT_DEV | options.flags();
     /// options.set_flags(flags);
+    /// ```
     pub fn set_flags(&mut self, flags: DmFlags) -> &mut DmOptions {
         self.flags = flags;
         self
@@ -50,6 +51,7 @@ impl DmOptions {
     ///
     /// let new_cookie = options.cookie() | DmCookie::DM_UDEV_DISABLE_DM_RULES_FLAG;
     /// options.set_cookie(new_cookie);
+    /// ```
     pub fn set_cookie(&mut self, cookie: DmCookie) -> &mut DmOptions {
         self.cookie = cookie;
         self

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use super::dm_flags::DmFlags;
+
+/// Encapsulates options for device mapper calls
+#[derive(Debug, Clone)]
+pub struct DmOptions {
+    flags: DmFlags,
+    event_nr: u32,
+}
+
+impl DmOptions {
+    /// Create a new empty option
+    pub fn new() -> DmOptions {
+        DmOptions {
+            flags: DmFlags::empty(),
+            event_nr: 0,
+        }
+    }
+
+    /// Synonym for new()
+    pub fn empty() -> DmOptions {
+        DmOptions::new()
+    }
+
+    /// Set the DmFlags value for option
+    pub fn set_flags(mut self, flags: DmFlags) -> DmOptions {
+        self.flags = flags;
+        self
+    }
+
+    /// Set the event_nr value for option
+    pub fn set_event_nr(mut self, event_nr: u32) -> DmOptions {
+        self.event_nr = event_nr;
+        self
+    }
+
+    /// Retrieve the flags value
+    pub fn get_flags(&self) -> DmFlags {
+        self.flags
+    }
+
+    /// Retrieve the event_nr value
+    pub fn get_event_nr(&self) -> u32 {
+        self.event_nr
+    }
+}

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -1,7 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 use super::dm_flags::{DmCookie, DmFlags};
 
 /// Encapsulates options for device mapper calls

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -33,10 +33,10 @@ impl DmOptions {
     /// use devicemapper::DmOptions;
     ///
     /// let mut options = DmOptions::new();
-    /// options = options.set_flags(DmFlags::DM_READONLY);
+    /// options.set_flags(DmFlags::DM_READONLY);
     /// let flags = DmFlags::DM_PERSISTENT_DEV | options.flags();
-    /// options = options.set_flags(flags);
-    pub fn set_flags(mut self, flags: DmFlags) -> DmOptions {
+    /// options.set_flags(flags);
+    pub fn set_flags<'a>(&'a mut self, flags: DmFlags) -> &'a mut DmOptions {
         self.flags = flags;
         self
     }
@@ -51,11 +51,11 @@ impl DmOptions {
     /// use devicemapper::DmOptions;
     ///
     /// let mut options = DmOptions::new();
-    /// options = options.set_cookie(DmCookie::DM_UDEV_PRIMARY_SOURCE_FLAG);
+    /// options.set_cookie(DmCookie::DM_UDEV_PRIMARY_SOURCE_FLAG);
     ///
     /// let new_cookie = options.cookie() | DmCookie::DM_UDEV_DISABLE_DM_RULES_FLAG;
-    /// options = options.set_cookie(new_cookie);
-    pub fn set_cookie(mut self, cookie: DmCookie) -> DmOptions {
+    /// options.set_cookie(new_cookie);
+    pub fn set_cookie<'a>(&'a mut self, cookie: DmCookie) -> &'a mut DmOptions {
         self.cookie = cookie;
         self
     }

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -38,12 +38,12 @@ impl DmOptions {
     }
 
     /// Retrieve the flags value
-    pub fn get_flags(&self) -> DmFlags {
+    pub fn flags(&self) -> DmFlags {
         self.flags
     }
 
     /// Retrieve the event_nr value
-    pub fn get_event_nr(&self) -> u32 {
+    pub fn event_nr(&self) -> u32 {
         self.event_nr
     }
 }

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -41,9 +41,9 @@ impl DmOptions {
         self
     }
 
-    /// Set the event_nr value for option
-    pub fn set_event_nr(mut self, event_nr: u32) -> DmOptions {
-        self.event_nr = event_nr;
+    /// Set the cookie value for option (overloaded meaning with event_nr in header).
+    pub fn set_cookie(mut self, value: u32) -> DmOptions {
+        self.event_nr = value;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub use cachedev::{CacheDev, CacheDevPerformance, CacheDevStatus, CacheDevUsage,
 pub use consts::{IEC, SECTOR_SIZE};
 pub use device::{devnode_to_devno, Device};
 pub use dm::DM;
-pub use dm_flags::DmFlags;
+pub use dm_flags::{DmCookie, DmFlags};
 pub use dm_options::DmOptions;
 pub use lineardev::{FlakeyTargetParams, LinearDev, LinearDevTargetParams, LinearDevTargetTable,
                     LinearTargetParams};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,14 +73,14 @@ extern crate macro_attr;
 #[macro_use]
 extern crate newtype_derive;
 
-extern crate libc;
-#[macro_use]
-extern crate nix;
-extern crate serde;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
 extern crate error_chain;
+extern crate libc;
+#[macro_use]
+extern crate nix;
+extern crate serde;
 
 #[cfg(test)]
 extern crate loopdev;
@@ -112,6 +112,8 @@ mod deviceinfo;
 mod dm;
 /// DM flags
 mod dm_flags;
+/// Options for dm function calls
+mod dm_options;
 /// error chain errors for core dm
 mod errors;
 /// functions to create continuous linear space given device segments
@@ -139,6 +141,7 @@ pub use consts::{IEC, SECTOR_SIZE};
 pub use device::{devnode_to_devno, Device};
 pub use dm::DM;
 pub use dm_flags::DmFlags;
+pub use dm_options::DmOptions;
 pub use lineardev::{FlakeyTargetParams, LinearDev, LinearDevTargetParams, LinearDevTargetTable,
                     LinearTargetParams};
 pub use result::{DmError, DmResult, ErrorEnum};

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -436,7 +436,7 @@ impl DmDevice<LinearDevTargetTable> for LinearDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), &DmOptions::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         Ok(())
     }
 

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::DM;
-use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{device_create, device_exists, device_match, parse_device, DmDevice,
                     TargetLine, TargetParams, TargetTable};
@@ -436,7 +436,7 @@ impl DmDevice<LinearDevTargetTable> for LinearDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::empty())?;
         Ok(())
     }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -79,7 +79,7 @@ pub trait DmDevice<T: TargetTable> {
 
     /// Resume I/O on the device.
     fn resume(&mut self, dm: &DM) -> DmResult<()> {
-        dm.device_suspend(&DevId::Name(self.name()), &DmOptions::empty())?;
+        dm.device_suspend(&DevId::Name(self.name()), &DmOptions::new())?;
         Ok(())
     }
 
@@ -128,17 +128,17 @@ pub fn device_create<T: TargetTable>(
     uuid: Option<&DmUuid>,
     table: &T,
 ) -> DmResult<DeviceInfo> {
-    dm.device_create(name, uuid, &DmOptions::empty())?;
+    dm.device_create(name, uuid, &DmOptions::new())?;
 
     let id = DevId::Name(name);
     let dev_info = match dm.table_load(&id, &table.to_raw_table()) {
         Err(e) => {
-            dm.device_remove(&id, &DmOptions::empty())?;
+            dm.device_remove(&id, &DmOptions::new())?;
             return Err(e);
         }
         Ok(dev_info) => dev_info,
     };
-    dm.device_suspend(&id, &DmOptions::empty())?;
+    dm.device_suspend(&id, &DmOptions::new())?;
 
     Ok(dev_info)
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -89,11 +89,12 @@ pub trait DmDevice<T: TargetTable> {
     /// Suspend I/O on the device. If flush is true, flush the device first.
     fn suspend(&mut self, dm: &DM, flush: bool) -> DmResult<()> {
         let mut options = DmOptions::new();
-        let options = if flush {
-            options.set_flags(DmFlags::DM_SUSPEND)
+        options.set_flags(if flush {
+            DmFlags::DM_SUSPEND
         } else {
-            options.set_flags(DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH)
-        };
+            DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH
+        });
+
         dm.device_suspend(&DevId::Name(self.name()), &options)?;
         Ok(())
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -88,10 +88,11 @@ pub trait DmDevice<T: TargetTable> {
 
     /// Suspend I/O on the device. If flush is true, flush the device first.
     fn suspend(&mut self, dm: &DM, flush: bool) -> DmResult<()> {
+        let mut options = DmOptions::new();
         let options = if flush {
-            DmOptions::new().set_flags(DmFlags::DM_SUSPEND)
+            options.set_flags(DmFlags::DM_SUSPEND)
         } else {
-            DmOptions::new().set_flags(DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH)
+            options.set_flags(DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH)
         };
         dm.device_suspend(&DevId::Name(self.name()), &options)?;
         Ok(())

--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -10,7 +10,7 @@ use mnt::get_submounts;
 use nix::mount::{MntFlags, umount2};
 
 use super::dm::DM;
-use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::result::DmResult;
 use super::types::{DevId, DmNameBuf, DmUuidBuf};
 
@@ -80,7 +80,7 @@ fn dm_test_devices_remove() -> Result<()> {
             .map(|d| &d.0)
             .filter(|n| n.to_string().contains(DM_TEST_ID))
         {
-            match get_dm().device_remove(&DevId::Name(n), DmFlags::empty()) {
+            match get_dm().device_remove(&DevId::Name(n), &DmOptions::empty()) {
                 Ok(_) => progress_made = true,
                 Err(_) => remain.push(n.to_string()),
             }

--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -80,7 +80,7 @@ fn dm_test_devices_remove() -> Result<()> {
             .map(|d| &d.0)
             .filter(|n| n.to_string().contains(DM_TEST_ID))
         {
-            match get_dm().device_remove(&DevId::Name(n), &DmOptions::empty()) {
+            match get_dm().device_remove(&DevId::Name(n), &DmOptions::new()) {
                 Ok(_) => progress_made = true,
                 Err(_) => remain.push(n.to_string()),
             }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -173,7 +173,7 @@ impl DmDevice<ThinDevTargetTable> for ThinDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), &DmOptions::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         Ok(())
     }
 
@@ -304,7 +304,7 @@ impl ThinDev {
                 snapshot_thin_id, self.table.table.params.thin_id
             ),
         )?;
-        dm.device_suspend(&source_id, &DmOptions::empty())?;
+        dm.device_suspend(&source_id, &DmOptions::new())?;
         let table = ThinDev::gen_default_table(self.size(), thin_pool.device(), snapshot_thin_id);
         let dev_info = Box::new(device_create(dm, snapshot_name, snapshot_uuid, &table)?);
         Ok(ThinDev { dev_info, table })
@@ -336,7 +336,7 @@ impl ThinDev {
 
     /// Get the current status of the thin device.
     pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
-        let (_, table) = dm.table_status(&DevId::Name(self.name()), &DmOptions::empty())?;
+        let (_, table) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
 
         assert_eq!(
             table.len(),

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -246,7 +246,7 @@ impl DmDevice<ThinPoolDevTargetTable> for ThinPoolDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), &DmOptions::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         self.data_dev.teardown(dm)?;
         self.meta_dev.teardown(dm)?;
         Ok(())
@@ -467,7 +467,7 @@ impl ThinPoolDev {
     /// pass tests unless it were correct and the kernel docs wrong.
     // Justification: see comment above DM::parse_table_status.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
-        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::empty())?;
+        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
 
         assert_eq!(
             status.len(),
@@ -772,9 +772,9 @@ mod tests {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
         });
-        dm.device_remove(&DevId::Name(&meta_name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&meta_name), &DmOptions::new())
             .unwrap();
-        dm.device_remove(&DevId::Name(&data_name), &DmOptions::empty())
+        dm.device_remove(&DevId::Name(&data_name), &DmOptions::new())
             .unwrap();
     }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::DM;
-use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::lineardev::{LinearDev, LinearDevTargetParams};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{device_create, device_exists, device_match, parse_device, DmDevice,
@@ -246,7 +246,7 @@ impl DmDevice<ThinPoolDevTargetTable> for ThinPoolDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::empty())?;
         self.data_dev.teardown(dm)?;
         self.meta_dev.teardown(dm)?;
         Ok(())
@@ -467,7 +467,7 @@ impl ThinPoolDev {
     /// pass tests unless it were correct and the kernel docs wrong.
     // Justification: see comment above DM::parse_table_status.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
-        let (_, status) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
+        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::empty())?;
 
         assert_eq!(
             status.len(),
@@ -772,10 +772,9 @@ mod tests {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
         });
-
-        dm.device_remove(&DevId::Name(&meta_name), DmFlags::empty())
+        dm.device_remove(&DevId::Name(&meta_name), &DmOptions::empty())
             .unwrap();
-        dm.device_remove(&DevId::Name(&data_name), DmFlags::empty())
+        dm.device_remove(&DevId::Name(&data_name), &DmOptions::empty())
             .unwrap();
     }
 


### PR DESCRIPTION
Replace pub functions which took a DmFlags with a new DmOptions which utilizes a
builder pattern.  With this change we should be able to accommodate changes to
the device mapper structure over time, especially the IOCTL structure without
requiring new function calls to be created for every affected function.

This change incorporates suggestions from @agrover in this previous PR https://github.com/stratis-storage/devicemapper-rs/pull/307, mainly by removing the many uses of `Option`.