### PR TITLE
Change teardown methods to take &mut self

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -452,7 +452,7 @@ impl DmDevice<CacheDevTargetTable> for CacheDev {
         table!(self)
     }
 
-    fn teardown(self, dm: &DM) -> DmResult<()> {
+    fn teardown(&mut self, dm: &DM) -> DmResult<()> {
         dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         self.cache_dev.teardown(dm)?;
         self.origin_dev.teardown(dm)?;
@@ -878,7 +878,7 @@ mod tests {
     fn test_minimal_cache_dev(paths: &[&Path]) -> () {
         assert!(paths.len() >= 2);
         let dm = DM::new().unwrap();
-        let cache = minimal_cachedev(&dm, paths);
+        let mut cache = minimal_cachedev(&dm, paths);
 
         match cache.status(&dm).unwrap() {
             CacheDevStatus::Working(ref status) => {

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -437,7 +437,7 @@ impl DmDevice<LinearDevTargetTable> for LinearDev {
         table!(self)
     }
 
-    fn teardown(self, dm: &DM) -> DmResult<()> {
+    fn teardown(&mut self, dm: &DM) -> DmResult<()> {
         dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         Ok(())
     }
@@ -634,7 +634,7 @@ mod tests {
         ];
         let range: Sectors = table.iter().map(|s| s.length).sum();
         let count = table.len();
-        let ld = LinearDev::setup(&dm, &name, None, table).unwrap();
+        let mut ld = LinearDev::setup(&dm, &name, None, table).unwrap();
 
         let table = LinearDev::read_kernel_table(&dm, &DevId::Name(ld.name()))
             .unwrap()
@@ -674,7 +674,7 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        let ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
+        let mut ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
 
         let loaded_table = LinearDev::read_kernel_table(&dm, &DevId::Name(ld.name())).unwrap();
         assert!(
@@ -698,7 +698,7 @@ mod tests {
             Sectors(1),
             LinearDevTargetParams::Linear(params),
         )];
-        let ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
+        let mut ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
         let params2 = LinearTargetParams::new(dev, Sectors(1));
         let table2 = vec![TargetLine::new(
             Sectors(0),
@@ -724,7 +724,7 @@ mod tests {
             Sectors(1),
             LinearDevTargetParams::Linear(params),
         )];
-        let ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
+        let mut ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
         let ld2 = LinearDev::setup(&dm, &ersatz, None, table);
         assert!(ld2.is_ok());
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -109,7 +109,7 @@ pub trait DmDevice<T: TargetTable> {
     }
 
     /// Erase the kernel's memory of this device.
-    fn teardown(self, dm: &DM) -> DmResult<()>;
+    fn teardown(&mut self, dm: &DM) -> DmResult<()>;
 
     /// The device's UUID, if available.
     /// Note that the UUID is not any standard UUID format.

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -256,7 +256,7 @@ impl DmDevice<ThinPoolDevTargetTable> for ThinPoolDev {
         table!(self)
     }
 
-    fn teardown(self, dm: &DM) -> DmResult<()> {
+    fn teardown(&mut self, dm: &DM) -> DmResult<()> {
         dm.device_remove(&DevId::Name(self.name()), &DmOptions::new())?;
         self.data_dev.teardown(dm)?;
         self.meta_dev.teardown(dm)?;
@@ -729,7 +729,7 @@ mod tests {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
-        let tp = minimal_thinpool(&dm, paths[0]);
+        let mut tp = minimal_thinpool(&dm, paths[0]);
         match tp.status(&dm).unwrap() {
             ThinPoolStatus::Working(ref status)
                 if status.summary == ThinPoolStatusSummary::Good =>


### PR DESCRIPTION
The problem with teardown taking self is that if it fails, we no longer
have ownership of the object. Instead, pass in a mutable reference. This
leaves the caller with the object if the teardown/destroy fails.

Signed-off-by: Andy Grover <agrover@redhat.com>