### PR TITLE
Use primitive type-based chaining mechanism

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -10,7 +10,7 @@ use std::{fmt, io};
 use libc::{dev_t, major, makedev, minor};
 use nix::sys::stat::SFlag;
 
-use super::errors::{Error, ErrorKind};
+use super::errors::ErrorKind;
 use super::result::{DmError, DmResult};
 
 /// A struct containing the device's major and minor numbers
@@ -113,8 +113,7 @@ pub fn devnode_to_devno(path: &Path) -> DmResult<Option<u64>> {
             if err.kind() == io::ErrorKind::NotFound {
                 return Ok(None);
             }
-            let err_msg = format!("failed to get metadata for device at {:?}", path);
-            Err(Error::with_chain(err, ErrorKind::Msg(err_msg)))?
+            Err(DmError::Core(ErrorKind::MetadataIoError(err).into()))
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -113,7 +113,9 @@ pub fn devnode_to_devno(path: &Path) -> DmResult<Option<u64>> {
             if err.kind() == io::ErrorKind::NotFound {
                 return Ok(None);
             }
-            Err(DmError::Core(ErrorKind::MetadataIoError(err).into()))
+            Err(DmError::Core(
+                ErrorKind::MetadataIoError(path.to_owned(), err).into(),
+            ))
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std;
+use std::path::PathBuf;
 
 use nix;
 
@@ -34,9 +35,9 @@ error_chain! {
         }
 
         /// An error returned on failure to get metadata for a device
-        MetadataIoError(e: std::io::Error) {
+        MetadataIoError(path: PathBuf, e: std::io::Error) {
             description("failed to get metadata for a device")
-            display("failed to stat metadata for a device due to IO error: {:}", e)
+            display("failed to stat metadata for device at {} due to IO error: {:}", path.to_string_lossy(), e)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,7 +14,7 @@ error_chain! {
         /// An error returned on failure to create a devicemapper context.
         ContextInitError(e: std::io::Error) {
             description("DM context not initialized")
-            display("DM context not initialized due to IO error: {:}", e)
+            display("DM context not initialized due to IO error: {}", e)
         }
 
         /// This is a generic error that can be returned when a method
@@ -31,7 +31,7 @@ error_chain! {
         /// numerous wrapper methods.
         IoctlError(t: Box<DeviceInfo>, n: nix::Error) {
             description("low-level ioctl error")
-            display("low-level ioctl error due to nix error: {:}", n)
+            display("low-level ioctl error due to nix error: {}", n)
         }
 
         /// An error returned on failure to get metadata for a device

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,14 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std;
+
+use nix;
+
 use super::deviceinfo::DeviceInfo;
 
 error_chain! {
     errors {
         /// An error returned on failure to create a devicemapper context.
-        ContextInitError {
+        ContextInitError(e: std::io::Error) {
             description("DM context not initialized")
-            display("DM context not initialized")
+            display("DM context not initialized due to IO error: {:}", e)
         }
 
         /// This is a generic error that can be returned when a method
@@ -24,9 +28,15 @@ error_chain! {
         /// An error returned exclusively by DM methods.
         /// This error is initiated in DM::do_ioctl and returned by
         /// numerous wrapper methods.
-        IoctlError(t: Box<DeviceInfo>) {
+        IoctlError(t: Box<DeviceInfo>, n: nix::Error) {
             description("low-level ioctl error")
-            display("low-level ioctl error")
+            display("low-level ioctl error due to nix error: {:}", n)
+        }
+
+        /// An error returned on failure to get metadata for a device
+        MetadataIoError(e: std::io::Error) {
+            description("failed to get metadata for a device")
+            display("failed to stat metadata for a device due to IO error: {:}", e)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,7 +37,7 @@ error_chain! {
         /// An error returned on failure to get metadata for a device
         MetadataIoError(path: PathBuf, e: std::io::Error) {
             description("failed to get metadata for a device")
-            display("failed to stat metadata for device at {} due to IO error: {:}", path.to_string_lossy(), e)
+            display("failed to stat metadata for device at {} due to IO error: {}", path.to_string_lossy(), e)
         }
     }
 }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -511,7 +511,7 @@ mod tests {
             &tp,
             ThinDevId::new_u64(0).expect("is below limit")
         ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
             _ => false,
         });
 
@@ -558,7 +558,7 @@ mod tests {
 
         // New thindev w/ same id fails.
         assert!(match ThinDev::new(&dm, &id, None, td_size, &tp, thin_id) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
             _ => false,
         });
 
@@ -893,7 +893,7 @@ mod tests {
         // This should fail
         assert!(
             match ThinDev::setup(&dm, &thin_name, None, tp.size(), &tp, thin_id) {
-                Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+                Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
                 _ => false,
             }
         );

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -796,7 +796,7 @@ mod tests {
             MIN_DATA_BLOCK_SIZE / 2u64,
             DataBlocks(1)
         ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_), _))) => true,
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
             _ => false,
         });
         dm.device_remove(&DevId::Name(&meta_name), &DmOptions::new())


### PR DESCRIPTION
Due to restrictions in the standard library, using error-chain does not
allow most handy programmatic access to the elements of the chain.

Thus, it seems better to fall back on a simple type-based mechanism,
which is unfortunately more brittle but also more useful.

Make some description fields more descriptive.

Do not bother to remove error-chaining from test infrastructure, it is
not necessary to have programmatic access to it in the same way as to
a part of the actual library.

Signed-off-by: mulhern <amulhern@redhat.com>