### PR TITLE
Make clippy an allowed failure on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ language: rust
 cache: cargo
 
 matrix:
+    allow_failures:
+        - env: TASK=clippy
     include:
         - rust: stable
           env: TASK=travis_fmt


### PR DESCRIPTION
It has become too flaky to be allowed to gate a PR.

Signed-off-by: mulhern <amulhern@redhat.com>