### PR TITLE
Set cookie for setup and snapshot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ error-chain = "0.11"
 [dev-dependencies]
 loopdev = "0.2"
 tempfile = "3.0.1"
+libudev = "0.2.0"
 
 [dev-dependencies.uuid]
 version = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,8 @@ extern crate nix;
 extern crate serde;
 
 #[cfg(test)]
+extern crate libudev;
+#[cfg(test)]
 extern crate loopdev;
 #[cfg(test)]
 extern crate mnt;

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -279,7 +279,13 @@ impl ThinDev {
             device_match(dm, &dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table, &DmOptions::new())?;
+            let dev_info = device_create(
+                dm,
+                name,
+                uuid,
+                &table,
+                &DmOptions::new().set_cookie(DmCookie::DM_UDEV_PRIMARY_SOURCE_FLAG),
+            )?;
             ThinDev {
                 dev_info: Box::new(dev_info),
                 table,
@@ -317,7 +323,7 @@ impl ThinDev {
             snapshot_name,
             snapshot_uuid,
             &table,
-            &DmOptions::new(),
+            &DmOptions::new().set_cookie(DmCookie::DM_UDEV_PRIMARY_SOURCE_FLAG),
         )?);
         Ok(ThinDev { dev_info, table })
     }


### PR DESCRIPTION
Previous PR:
#323

Introduced a cookie to get userspace to handle udev event, but
we left out the setup and snapshot code paths, so add those too.
