### PR TITLE
Add DmOptions builder

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::DM;
-use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::lineardev::{LinearDev, LinearDevTargetParams};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{device_create, device_exists, device_match, parse_device, DmDevice,
@@ -450,7 +450,7 @@ impl DmDevice<CacheDevTargetTable> for CacheDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         self.cache_dev.teardown(dm)?;
         self.origin_dev.teardown(dm)?;
         self.meta_dev.teardown(dm)?;
@@ -629,7 +629,7 @@ impl CacheDev {
     // Note: This method is not entirely complete. In particular, *_args values
     // may require more or better checking or processing.
     pub fn status(&self, dm: &DM) -> DmResult<CacheDevStatus> {
-        let (_, status) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
+        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
 
         assert_eq!(
             status.len(),

--- a/src/dm_flags.rs
+++ b/src/dm_flags.rs
@@ -48,3 +48,29 @@ bitflags! {
         const DM_INTERNAL_SUSPEND     = (1 << 18);
     }
 }
+
+bitflags! {
+    /// Flags used by devicemapper, see:
+    /// https://sourceware.org/git/?p=lvm2.git;a=blob;f=libdm/libdevmapper.h#l3627
+    /// for complete information about the meaning of the flags.
+    #[derive(Default)]
+    pub struct DmCookie: dmi::__u16 {
+        #[allow(identity_op)]
+        /// Disables basic device-mapper udev rules that create symlinks in /dev/<DM_DIR>
+        /// directory.
+        const DM_UDEV_DISABLE_DM_RULES_FLAG = (1 << 0);
+        /// Disable subsystem udev rules, but allow general DM udev rules to run.
+        const DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG = (1 << 1);
+        /// Disable dm udev rules which create symlinks in /dev/disk/* directory.
+        const DM_UDEV_DISABLE_DISK_RULES_FLAG = (1 << 2);
+        /// Disable all rules that are not general dm nor subsystem related.
+        const DM_UDEV_DISABLE_OTHER_RULES_FLAG = (1 << 3);
+        /// Instruct udev rules to give lower priority to the device.
+        const DM_UDEV_LOW_PRIORITY_FLAG = (1 << 4);
+        /// Disable libdevmapper's node management.
+        const DM_UDEV_DISABLE_LIBRARY_FALLBACK = (1 << 5);
+        /// Automatically appended to all IOCTL calls issues by libdevmapper for generating
+        /// udev uevents.
+        const DM_UDEV_PRIMARY_SOURCE_FLAG = (1 << 6);
+    }
+}

--- a/src/dm_options.rs
+++ b/src/dm_options.rs
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+use super::dm_flags::{DmCookie, DmFlags};
+
+/// Encapsulates options for device mapper calls
+#[derive(Debug, Default, Clone)]
+pub struct DmOptions {
+    flags: DmFlags,
+    cookie: DmCookie,
+}
+
+impl DmOptions {
+    /// Create a new empty option
+    pub fn new() -> DmOptions {
+        DmOptions {
+            flags: DmFlags::empty(),
+            cookie: DmCookie::empty(),
+        }
+    }
+
+    /// Set the DmFlags value for option.  Note this call is not additive in that it sets (replaces)
+    /// entire flag value in one call.  Thus if you want to incrementally add additional flags you
+    /// need to retrieve current and '|' with new.
+    ///
+    /// ```no_run
+    /// use devicemapper::DmFlags;
+    /// use devicemapper::DmOptions;
+    ///
+    /// let mut options = DmOptions::new();
+    /// options.set_flags(DmFlags::DM_READONLY);
+    /// let flags = DmFlags::DM_PERSISTENT_DEV | options.flags();
+    /// options.set_flags(flags);
+    /// ```
+    pub fn set_flags(&mut self, flags: DmFlags) -> &mut DmOptions {
+        self.flags = flags;
+        self
+    }
+
+    /// Set the cookie bitfield value for option (overloaded meaning with event_nr in header).
+    /// Note this call is not additive in that it sets (replaces) entire cookie value in one call.
+    /// Thus if you want to incrementally add additional flags you need to retrieve current and '|'
+    /// with new.
+    ///
+    /// ```no_run
+    /// use devicemapper::{DmCookie, DmFlags};
+    /// use devicemapper::DmOptions;
+    ///
+    /// let mut options = DmOptions::new();
+    /// options.set_cookie(DmCookie::DM_UDEV_PRIMARY_SOURCE_FLAG);
+    ///
+    /// let new_cookie = options.cookie() | DmCookie::DM_UDEV_DISABLE_DM_RULES_FLAG;
+    /// options.set_cookie(new_cookie);
+    /// ```
+    pub fn set_cookie(&mut self, cookie: DmCookie) -> &mut DmOptions {
+        self.cookie = cookie;
+        self
+    }
+
+    /// Retrieve the flags value
+    pub fn flags(&self) -> DmFlags {
+        self.flags
+    }
+
+    /// Retrieve the cookie value (used for input in upper 16 bits of event_nr header field).
+    pub fn cookie(&self) -> DmCookie {
+        self.cookie
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,14 +73,14 @@ extern crate macro_attr;
 #[macro_use]
 extern crate newtype_derive;
 
-extern crate libc;
-#[macro_use]
-extern crate nix;
-extern crate serde;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
 extern crate error_chain;
+extern crate libc;
+#[macro_use]
+extern crate nix;
+extern crate serde;
 
 #[cfg(test)]
 extern crate loopdev;
@@ -112,6 +112,8 @@ mod deviceinfo;
 mod dm;
 /// DM flags
 mod dm_flags;
+/// Options for dm function calls
+mod dm_options;
 /// error chain errors for core dm
 mod errors;
 /// functions to create continuous linear space given device segments
@@ -138,7 +140,8 @@ pub use cachedev::{CacheDev, CacheDevPerformance, CacheDevStatus, CacheDevUsage,
 pub use consts::{IEC, SECTOR_SIZE};
 pub use device::{devnode_to_devno, Device};
 pub use dm::DM;
-pub use dm_flags::DmFlags;
+pub use dm_flags::{DmCookie, DmFlags};
+pub use dm_options::DmOptions;
 pub use lineardev::{FlakeyTargetParams, LinearDev, LinearDevTargetParams, LinearDevTargetTable,
                     LinearTargetParams};
 pub use result::{DmError, DmResult, ErrorEnum};

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::DM;
-use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{device_create, device_exists, device_match, parse_device, DmDevice,
                     TargetLine, TargetParams, TargetTable};
@@ -436,7 +436,7 @@ impl DmDevice<LinearDevTargetTable> for LinearDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         Ok(())
     }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -13,6 +13,7 @@ use super::device::{devnode_to_devno, Device};
 use super::deviceinfo::DeviceInfo;
 use super::dm::DM;
 use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::types::{DevId, DmName, DmUuid, Sectors, TargetTypeBuf};
 
@@ -68,7 +69,8 @@ pub trait DmDevice<T: TargetTable> {
 
     /// Read the devicemapper table
     fn read_kernel_table(dm: &DM, id: &DevId) -> DmResult<T> {
-        let (_, table) = dm.table_status(id, DmFlags::DM_STATUS_TABLE)?;
+        let (_, table) =
+            dm.table_status(id, &DmOptions::new().set_flags(DmFlags::DM_STATUS_TABLE))?;
         T::from_raw_table(&table)
     }
 
@@ -77,7 +79,7 @@ pub trait DmDevice<T: TargetTable> {
 
     /// Resume I/O on the device.
     fn resume(&mut self, dm: &DM) -> DmResult<()> {
-        dm.device_suspend(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_suspend(&DevId::Name(self.name()), &DmOptions::new())?;
         Ok(())
     }
 
@@ -86,12 +88,14 @@ pub trait DmDevice<T: TargetTable> {
 
     /// Suspend I/O on the device. If flush is true, flush the device first.
     fn suspend(&mut self, dm: &DM, flush: bool) -> DmResult<()> {
-        let flags = if flush {
+        let mut options = DmOptions::new();
+        options.set_flags(if flush {
             DmFlags::DM_SUSPEND
         } else {
             DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH
-        };
-        dm.device_suspend(&DevId::Name(self.name()), flags)?;
+        });
+
+        dm.device_suspend(&DevId::Name(self.name()), &options)?;
         Ok(())
     }
 
@@ -125,17 +129,17 @@ pub fn device_create<T: TargetTable>(
     uuid: Option<&DmUuid>,
     table: &T,
 ) -> DmResult<DeviceInfo> {
-    dm.device_create(name, uuid, DmFlags::empty())?;
+    dm.device_create(name, uuid, &DmOptions::new())?;
 
     let id = DevId::Name(name);
     let dev_info = match dm.table_load(&id, &table.to_raw_table()) {
         Err(e) => {
-            dm.device_remove(&id, DmFlags::empty())?;
+            dm.device_remove(&id, &DmOptions::new())?;
             return Err(e);
         }
         Ok(dev_info) => dev_info,
     };
-    dm.device_suspend(&id, DmFlags::empty())?;
+    dm.device_suspend(&id, &DmOptions::new())?;
 
     Ok(dev_info)
 }

--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -10,7 +10,7 @@ use mnt::get_submounts;
 use nix::mount::{MntFlags, umount2};
 
 use super::dm::DM;
-use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::result::DmResult;
 use super::types::{DevId, DmNameBuf, DmUuidBuf};
 
@@ -80,7 +80,7 @@ fn dm_test_devices_remove() -> Result<()> {
             .map(|d| &d.0)
             .filter(|n| n.to_string().contains(DM_TEST_ID))
         {
-            match get_dm().device_remove(&DevId::Name(n), DmFlags::empty()) {
+            match get_dm().device_remove(&DevId::Name(n), &DmOptions::new()) {
                 Ok(_) => progress_made = true,
                 Err(_) => remain.push(n.to_string()),
             }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -10,6 +10,7 @@ use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::DM;
 use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{device_create, device_exists, device_match, message, parse_device, DmDevice,
                     TargetLine, TargetParams, TargetTable};
@@ -172,7 +173,7 @@ impl DmDevice<ThinDevTargetTable> for ThinDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         Ok(())
     }
 
@@ -294,7 +295,7 @@ impl ThinDev {
         snapshot_thin_id: ThinDevId,
     ) -> DmResult<ThinDev> {
         let source_id = DevId::Name(self.name());
-        dm.device_suspend(&source_id, DmFlags::DM_SUSPEND)?;
+        dm.device_suspend(&source_id, &DmOptions::new().set_flags(DmFlags::DM_SUSPEND))?;
         message(
             dm,
             thin_pool,
@@ -303,7 +304,7 @@ impl ThinDev {
                 snapshot_thin_id, self.table.table.params.thin_id
             ),
         )?;
-        dm.device_suspend(&source_id, DmFlags::empty())?;
+        dm.device_suspend(&source_id, &DmOptions::new())?;
         let table = ThinDev::gen_default_table(self.size(), thin_pool.device(), snapshot_thin_id);
         let dev_info = Box::new(device_create(dm, snapshot_name, snapshot_uuid, &table)?);
         Ok(ThinDev { dev_info, table })
@@ -335,7 +336,7 @@ impl ThinDev {
 
     /// Get the current status of the thin device.
     pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
-        let (_, table) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
+        let (_, table) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
 
         assert_eq!(
             table.len(),

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use super::device::Device;
 use super::deviceinfo::DeviceInfo;
 use super::dm::DM;
-use super::dm_flags::DmFlags;
+use super::dm_options::DmOptions;
 use super::lineardev::{LinearDev, LinearDevTargetParams};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{device_create, device_exists, device_match, parse_device, DmDevice,
@@ -246,7 +246,7 @@ impl DmDevice<ThinPoolDevTargetTable> for ThinPoolDev {
     }
 
     fn teardown(self, dm: &DM) -> DmResult<()> {
-        dm.device_remove(&DevId::Name(self.name()), DmFlags::empty())?;
+        dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         self.data_dev.teardown(dm)?;
         self.meta_dev.teardown(dm)?;
         Ok(())
@@ -467,7 +467,7 @@ impl ThinPoolDev {
     /// pass tests unless it were correct and the kernel docs wrong.
     // Justification: see comment above DM::parse_table_status.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
-        let (_, status) = dm.table_status(&DevId::Name(self.name()), DmFlags::empty())?;
+        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
 
         assert_eq!(
             status.len(),
@@ -772,10 +772,9 @@ mod tests {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
             _ => false,
         });
-
-        dm.device_remove(&DevId::Name(&meta_name), DmFlags::empty())
+        dm.device_remove(&DevId::Name(&meta_name), &DmOptions::new())
             .unwrap();
-        dm.device_remove(&DevId::Name(&data_name), DmFlags::empty())
+        dm.device_remove(&DevId::Name(&data_name), &DmOptions::new())
             .unwrap();
     }
 


### PR DESCRIPTION
Replace pub functions which took a DmFlags with a new DmOptions which utilizes a
builder pattern.  With this change we should be able to accommodate changes to
the device mapper structure over time, especially the IOCTL structure without
requiring new function calls to be created for every affected function.

Signed-off-by: Tony Asleson <tasleson@redhat.com>