### PR TITLE
Remove some error-chain specific clippy allows

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,10 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// The error we are trying to eliminate is:
-// lint unused_doc_comment had been renamed to unused_doc_comments.
-// GitHub URL: https://github.com/rust-lang-nursery/error-chain/issues/245.
-#![allow(renamed_and_removed_lints)]
 use super::deviceinfo::DeviceInfo;
 
 error_chain! {

--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -93,7 +93,6 @@ pub fn test_uuid(name: &str) -> DmResult<DmUuidBuf> {
     DmUuidBuf::new(test_string(name))
 }
 
-#[allow(renamed_and_removed_lints)]
 mod cleanup_errors {
     use mnt;
     use nix;


### PR DESCRIPTION
We believe that the necessity has been removed by the recent error-chain
update: https://github.com/rust-lang-nursery/error-chain/issues/245

Signed-off-by: mulhern <amulhern@redhat.com>