### PR TITLE
An experiment with using the failure crate in devicemapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ newtype_derive = "0.1"
 macro-attr = "0.2.0"
 serde = "1"
 error-chain = "0.12"
+failure = "0.1.3"
+failure_derive = "0.1.3"
 
 [dev-dependencies]
 loopdev = "0.2"

--- a/src/device.rs
+++ b/src/device.rs
@@ -38,22 +38,22 @@ impl FromStr for Device {
         let vals = s.split(':').collect::<Vec<_>>();
         if vals.len() != 2 {
             let err_msg = format!("value \"{}\" split into wrong number of fields", s);
-            return Err(DmError::Core(ErrorKind::InvalidArgument(err_msg).into()));
+            return Err(DmError::Core(
+                ErrorKind::InvalidArgument { t: err_msg }.into(),
+            ));
         }
         let major = vals[0].parse::<u32>().map_err(|_| {
             DmError::Core(
-                ErrorKind::InvalidArgument(format!(
-                    "could not parse \"{}\" to obtain major number",
-                    vals[0]
-                )).into(),
+                ErrorKind::InvalidArgument {
+                    t: format!("could not parse \"{}\" to obtain major number", vals[0]),
+                }.into(),
             )
         })?;
         let minor = vals[1].parse::<u32>().map_err(|_| {
             DmError::Core(
-                ErrorKind::InvalidArgument(format!(
-                    "could not parse \"{}\" to obtain minor number",
-                    vals[0]
-                )).into(),
+                ErrorKind::InvalidArgument {
+                    t: format!("could not parse \"{}\" to obtain minor number", vals[0]),
+                }.into(),
             )
         })?;
         Ok(Device { major, minor })
@@ -114,7 +114,10 @@ pub fn devnode_to_devno(path: &Path) -> DmResult<Option<u64>> {
                 return Ok(None);
             }
             Err(DmError::Core(
-                ErrorKind::MetadataIoError(path.to_owned(), err).into(),
+                ErrorKind::MetadataIoError {
+                    path: path.to_owned(),
+                    e: err,
+                }.into(),
             ))
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,48 +3,108 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std;
+use std::fmt;
 use std::path::PathBuf;
 
+use failure::Context;
 use nix;
 
 use super::deviceinfo::DeviceInfo;
 
-error_chain! {
-    errors {
-        /// An error returned on failure to create a devicemapper context.
-        ContextInitError(e: std::io::Error) {
-            description("DM context not initialized")
-            display("DM context not initialized due to IO error: {}", e)
-        }
+#[derive(Debug, Fail)]
+pub enum ErrorKind {
+    /// An error returned on failure to create a devicemapper context.
+    ContextInitError { e: std::io::Error },
+    /// This is a generic error that can be returned when a method
+    /// receives an invalid argument. Ideally, the argument should be
+    /// invalid in itself, i.e., it should not be made invalid by some
+    /// part of the program state or the environment.
+    InvalidArgument { t: String },
+    /// An error returned exclusively by DM methods.
+    /// This error is initiated in DM::do_ioctl and returned by
+    /// numerous wrapper methods.
+    IoctlError { t: Box<DeviceInfo>, n: nix::Error },
+    /// An error returned when the response exceeds the maximum possible
+    /// size of the ioctl buffer.
+    IoctlResultTooLargeError,
+    /// An error returned on failure to get metadata for a device
+    MetadataIoError { path: PathBuf, e: std::io::Error },
+}
 
-        /// This is a generic error that can be returned when a method
-        /// receives an invalid argument. Ideally, the argument should be
-        /// invalid in itself, i.e., it should not be made invalid by some
-        /// part of the program state or the environment.
-        InvalidArgument(t: String) {
-            description("an invalid argument was passed")
-            display("invalid argument: '{}'", t)
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ErrorKind::ContextInitError { ref e } => {
+                write!(f, "DM context not initialized due to IO error: {}", e)
+            }
+            ErrorKind::InvalidArgument { ref t } => write!(f, "invalid argument: '{}'", t),
+            ErrorKind::IoctlError { ref n, .. } => {
+                write!(f, "low-level ioctl error due to nix error: {}", n)
+            }
+            ErrorKind::IoctlResultTooLargeError => write!(
+                f,
+                "ioctl result too large for maximum buffer size: 4294967295 bytes"
+            ),
+            ErrorKind::MetadataIoError { ref path, ref e } => write!(
+                f,
+                "failed to stat metadata for device at {} due to IO error: {}",
+                path.to_string_lossy(),
+                e
+            ),
         }
+    }
+}
 
-        /// An error returned exclusively by DM methods.
-        /// This error is initiated in DM::do_ioctl and returned by
-        /// numerous wrapper methods.
-        IoctlError(t: Box<DeviceInfo>, n: nix::Error) {
-            description("low-level ioctl error")
-            display("low-level ioctl error due to nix error: {}", n)
-        }
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
 
-        /// An error returned when the response exceeds the maximum possible
-        /// size of the ioctl buffer.
-        IoctlResultTooLargeError {
-            description("ioctl result too large for maximum buffer size: 4294967295 bytes")
-            display("ioctl result too large for maximum buffer size: 4294967295 bytes")
-        }
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
 
-        /// An error returned on failure to get metadata for a device
-        MetadataIoError(path: PathBuf, e: std::io::Error) {
-            description("failed to get metadata for a device")
-            display("failed to stat metadata for device at {} due to IO error: {}", path.to_string_lossy(), e)
+impl Error {
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(kind),
         }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner }
+    }
+}
+
+impl std::error::Error for Error {
+    // TODO: This method has been soft-deprecated as of 1.30.
+    // Remove it as soon as lowest required version of rustc makes that
+    // acceptable.
+    fn description(&self) -> &str {
+        match *self.kind() {
+            ErrorKind::ContextInitError { .. } => "DM context not initialized due to IO error",
+            ErrorKind::InvalidArgument { .. } => "invalid argument",
+            ErrorKind::IoctlError { .. } => "low-level ioctl error due to nix error: {}",
+            ErrorKind::IoctlResultTooLargeError => {
+                "ioctl result too large for maximum buffer size: 4294967295 bytes"
+            }
+            ErrorKind::MetadataIoError { .. } => "failed to get metadata for a device",
+        }
+    }
+
+    // TODO: This method will be deprecated in 1.33.0.
+    // Replace it with source at that time.
+    fn cause(&self) -> Option<&std::error::Error> {
+        None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,9 @@ extern crate tempfile;
 extern crate uuid;
 
 extern crate failure;
+// macro_use is required for rustc 1.25 - 1.28, but its use results in an
+// unused macro error in 1.31.
+#[allow(unused_macros)]
 #[macro_use]
 extern crate failure_derive;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,13 +73,14 @@ extern crate newtype_derive;
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate error_chain;
 extern crate libc;
 #[macro_use]
 extern crate nix;
 extern crate serde;
 
+#[cfg(test)]
+#[macro_use]
+extern crate error_chain;
 #[cfg(test)]
 extern crate libmount;
 #[cfg(test)]
@@ -90,6 +91,10 @@ extern crate loopdev;
 extern crate tempfile;
 #[cfg(test)]
 extern crate uuid;
+
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 
 /// shared constants
 mod consts;

--- a/src/result.rs
+++ b/src/result.rs
@@ -14,8 +14,6 @@ pub enum ErrorEnum {
     Error,
     /// invalid value passed as argument
     Invalid,
-    /// something not found
-    NotFound,
 }
 
 impl fmt::Display for ErrorEnum {

--- a/src/result.rs
+++ b/src/result.rs
@@ -53,6 +53,9 @@ impl fmt::Display for DmError {
 }
 
 impl Error for DmError {
+    // TODO: This method has been soft-deprecated as of 1.30.
+    // Remove it as soon as the lowest required version of rustc makes that
+    // acceptable.
     fn description(&self) -> &str {
         match *self {
             DmError::Core(ref err) => err.description(),

--- a/src/result.rs
+++ b/src/result.rs
@@ -10,6 +10,7 @@ use super::errors;
 /// A very simple breakdown of outer layer errors.
 #[derive(Debug)]
 pub enum ErrorEnum {
+    #[cfg(test)]
     /// generic error code
     Error,
     /// invalid value passed as argument

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -434,7 +434,7 @@ mod tests {
     use super::super::thinpooldev::{minimal_thinpool, ThinPoolStatus};
     use super::super::types::DataBlocks;
 
-    use super::super::errors::{Error, ErrorKind};
+    use super::super::errors::ErrorKind;
 
     use super::*;
 
@@ -509,7 +509,10 @@ mod tests {
             &tp,
             ThinDevId::new_u64(0).expect("is below limit")
         ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
+            Err(DmError::Core(err)) => match err.kind() {
+                ErrorKind::IoctlError { t: _, n: _ } => true,
+                _ => false,
+            },
             _ => false,
         });
 
@@ -556,7 +559,10 @@ mod tests {
 
         // New thindev w/ same id fails.
         assert!(match ThinDev::new(&dm, &id, None, td_size, &tp, thin_id) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
+            Err(DmError::Core(err)) => match err.kind() {
+                ErrorKind::IoctlError { t: _, n: _ } => true,
+                _ => false,
+            },
             _ => false,
         });
 
@@ -891,7 +897,10 @@ mod tests {
         // This should fail
         assert!(
             match ThinDev::setup(&dm, &thin_name, None, tp.size(), &tp, thin_id) {
-                Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
+                Err(DmError::Core(err)) => match err.kind() {
+                    ErrorKind::IoctlError { t: _, n: _ } => true,
+                    _ => false,
+                },
                 _ => false,
             }
         );

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -695,7 +695,7 @@ pub fn minimal_thinpool(dm: &DM, path: &Path) -> ThinPoolDev {
 mod tests {
     use std::path::Path;
 
-    use super::super::errors::{Error, ErrorKind};
+    use super::super::errors::ErrorKind;
     use super::super::loopbacked::test_with_spec;
 
     use super::*;
@@ -774,7 +774,10 @@ mod tests {
             MIN_DATA_BLOCK_SIZE / 2u64,
             DataBlocks(1)
         ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
+            Err(DmError::Core(err)) => match err.kind() {
+                ErrorKind::IoctlError { t: _, n: _ } => true,
+                _ => false,
+            },
             _ => false,
         });
         dm.device_remove(&DevId::Name(&meta_name), &DmOptions::new())

--- a/src/types.rs
+++ b/src/types.rs
@@ -343,12 +343,16 @@ impl fmt::Display for Sectors {
 fn str_check(value: &str, max_allowed_chars: usize) -> DmResult<()> {
     if !value.is_ascii() {
         let err_msg = format!("value {} has some non-ascii characters", value);
-        return Err(DmError::Core(ErrorKind::InvalidArgument(err_msg).into()));
+        return Err(DmError::Core(
+            ErrorKind::InvalidArgument { t: err_msg }.into(),
+        ));
     }
     let num_chars = value.len();
     if num_chars == 0 {
         return Err(DmError::Core(
-            ErrorKind::InvalidArgument("value has zero characters".into()).into(),
+            ErrorKind::InvalidArgument {
+                t: "value has zero characters".into(),
+            }.into(),
         ));
     }
     if num_chars > max_allowed_chars {
@@ -356,7 +360,9 @@ fn str_check(value: &str, max_allowed_chars: usize) -> DmResult<()> {
             "value {} has {} chars which is greater than maximum allowed {}",
             value, num_chars, max_allowed_chars
         );
-        return Err(DmError::Core(ErrorKind::InvalidArgument(err_msg).into()));
+        return Err(DmError::Core(
+            ErrorKind::InvalidArgument { t: err_msg }.into(),
+        ));
     }
     Ok(())
 }
@@ -471,8 +477,6 @@ str_id!(TargetType, TargetTypeBuf, DM_TARGET_TYPE_LEN, str_check);
 
 #[cfg(test)]
 mod tests {
-    use super::super::errors::Error;
-
     use super::*;
 
     #[test]
@@ -486,7 +490,10 @@ mod tests {
     /// Verify that creating an empty DmName is an error.
     pub fn test_empty_name() {
         assert!(match DmName::new("") {
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _))) => true,
+            Err(DmError::Core(err)) => match err.kind() {
+                ErrorKind::InvalidArgument { t: _ } => true,
+                _ => false,
+            },
             _ => false,
         })
     }


### PR DESCRIPTION
This substitutes use of the failure crate for error-chain.

This uses the most complicated failure pattern, the combination of Error and ErrorKind. It breaks the recommendation of having ErrorKind constructors be nullary or only take simple arguments. As a consequence of this, comparison can not be done with equality, and the ```kind()``` method returns a reference to an ErrorKind, rather than a value.

~~It has a serious problem...if I make the Core Error implement std::Error it doesn't compile, complaining about an existing implementation of Fail. I don't know why this is.~~ This is due to the "blanket implementation" of ```Fail``` which I believe is a technical term. If the type implements certain traits and the crate imports ```failure``` then this blanket implementation will be applied. That implementation of ```Fail``` will be the prior one, and an explicit implementation of ```Fail``` will be the conflicting one.

~~One can legally drop the definition of ```fn description()``` from an error implementation in Rust 1.29.1, and I did so, but will that work for the earliest version of Rust that we are required to support? Maybe not.~~