### PR TITLE
Add parse_value(), add description to parse_device(), and replace panic()s with Err()s

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -83,9 +83,9 @@ impl FromStr for CacheTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let metadata_dev = parse_device(vals[1])?;
-        let cache_dev = parse_device(vals[2])?;
-        let origin_dev = parse_device(vals[3])?;
+        let metadata_dev = parse_device(vals[1], "metadata dev")?;
+        let cache_dev = parse_device(vals[2], "cache dev")?;
+        let origin_dev = parse_device(vals[3], "origin dev")?;
 
         let block_size = Sectors(parse_value(vals[4], "data block size")?);
         let num_feature_args: usize = parse_value(vals[5], "number of feature args")?;

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -83,9 +83,9 @@ impl FromStr for CacheTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let metadata_dev = parse_device(vals[1], "metadata dev")?;
-        let cache_dev = parse_device(vals[2], "cache dev")?;
-        let origin_dev = parse_device(vals[3], "origin dev")?;
+        let metadata_dev = parse_device(vals[1], "metadata sub-device for cache target")?;
+        let cache_dev = parse_device(vals[2], "cache sub-device for cache target")?;
+        let origin_dev = parse_device(vals[3], "origin sub-device for cache target")?;
 
         let block_size = Sectors(parse_value(vals[4], "data block size")?);
         let num_feature_args: usize = parse_value(vals[5], "number of feature args")?;

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -607,7 +607,6 @@ impl CacheDev {
     }
 
     /// Parse pairs of arguments from a slice
-    /// Use the same policy as status() method in asserting
     fn parse_pairs(start_index: usize, vals: &[&str]) -> DmResult<(usize, Vec<(String, String)>)> {
         let num_pairs: usize = parse_value(vals[start_index], "number of pairs")?;
         if num_pairs % 2 != 0 {

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -690,21 +690,31 @@ impl CacheDev {
         let cache_metadata_mode = match status_vals[rest_start_index] {
             "rw" => CacheDevMetadataMode::Good,
             "ro" => CacheDevMetadataMode::ReadOnly,
-            val => panic!(format!(
-                "Kernel returned unexpected {}th value \"{}\" in thin pool status",
-                rest_start_index + 1,
-                val
-            )),
+            val => {
+                return Err(DmError::Dm(
+                    ErrorEnum::Invalid,
+                    format!(
+                        "Kernel returned unexpected {}th value \"{}\" in thin pool status",
+                        rest_start_index + 1,
+                        val,
+                    ),
+                ))
+            }
         };
 
         let needs_check = match status_vals[rest_start_index + 1] {
             "-" => false,
             "needs_check" => true,
-            val => panic!(format!(
-                "Kernel returned unexpected {}th value \"{}\" in thin pool status",
-                rest_start_index + 2,
-                val
-            )),
+            val => {
+                return Err(DmError::Dm(
+                    ErrorEnum::Invalid,
+                    format!(
+                        "Kernel returned unexpected {}th value \"{}\" in thin pool status",
+                        rest_start_index + 1,
+                        val,
+                    ),
+                ))
+            }
         };
 
         Ok(CacheDevStatus::Working(Box::new(

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -14,8 +14,8 @@ use super::dm_options::DmOptions;
 use super::lineardev::{LinearDev, LinearDevTargetParams};
 use super::result::{DmError, DmResult, ErrorEnum};
 use super::shared::{
-    device_create, device_exists, device_match, parse_device, DmDevice, TargetLine, TargetParams,
-    TargetTable,
+    device_create, device_exists, device_match, parse_device, parse_value, DmDevice, TargetLine,
+    TargetParams, TargetTable,
 };
 use super::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetTypeBuf};
 
@@ -87,25 +87,8 @@ impl FromStr for CacheTargetParams {
         let cache_dev = parse_device(vals[2])?;
         let origin_dev = parse_device(vals[3])?;
 
-        let block_size = vals[4].parse::<u64>().map(Sectors).map_err(|_| {
-            DmError::Dm(
-                ErrorEnum::Invalid,
-                format!(
-                    "failed to parse value for data block size from \"{}\"",
-                    vals[4]
-                ),
-            )
-        })?;
-
-        let num_feature_args = vals[5].parse::<usize>().map_err(|_| {
-            DmError::Dm(
-                ErrorEnum::Invalid,
-                format!(
-                    "failed to parse value for number of feature args from \"{}\"",
-                    vals[5]
-                ),
-            )
-        })?;
+        let block_size = Sectors(parse_value(vals[4], "data block size")?);
+        let num_feature_args: usize = parse_value(vals[5], "number of feature args")?;
 
         let end_feature_args_index = 6 + num_feature_args;
         let feature_args: Vec<String> = vals[6..end_feature_args_index]
@@ -115,17 +98,8 @@ impl FromStr for CacheTargetParams {
 
         let policy = vals[end_feature_args_index].to_owned();
 
-        let num_policy_args = vals[end_feature_args_index + 1]
-            .parse::<usize>()
-            .map_err(|_| {
-                DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "failed to parse value for number of policy args from \"{}\"",
-                        vals[end_feature_args_index + 1]
-                    ),
-                )
-            })?;
+        let num_policy_args: usize =
+            parse_value(vals[end_feature_args_index + 1], "number of policy args")?;
 
         let start_policy_args_index = end_feature_args_index + 2;
         let end_policy_args_index = start_policy_args_index + num_policy_args;
@@ -680,66 +654,26 @@ impl CacheDev {
             let cache_block_size = status_vals[2];
             let cache_usage = status_vals[3].split('/').collect::<Vec<_>>();
             CacheDevUsage::new(
-                Sectors(
-                    meta_block_size
-                        .parse::<u64>()
-                        .expect("meta_block_size value must be valid"),
-                ),
-                MetaBlocks(
-                    meta_usage[0]
-                        .parse::<u64>()
-                        .expect("used_meta value must be valid"),
-                ),
-                MetaBlocks(
-                    meta_usage[1]
-                        .parse::<u64>()
-                        .expect("total_meta value must be valid"),
-                ),
-                Sectors(
-                    cache_block_size
-                        .parse::<u64>()
-                        .expect("cache_block_size value must be valid"),
-                ),
-                DataBlocks(
-                    cache_usage[0]
-                        .parse::<u64>()
-                        .expect("used_cache value must be valid"),
-                ),
-                DataBlocks(
-                    cache_usage[1]
-                        .parse::<u64>()
-                        .expect("total_cache value must be valid"),
-                ),
+                Sectors(parse_value(meta_block_size, "meta block size")?),
+                MetaBlocks(parse_value(meta_usage[0], "used meta")?),
+                MetaBlocks(parse_value(meta_usage[1], "total meta")?),
+                Sectors(parse_value(cache_block_size, "cache block size")?),
+                DataBlocks(parse_value(cache_usage[0], "used cache")?),
+                DataBlocks(parse_value(cache_usage[1], "total cache")?),
             )
         };
 
         let performance = CacheDevPerformance::new(
-            status_vals[4]
-                .parse::<u64>()
-                .expect("read hits value must be valid format"),
-            status_vals[5]
-                .parse::<u64>()
-                .expect("read misses value must be valid format"),
-            status_vals[6]
-                .parse::<u64>()
-                .expect("write hits value must be valid format"),
-            status_vals[7]
-                .parse::<u64>()
-                .expect("write misses value must be valid format"),
-            status_vals[8]
-                .parse::<u64>()
-                .expect("demotions value must be valid format"),
-            status_vals[9]
-                .parse::<u64>()
-                .expect("promotions value must be valid format"),
-            status_vals[10]
-                .parse::<u64>()
-                .expect("dirty value must be valid format"),
+            parse_value(status_vals[4], "read hits")?,
+            parse_value(status_vals[5], "read misses")?,
+            parse_value(status_vals[6], "write hits")?,
+            parse_value(status_vals[7], "write misses")?,
+            parse_value(status_vals[8], "demotions")?,
+            parse_value(status_vals[9], "promotions")?,
+            parse_value(status_vals[10], "dirty")?,
         );
 
-        let num_feature_args = status_vals[11]
-            .parse::<usize>()
-            .expect("number value must be valid format");
+        let num_feature_args: usize = parse_value(status_vals[11], "number of feature args")?;
         let core_args_start_index = 12usize + num_feature_args;
         let feature_args: Vec<String> = status_vals[12..core_args_start_index]
             .iter()

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -68,8 +68,7 @@ impl FromStr for LinearTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let device = parse_device(vals[1])?;
-
+        let device = parse_device(vals[1], "linear dev")?;
         let start = Sectors(parse_value(vals[2], "physical start offset")?);
 
         Ok(LinearTargetParams::new(device, start))
@@ -191,7 +190,7 @@ impl FromStr for FlakeyTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let device = parse_device(vals[1])?;
+        let device = parse_device(vals[1], "flakey device")?;
         let start_offset = Sectors(parse_value(vals[2], "physical start offset")?);
 
         let up_interval = parse_value(vals[3], "up interval")?;

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -68,7 +68,7 @@ impl FromStr for LinearTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let device = parse_device(vals[1], "linear dev")?;
+        let device = parse_device(vals[1], "block device for linear target")?;
         let start = Sectors(parse_value(vals[2], "physical start offset")?);
 
         Ok(LinearTargetParams::new(device, start))
@@ -190,7 +190,7 @@ impl FromStr for FlakeyTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let device = parse_device(vals[1], "flakey device")?;
+        let device = parse_device(vals[1], "block device for flakey target")?;
         let start_offset = Sectors(parse_value(vals[2], "physical start offset")?);
 
         let up_interval = parse_value(vals[3], "up interval")?;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -190,10 +190,7 @@ pub fn parse_device(val: &str, desc: &str) -> DmResult<Device> {
             .ok_or_else(|| {
                 DmError::Dm(
                     ErrorEnum::Invalid,
-                    format!(
-                        "Failed to parse device for \"{}\" from input \"{}\"",
-                        desc, val
-                    ),
+                    format!("Failed to parse \"{}\" from input \"{}\"", desc, val),
                 )
             })?
             .into()

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -199,3 +199,19 @@ pub fn parse_device(val: &str) -> DmResult<Device> {
     };
     Ok(device)
 }
+
+/// Parse a value or return an error.
+pub fn parse_value<T>(val: &str, desc: &str) -> DmResult<T>
+where
+    T: FromStr,
+{
+    val.parse::<T>().map_err(|_| {
+        DmError::Dm(
+            ErrorEnum::Invalid,
+            format!(
+                "Failed to parse value for \"{}\" from input \"{}\"",
+                desc, val
+            ),
+        )
+    })
+}

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -184,13 +184,16 @@ pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
 }
 
 /// Parse a device from either of a path or a maj:min pair
-pub fn parse_device(val: &str) -> DmResult<Device> {
+pub fn parse_device(val: &str, desc: &str) -> DmResult<Device> {
     let device = if val.starts_with('/') {
         devnode_to_devno(Path::new(val))?
             .ok_or_else(|| {
                 DmError::Dm(
                     ErrorEnum::Invalid,
-                    format!("failed to parse device number from \"{}\"", val),
+                    format!(
+                        "Failed to parse device for \"{}\" from input \"{}\"",
+                        desc, val
+                    ),
                 )
             })?
             .into()

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -72,12 +72,12 @@ impl FromStr for ThinTargetParams {
         }
 
         Ok(ThinTargetParams::new(
-            parse_device(vals[1])?,
+            parse_device(vals[1], "pool dev")?,
             vals[2].parse::<ThinDevId>()?,
             if len == 3 {
                 None
             } else {
-                Some(parse_device(vals[3])?)
+                Some(parse_device(vals[3], "external origin dev")?)
             },
         ))
     }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -72,12 +72,15 @@ impl FromStr for ThinTargetParams {
         }
 
         Ok(ThinTargetParams::new(
-            parse_device(vals[1], "pool dev")?,
+            parse_device(vals[1], "thinpool device for thin target")?,
             vals[2].parse::<ThinDevId>()?,
             if len == 3 {
                 None
             } else {
-                Some(parse_device(vals[3], "external origin dev")?)
+                Some(parse_device(
+                    vals[3],
+                    "external origin device for thin snapshot",
+                )?)
             },
         ))
     }

--- a/src/thindevid.rs
+++ b/src/thindevid.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use serde;
 
 use super::result::{DmError, DmResult, ErrorEnum};
+use super::shared::parse_value;
 
 const THIN_DEV_ID_LIMIT: u64 = 0x1_000_000; // 2 ^ 24
 
@@ -50,14 +51,7 @@ impl FromStr for ThinDevId {
     type Err = DmError;
 
     fn from_str(s: &str) -> Result<ThinDevId, DmError> {
-        s.parse::<u64>()
-            .map_err(|_| {
-                DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!("failed to parse value for thindev id \"{}\"", s),
-                )
-            })
-            .map(ThinDevId::new_u64)?
+        Ok(ThinDevId::new_u64(parse_value(s, "thindev id")?)?)
     }
 }
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -507,37 +507,57 @@ impl ThinPoolDev {
             "rw" => ThinPoolStatusSummary::Good,
             "ro" => ThinPoolStatusSummary::ReadOnly,
             "out_of_data_space" => ThinPoolStatusSummary::OutOfSpace,
-            val => panic!(format!(
-                "Kernel returned unexpected 5th value \"{}\" in thin pool status",
-                val
-            )),
+            val => {
+                return Err(DmError::Dm(
+                    ErrorEnum::Invalid,
+                    format!(
+                        "Kernel returned unexpected 5th value \"{}\" in thin pool status",
+                        val
+                    ),
+                ))
+            }
         };
 
         let discard_passdown = match status_vals[5] {
             "discard_passdown" => true,
             "no_discard_passdown" => false,
-            val => panic!(format!(
-                "Kernel returned unexpected 6th value \"{}\" in thin pool status",
-                val
-            )),
+            val => {
+                return Err(DmError::Dm(
+                    ErrorEnum::Invalid,
+                    format!(
+                        "Kernel returned unexpected 6th value \"{}\" in thin pool status",
+                        val
+                    ),
+                ))
+            }
         };
 
         let no_space_policy = match status_vals[6] {
             "error_if_no_space" => ThinPoolNoSpacePolicy::Error,
             "queue_if_no_space" => ThinPoolNoSpacePolicy::Queue,
-            val => panic!(format!(
-                "Kernel returned unexpected 7th value \"{}\" in thin pool status",
-                val
-            )),
+            val => {
+                return Err(DmError::Dm(
+                    ErrorEnum::Invalid,
+                    format!(
+                        "Kernel returned unexpected 7th value \"{}\" in thin pool status",
+                        val
+                    ),
+                ))
+            }
         };
 
         let needs_check = match status_vals[7] {
             "-" => false,
             "needs_check" => true,
-            val => panic!(format!(
-                "Kernel returned unexpected 8th value \"{}\" in thin pool status",
-                val
-            )),
+            val => {
+                return Err(DmError::Dm(
+                    ErrorEnum::Invalid,
+                    format!(
+                        "Kernel returned unexpected 8th value \"{}\" in thin pool status",
+                        val
+                    ),
+                ))
+            }
         };
 
         let meta_low_water = status_vals

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -82,8 +82,8 @@ impl FromStr for ThinPoolTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let metadata_dev = parse_device(vals[1], "metadata dev")?;
-        let data_dev = parse_device(vals[2], "data dev")?;
+        let metadata_dev = parse_device(vals[1], "metadata device for thinpool target")?;
+        let data_dev = parse_device(vals[2], "data device for thinpool target")?;
 
         let data_block_size = Sectors(parse_value(vals[3], "data block size")?);
         let low_water_mark = DataBlocks(parse_value(vals[4], "low water mark")?);

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -82,8 +82,8 @@ impl FromStr for ThinPoolTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let metadata_dev = parse_device(vals[1])?;
-        let data_dev = parse_device(vals[2])?;
+        let metadata_dev = parse_device(vals[1], "metadata dev")?;
+        let data_dev = parse_device(vals[2], "data dev")?;
 
         let data_block_size = Sectors(parse_value(vals[3], "data block size")?);
         let low_water_mark = DataBlocks(parse_value(vals[4], "low water mark")?);


### PR DESCRIPTION
Unify parsing of numbers into values with a function. Since we want to
say WHICH number parsing was bad, also take a description of what was being
parsed.

Use this to streamline places where parsing a number returns an error, but
also in places where parsing a number panics. My former position was that
a change in the kernel ABI (which is what dm status strings are) warranted
a panic but since it's actually easier to return a Result *and* it's
less verbose... why not play nice?

Change some unrelated spots to return an Err instead of panicing.

Add "desc" argument to parse_value() as well as parse_device(). This is
strictly to return error strings that give a little more info.

Signed-off-by: Andy Grover <agrover@redhat.com>