### PR TITLE
Make clippy task an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ addons:
 language: rust
 
 matrix:
+    allow_failures:
+        - env: TASK=clippy
     include:
         - rust: stable
           env: TASK=travis_fmt


### PR DESCRIPTION
clippy wants scope modifiers for allow directives, but my current compiler
won't deal with them. We need to persuade clippy to accept directives
without scope modifiers or compiler to ignore directives with modifiers,
and we haven't figured out how to do that yet.

So, since snapshot is coming up soon, not gating PRs on clippy correctness
seems like a good idea.

I couldn't find any issue about this at clippy repository.

Signed-off-by: mulhern <amulhern@redhat.com>