### PR TITLE
Add nix::Errno attribute to IoctlError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use nix;
+
 use super::deviceinfo::DeviceInfo;
 
 error_chain! {
@@ -24,7 +26,7 @@ error_chain! {
         /// An error returned exclusively by DM methods.
         /// This error is initiated in DM::do_ioctl and returned by
         /// numerous wrapper methods.
-        IoctlError(t: Box<DeviceInfo>) {
+        IoctlError(t: Box<DeviceInfo>, errno: Option<nix::errno::Errno>) {
             description("low-level ioctl error")
             display("low-level ioctl error")
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ mod dm_flags;
 /// Options for dm function calls
 mod dm_options;
 /// error chain errors for core dm
-mod errors;
+pub mod errors;
 /// functions to create continuous linear space given device segments
 mod lineardev;
 /// return results container

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -511,7 +511,7 @@ mod tests {
             &tp,
             ThinDevId::new_u64(0).expect("is below limit")
         ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
             _ => false,
         });
 
@@ -558,7 +558,7 @@ mod tests {
 
         // New thindev w/ same id fails.
         assert!(match ThinDev::new(&dm, &id, None, td_size, &tp, thin_id) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
             _ => false,
         });
 
@@ -893,7 +893,7 @@ mod tests {
         // This should fail
         assert!(
             match ThinDev::setup(&dm, &thin_name, None, tp.size(), &tp, thin_id) {
-                Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+                Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
                 _ => false,
             }
         );

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -796,7 +796,7 @@ mod tests {
             MIN_DATA_BLOCK_SIZE / 2u64,
             DataBlocks(1)
         ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
             _ => false,
         });
         dm.device_remove(&DevId::Name(&meta_name), &DmOptions::new())


### PR DESCRIPTION
In addition to having the DeviceInfo, it's also handy to know the errno
that caused the IoctlError, if available. Include this.

Change test locations since ErrorKind::IoctlError now has two fields.

Make errors public so external code has visibility into the Core error
types.

Signed-off-by: Andy Grover <agrover@redhat.com>