### PR TITLE
Change parse_device() to take a description

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -83,9 +83,9 @@ impl FromStr for CacheTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let metadata_dev = parse_device(vals[1], "metadata dev")?;
-        let cache_dev = parse_device(vals[2], "cache dev")?;
-        let origin_dev = parse_device(vals[3], "origin dev")?;
+        let metadata_dev = parse_device(vals[1], "metadata sub-device for cache target")?;
+        let cache_dev = parse_device(vals[2], "cache sub-device for cache target")?;
+        let origin_dev = parse_device(vals[3], "origin sub-device for cache target")?;
 
         let block_size = vals[4].parse::<u64>().map(Sectors).map_err(|_| {
             DmError::Dm(

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -83,9 +83,9 @@ impl FromStr for CacheTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let metadata_dev = parse_device(vals[1])?;
-        let cache_dev = parse_device(vals[2])?;
-        let origin_dev = parse_device(vals[3])?;
+        let metadata_dev = parse_device(vals[1], "metadata dev")?;
+        let cache_dev = parse_device(vals[2], "cache dev")?;
+        let origin_dev = parse_device(vals[3], "origin dev")?;
 
         let block_size = vals[4].parse::<u64>().map(Sectors).map_err(|_| {
             DmError::Dm(

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -68,8 +68,7 @@ impl FromStr for LinearTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let device = parse_device(vals[1])?;
-
+        let device = parse_device(vals[1], "linear dev")?;
         let start = vals[2].parse::<u64>().map(Sectors).map_err(|_| {
             DmError::Dm(
                 ErrorEnum::Invalid,
@@ -199,7 +198,7 @@ impl FromStr for FlakeyTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let device = parse_device(vals[1])?;
+        let device = parse_device(vals[1], "flakey device")?;
 
         let start_offset = vals[2].parse::<u64>().map(Sectors).map_err(|_| {
             DmError::Dm(

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -68,7 +68,7 @@ impl FromStr for LinearTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let device = parse_device(vals[1], "linear dev")?;
+        let device = parse_device(vals[1], "block device for linear target")?;
         let start = vals[2].parse::<u64>().map(Sectors).map_err(|_| {
             DmError::Dm(
                 ErrorEnum::Invalid,
@@ -198,7 +198,7 @@ impl FromStr for FlakeyTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let device = parse_device(vals[1], "flakey device")?;
+        let device = parse_device(vals[1], "block device for flakey target")?;
 
         let start_offset = vals[2].parse::<u64>().map(Sectors).map_err(|_| {
             DmError::Dm(

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -190,10 +190,7 @@ pub fn parse_device(val: &str, desc: &str) -> DmResult<Device> {
             .ok_or_else(|| {
                 DmError::Dm(
                     ErrorEnum::Invalid,
-                    format!(
-                        "Failed to parse device for \"{}\" from input \"{}\"",
-                        desc, val
-                    ),
+                    format!("Failed to parse \"{}\" from input \"{}\"", desc, val),
                 )
             })?
             .into()

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -184,13 +184,16 @@ pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
 }
 
 /// Parse a device from either of a path or a maj:min pair
-pub fn parse_device(val: &str) -> DmResult<Device> {
+pub fn parse_device(val: &str, desc: &str) -> DmResult<Device> {
     let device = if val.starts_with('/') {
         devnode_to_devno(Path::new(val))?
             .ok_or_else(|| {
                 DmError::Dm(
                     ErrorEnum::Invalid,
-                    format!("failed to parse device number from \"{}\"", val),
+                    format!(
+                        "Failed to parse device for \"{}\" from input \"{}\"",
+                        desc, val
+                    ),
                 )
             })?
             .into()

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -72,12 +72,12 @@ impl FromStr for ThinTargetParams {
         }
 
         Ok(ThinTargetParams::new(
-            parse_device(vals[1])?,
+            parse_device(vals[1], "pool dev")?,
             vals[2].parse::<ThinDevId>()?,
             if len == 3 {
                 None
             } else {
-                Some(parse_device(vals[3])?)
+                Some(parse_device(vals[3], "external origin dev")?)
             },
         ))
     }

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -72,12 +72,15 @@ impl FromStr for ThinTargetParams {
         }
 
         Ok(ThinTargetParams::new(
-            parse_device(vals[1], "pool dev")?,
+            parse_device(vals[1], "thinpool device for thin target")?,
             vals[2].parse::<ThinDevId>()?,
             if len == 3 {
                 None
             } else {
-                Some(parse_device(vals[3], "external origin dev")?)
+                Some(parse_device(
+                    vals[3],
+                    "external origin device for thin snapshot",
+                )?)
             },
         ))
     }

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -82,8 +82,8 @@ impl FromStr for ThinPoolTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let metadata_dev = parse_device(vals[1], "metadata dev")?;
-        let data_dev = parse_device(vals[2], "data dev")?;
+        let metadata_dev = parse_device(vals[1], "metadata device for thinpool target")?;
+        let data_dev = parse_device(vals[2], "data device for thinpool target")?;
 
         let data_block_size = vals[3].parse::<u64>().map(Sectors).map_err(|_| {
             DmError::Dm(

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -82,8 +82,8 @@ impl FromStr for ThinPoolTargetParams {
             return Err(DmError::Dm(ErrorEnum::Invalid, err_msg));
         }
 
-        let metadata_dev = parse_device(vals[1])?;
-        let data_dev = parse_device(vals[2])?;
+        let metadata_dev = parse_device(vals[1], "metadata dev")?;
+        let data_dev = parse_device(vals[2], "data dev")?;
 
         let data_block_size = vals[3].parse::<u64>().map(Sectors).map_err(|_| {
             DmError::Dm(


### PR DESCRIPTION
This lets the error message include info for which value failed to parse.

Signed-off-by: Andy Grover <agrover@redhat.com>