### PR TITLE
Add DmOptions parameter to device_create

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -481,7 +481,7 @@ impl CacheDev {
         }
 
         let table = CacheDev::gen_default_table(&meta, &cache, &origin, cache_block_size);
-        let dev_info = device_create(dm, name, uuid, &table)?;
+        let dev_info = device_create(dm, name, uuid, &table, &DmOptions::new())?;
 
         Ok(CacheDev {
             dev_info: Box::new(dev_info),
@@ -515,7 +515,7 @@ impl CacheDev {
             device_match(dm, &dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table)?;
+            let dev_info = device_create(dm, name, uuid, &table, &DmOptions::new())?;
             CacheDev {
                 dev_info: Box::new(dev_info),
                 meta_dev: meta,

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -482,7 +482,7 @@ impl LinearDev {
             device_match(dm, &dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table)?;
+            let dev_info = device_create(dm, name, uuid, &table, &DmOptions::new())?;
             LinearDev {
                 dev_info: Box::new(dev_info),
                 table,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -122,12 +122,14 @@ pub fn message<T: TargetTable, D: DmDevice<T>>(dm: &DM, target: &D, msg: &str) -
     Ok(())
 }
 
-/// Create a device, load a table, and resume it.
+/// Create a device, load a table, and resume it allowing the caller to specify the DmOptions for
+/// resuming.
 pub fn device_create<T: TargetTable>(
     dm: &DM,
     name: &DmName,
     uuid: Option<&DmUuid>,
     table: &T,
+    suspend_options: &DmOptions,
 ) -> DmResult<DeviceInfo> {
     dm.device_create(name, uuid, &DmOptions::new())?;
 
@@ -139,7 +141,7 @@ pub fn device_create<T: TargetTable>(
         }
         Ok(dev_info) => dev_info,
     };
-    dm.device_suspend(&id, &DmOptions::new())?;
+    dm.device_suspend(&id, suspend_options)?;
 
     Ok(dev_info)
 }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -367,7 +367,7 @@ impl ThinPoolDev {
         }
 
         let table = ThinPoolDev::gen_default_table(&meta, &data, data_block_size, low_water_mark);
-        let dev_info = device_create(dm, name, uuid, &table)?;
+        let dev_info = device_create(dm, name, uuid, &table, &DmOptions::new())?;
 
         Ok(ThinPoolDev {
             dev_info: Box::new(dev_info),
@@ -419,7 +419,7 @@ impl ThinPoolDev {
             device_match(dm, &dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table)?;
+            let dev_info = device_create(dm, name, uuid, &table, &DmOptions::new())?;
             ThinPoolDev {
                 dev_info: Box::new(dev_info),
                 meta_dev: meta,


### PR DESCRIPTION
~~Current best approach for getting existing user space udev rules
to do what we need to get Stratis to be used for root fs and for
allowing Stratis backed XFS fs mounted in fstab.  This works by
setting a cookie value when we un-suspend the newly created thin
device which is utilized for newly created FS.~~

Current best approach for getting existing user space udev rules
to do what we need.  To allow Stratis to be used for root fs and for
allowing Stratis backed XFS fs mounted in fstab.  This works by
setting a cookie value when we resume the newly created thin
device which is utilized for newly created FS.


Signed-off-by: Tony Asleson <tasleson@redhat.com>