### PR TITLE
Add support for meta_low_water to ThinPoolWorkingStatus

### DIFF
--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -321,6 +321,9 @@ pub struct ThinPoolWorkingStatus {
     pub summary: ThinPoolStatusSummary,
     /// needs_check flag has been set in metadata superblock
     pub needs_check: bool,
+    /// The lowater value for the metadata device in metablocks. This value
+    /// is set by the kernel. Available in kernel version 4.19 and later.
+    pub meta_low_water: Option<u64>,
 }
 
 impl ThinPoolWorkingStatus {
@@ -332,6 +335,7 @@ impl ThinPoolWorkingStatus {
         no_space_policy: ThinPoolNoSpacePolicy,
         summary: ThinPoolStatusSummary,
         needs_check: bool,
+        meta_low_water: Option<u64>,
     ) -> ThinPoolWorkingStatus {
         ThinPoolWorkingStatus {
             transaction_id,
@@ -340,6 +344,7 @@ impl ThinPoolWorkingStatus {
             no_space_policy,
             summary,
             needs_check,
+            meta_low_water,
         }
     }
 }
@@ -576,6 +581,11 @@ impl ThinPoolDev {
             )),
         };
 
+        let meta_low_water = status_vals.get(8).map(|v| {
+            v.parse::<u64>()
+                .expect("meta low water value must be valid")
+        });
+
         Ok(ThinPoolStatus::Working(Box::new(
             ThinPoolWorkingStatus::new(
                 transaction_id,
@@ -584,6 +594,7 @@ impl ThinPoolDev {
                 no_space_policy,
                 summary,
                 needs_check,
+                meta_low_water,
             ),
         )))
     }


### PR DESCRIPTION
Upstream kernel has merged support for reporting the metadata low water
mark. The kernel sets this value, but userspace needs to know it in order
to tell when crossing the value has caused an event.

In some future API-breaking change we could just provide this value, but
for now it is available as an Option, to handle older kernels.

Signed-off-by: Andy Grover <agrover@redhat.com>