### PR TITLE
Add ThinPoolDev::set_low_water_mark() 

### DIFF
--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -26,13 +26,22 @@ use std::path::Path;
 
 const THINPOOL_TARGET_NAME: &str = "thin-pool";
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq)]
 pub struct ThinPoolTargetParams {
     pub metadata_dev: Device,
     pub data_dev: Device,
     pub data_block_size: Sectors,
     pub low_water_mark: DataBlocks,
     pub feature_args: HashSet<String>,
+}
+
+impl PartialEq for ThinPoolTargetParams {
+    fn eq(&self, other: &ThinPoolTargetParams) -> bool {
+        self.metadata_dev == other.metadata_dev
+            && self.data_dev == other.data_dev
+            && self.data_block_size == other.data_block_size
+            && self.feature_args == other.feature_args
+    }
 }
 
 impl ThinPoolTargetParams {

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -461,6 +461,35 @@ impl ThinPoolDev {
         )
     }
 
+    /// Set the low water mark to be something different than what was given
+    /// to ::new() or ::setup().
+    pub fn set_low_water_mark(&mut self, dm: &DM, low_water_mark: DataBlocks) -> DmResult<()> {
+        // Make a new table and params, with the changed low_water_mark
+        let new_table = ThinPoolDevTargetTable::new(
+            self.table.table.start,
+            self.table.table.length,
+            ThinPoolTargetParams::new(
+                self.table.table.params.metadata_dev,
+                self.table.table.params.data_dev,
+                self.table.table.params.data_block_size,
+                low_water_mark,
+                self.table
+                    .table
+                    .params
+                    .feature_args
+                    .iter()
+                    .map(|s| s.clone())
+                    .collect(),
+            ),
+        );
+        self.suspend(dm, false)?;
+        self.table_load(dm, &new_table)?;
+        self.resume(dm)?;
+
+        self.table = new_table;
+        Ok(())
+    }
+
     /// Get the current status of the thinpool.
     /// Returns an error if there was an error getting the status value.
     /// Panics if there is an error parsing the status value.


### PR DESCRIPTION
This PR allows clients to set the low water mark for an existing ThinPoolDev, and also implements PartialEq so two otherwise identical ThinPoolDevs with different low water marks compare as equal. (Low water mark configures eventing behavior, rather than some value that is critical to the device working correctly.)