### PR TITLE
Make clippy a mandatory test once more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ addons:
 language: rust
 
 matrix:
-    allow_failures:
-        - env: TASK=clippy
     include:
         - rust: stable
           env: TASK=travis_fmt

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -328,7 +328,7 @@ pub struct CacheDevWorkingStatus {
 
 impl CacheDevWorkingStatus {
     /// Make a new CacheDevWorkingStatus struct
-    #[allow(too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         usage: CacheDevUsage,
         performance: CacheDevPerformance,
@@ -750,7 +750,7 @@ use super::test_lib::test_name;
 /// The minimum size recommended in the docs for a cache block.
 pub const MIN_CACHE_BLOCK_SIZE: Sectors = Sectors(64); // 32 KiB
 /// The maximum size recommended in the docs for a cache block.
-#[allow(decimal_literal_representation)]
+#[allow(clippy::decimal_literal_representation)]
 pub const MAX_CACHE_BLOCK_SIZE: Sectors = Sectors(2_097_152); // 1 GiB
 
 #[cfg(test)]

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -443,6 +443,7 @@ impl DmDevice<CacheDevTargetTable> for CacheDev {
 impl CacheDev {
     /// Construct a new CacheDev with the given data and meta devs.
     /// Returns an error if the device is already known to the kernel.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         dm: &DM,
         name: &DmName,

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -819,7 +819,7 @@ mod tests {
 
     // Test creating a minimal cache dev.
     // Verify that status method executes and gives reasonable values.
-    fn test_minimal_cache_dev(paths: &[&Path]) -> () {
+    fn test_minimal_cache_dev(paths: &[&Path]) {
         assert!(paths.len() >= 2);
         let dm = DM::new().unwrap();
         let mut cache = minimal_cachedev(&dm, paths);

--- a/src/device.rs
+++ b/src/device.rs
@@ -130,13 +130,13 @@ mod tests {
     #[test]
     /// Verify conversion is correct both ways
     pub fn test_dev_t_conversion() {
-        let test_devt_1: dev_t = 0xabcdef1234567890;
+        let test_devt_1: dev_t = 0xabcd_ef12_3456_7890;
 
         let dev1 = Device::from(test_devt_1);
         // Default glibc dev_t encoding is MMMM Mmmm mmmM MMmm. I guess if
         // we're on a platform where non-default is used, we'll fail.
-        assert_eq!(dev1.major, 0xabcde678);
-        assert_eq!(dev1.minor, 0xf1234590);
+        assert_eq!(dev1.major, 0xabcd_e678);
+        assert_eq!(dev1.minor, 0xf123_4590);
 
         let test_devt_2: dev_t = dev_t::from(dev1);
         assert_eq!(test_devt_1, test_devt_2);
@@ -145,18 +145,18 @@ mod tests {
     #[test]
     /// Verify conversion is correct both ways
     pub fn test_kdev_t_conversion() {
-        let test_devt_1: u32 = 0x12345678;
+        let test_devt_1: u32 = 0x1234_5678;
 
         let dev1 = Device::from_kdev_t(test_devt_1);
         // Default kernel kdev_t "huge" encoding is mmmM MMmm.
         assert_eq!(dev1.major, 0x456);
-        assert_eq!(dev1.minor, 0x12378);
+        assert_eq!(dev1.minor, 0x1_2378);
 
         let test_devt_2: u32 = dev1.to_kdev_t().unwrap();
         assert_eq!(test_devt_1, test_devt_2);
 
         // a Device inexpressible as a kdev_t
-        let dev2 = Device::from(0xabcdef1234567890);
+        let dev2 = Device::from(0xabcd_ef12_3456_7890);
         assert_eq!(dev2.to_kdev_t(), None);
     }
 }

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -69,6 +69,7 @@ impl DmOptions {
 
 impl DM {
     /// Create a new context for communicating with DM.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> DmResult<DM> {
         Ok(DM {
             file: File::open(DM_CTL_PATH)

--- a/src/dm.rs
+++ b/src/dm.rs
@@ -132,7 +132,7 @@ impl DM {
         let cap = v.capacity();
         v.resize(cap, 0);
         let mut hdr = unsafe {
-            #[allow(cast_ptr_alignment)]
+            #[allow(clippy::cast_ptr_alignment)]
             (v.as_mut_ptr() as *mut dmi::Struct_dm_ioctl)
                 .as_mut()
                 .expect("pointer to own structure v can not be NULL")
@@ -167,7 +167,7 @@ impl DM {
             // v.resize() may move the buffer if the requested increase doesn't fit in continuous
             // memory.  Update hdr to the possibly new address.
             hdr = unsafe {
-                #[allow(cast_ptr_alignment)]
+                #[allow(clippy::cast_ptr_alignment)]
                 (v.as_mut_ptr() as *mut dmi::Struct_dm_ioctl)
                     .as_mut()
                     .expect("pointer to own structure v can not be NULL")
@@ -244,7 +244,7 @@ impl DM {
                             let aligned_offset = align_to(offset, size_of::<u64>());
                             let new_slc = &result[aligned_offset..];
 
-                            #[allow(cast_ptr_alignment)]
+                            #[allow(clippy::cast_ptr_alignment)]
                             let nr = unsafe { *(new_slc.as_ptr() as *const u32) };
 
                             Some(nr)
@@ -395,7 +395,7 @@ impl DM {
     ///
     /// This interface is not very friendly to monitoring multiple devices.
     /// Events are also exported via uevents, that method may be preferable.
-    #[allow(type_complexity)]
+    #[allow(clippy::type_complexity)]
     pub fn device_wait(
         &self,
         id: &DevId,
@@ -526,7 +526,7 @@ impl DM {
             };
 
             let dev_slc = unsafe {
-                #[allow(cast_ptr_alignment)]
+                #[allow(clippy::cast_ptr_alignment)]
                 slice::from_raw_parts(
                     result[size_of::<dmi::Struct_dm_target_deps>()..].as_ptr() as *const u64,
                     target_deps.count as usize,
@@ -564,7 +564,7 @@ impl DM {
             for _ in 0..count {
                 let result = &buf[next_off..];
                 let targ = unsafe {
-                    #[allow(cast_ptr_alignment)]
+                    #[allow(clippy::cast_ptr_alignment)]
                     (result.as_ptr() as *const dmi::Struct_dm_target_spec)
                         .as_ref()
                         .expect("assume all parsing succeeds")
@@ -623,7 +623,7 @@ impl DM {
     ///                           &DmOptions::new().set_flags(DmFlags::DM_STATUS_TABLE)).unwrap();
     /// println!("{} {:?}", res.0.name(), res.1);
     /// ```
-    #[allow(type_complexity)]
+    #[allow(clippy::type_complexity)]
     pub fn table_status(
         &self,
         id: &DevId,

--- a/src/dm_flags.rs
+++ b/src/dm_flags.rs
@@ -10,7 +10,7 @@ bitflags! {
     pub struct DmFlags: dmi::__u32 {
         /// In: Device should be read-only.
         /// Out: Device is read-only.
-        #[allow(identity_op)]
+        #[allow(clippy::identity_op)]
         const DM_READONLY             = (1 << 0);
         /// In: Device should be suspended.
         /// Out: Device is suspended.
@@ -55,7 +55,7 @@ bitflags! {
     /// for complete information about the meaning of the flags.
     #[derive(Default)]
     pub struct DmCookie: dmi::__u16 {
-        #[allow(identity_op)]
+        #[allow(clippy::identity_op)]
         /// Disables basic device-mapper udev rules that create symlinks in /dev/<DM_DIR>
         /// directory.
         const DM_UDEV_DISABLE_DM_RULES_FLAG = (1 << 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,7 @@
 //! 6. Optionally loop and re-invoke `poll()` on the fd to wait for more
 //! events.
 
-#![cfg_attr(not(features = "clippy"), allow(unknown_lints))]
-#![allow(doc_markdown)]
+#![allow(clippy::doc_markdown)]
 #![warn(missing_docs)]
 
 #[macro_use]

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -495,7 +495,7 @@ mod tests {
     use super::*;
 
     /// Verify that a new linear dev with 0 segments fails.
-    fn test_empty(_paths: &[&Path]) -> () {
+    fn test_empty(_paths: &[&Path]) {
         assert!(LinearDev::setup(
             &DM::new().unwrap(),
             &test_name("new").expect("valid format"),
@@ -506,7 +506,7 @@ mod tests {
     }
 
     /// Verify that setting an empty table on an existing DM device fails.
-    fn test_empty_table_set(paths: &[&Path]) -> () {
+    fn test_empty_table_set(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -526,7 +526,7 @@ mod tests {
     }
 
     /// Verify that id rename succeeds.
-    fn test_rename_id(paths: &[&Path]) -> () {
+    fn test_rename_id(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -547,7 +547,7 @@ mod tests {
     }
 
     /// Verify that after a rename, the device has the new name.
-    fn test_rename(paths: &[&Path]) -> () {
+    fn test_rename(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -572,7 +572,7 @@ mod tests {
     /// Verify that the size of the devnode is the size of the sum of the
     /// ranges of the segments. Verify that the table contains entries for both
     /// segments.
-    fn test_duplicate_segments(paths: &[&Path]) -> () {
+    fn test_duplicate_segments(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -618,7 +618,7 @@ mod tests {
 
     /// Use five segments, each distinct. If parsing works correctly,
     /// default table should match extracted table.
-    fn test_several_segments(paths: &[&Path]) -> () {
+    fn test_several_segments(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -645,7 +645,7 @@ mod tests {
 
     /// Verify that constructing a second dev with the same name succeeds
     /// only if it has the same list of segments.
-    fn test_same_name(paths: &[&Path]) -> () {
+    fn test_same_name(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -670,7 +670,7 @@ mod tests {
     }
 
     /// Verify constructing a second linear dev with the same segment succeeds.
-    fn test_same_segment(paths: &[&Path]) -> () {
+    fn test_same_segment(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -692,7 +692,7 @@ mod tests {
     }
 
     /// Verify that suspending and immediately resuming doesn't fail.
-    fn test_suspend(paths: &[&Path]) -> () {
+    fn test_suspend(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -507,7 +507,7 @@ mod tests {
 
     /// Verify that setting an empty table on an existing DM device fails.
     fn test_empty_table_set(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let name = test_name("name").expect("valid format");
@@ -527,7 +527,7 @@ mod tests {
 
     /// Verify that id rename succeeds.
     fn test_rename_id(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let name = test_name("name").expect("valid format");
@@ -548,7 +548,7 @@ mod tests {
 
     /// Verify that after a rename, the device has the new name.
     fn test_rename(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let name = test_name("name").expect("valid format");
@@ -573,7 +573,7 @@ mod tests {
     /// ranges of the segments. Verify that the table contains entries for both
     /// segments.
     fn test_duplicate_segments(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let name = test_name("name").expect("valid format");
@@ -619,7 +619,7 @@ mod tests {
     /// Use five segments, each distinct. If parsing works correctly,
     /// default table should match extracted table.
     fn test_several_segments(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let name = test_name("name").expect("valid format");
@@ -646,7 +646,7 @@ mod tests {
     /// Verify that constructing a second dev with the same name succeeds
     /// only if it has the same list of segments.
     fn test_same_name(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let name = test_name("name").expect("valid format");
@@ -671,7 +671,7 @@ mod tests {
 
     /// Verify constructing a second linear dev with the same segment succeeds.
     fn test_same_segment(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let name = test_name("name").expect("valid format");
@@ -693,7 +693,7 @@ mod tests {
 
     /// Verify that suspending and immediately resuming doesn't fail.
     fn test_suspend(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let name = test_name("name").expect("valid format");

--- a/src/loopbacked.rs
+++ b/src/loopbacked.rs
@@ -116,7 +116,7 @@ fn get_devices(count: u8, dir: &TempDir) -> Vec<LoopTestDev> {
 /// Set up count loopbacked devices.
 /// Then, run the designated test.
 /// Then, take down the loop devices.
-pub fn test_with_spec<F>(count: u8, test: F) -> ()
+pub fn test_with_spec<F>(count: u8, test: F)
 where
     F: Fn(&[&Path]) -> () + panic::RefUnwindSafe,
 {

--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -173,7 +173,6 @@ fn dm_test_fs_unmount() -> Result<()> {
         let parser = libmount::mountinfo::Parser::new(mount_data.as_bytes());
 
         for mount_point in parser
-            .into_iter()
             .filter_map(|x| x.ok())
             .filter_map(|m| m.mount_point.into_owned().into_string().ok())
             .filter(|mp| mp.contains(DM_TEST_ID))

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -442,6 +442,7 @@ mod tests {
     const MIN_THIN_DEV_SIZE: Sectors = Sectors(1);
 
     // Return a hashmap of key-value pairs for udev entry.
+    #[allow(clippy::let_and_return)] // Necessary to avoid a borrowing error
     fn get_udev_db_entry(dev_node_search: &PathBuf) -> Option<HashMap<String, String>> {
         // Takes a libudev device entry and returns the properties as a HashMap.
         fn device_as_map(device: &libudev::Device) -> HashMap<String, String> {

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -470,7 +470,7 @@ mod tests {
     }
 
     /// Verify that specifying a size of 0 Sectors will cause a failure.
-    fn test_zero_size(paths: &[&Path]) -> () {
+    fn test_zero_size(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -494,7 +494,7 @@ mod tests {
     /// causes an error. The underlying reason is that the thin pool hasn't
     /// been informed about the thin device by messaging the value of the
     /// thin id.
-    fn test_setup_without_new(paths: &[&Path]) -> () {
+    fn test_setup_without_new(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -524,7 +524,7 @@ mod tests {
     /// Verify that setup() succeeds on an existing device, whether or not
     /// it has been torn down. Verify that it is possible to suspend and resume
     /// the device.
-    fn test_basic(paths: &[&Path]) -> () {
+    fn test_basic(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -586,7 +586,7 @@ mod tests {
 
     /// Test thin device create, load, and snapshot and make sure that all is well with udev
     /// db and symlink generation.
-    fn test_udev_userspace(paths: &[&Path]) -> () {
+    fn test_udev_userspace(paths: &[&Path]) {
         // Make sure we are meeting all our expectations in user space with regards to udev
         // handling.
         fn validate(path_uuid: &Uuid, devnode: &PathBuf) {
@@ -673,7 +673,7 @@ mod tests {
     /// Verify success when taking a snapshot of a ThinDev.  Check that
     /// the size of the snapshot is the same as the source.
     /// Verify that empty thindev has no data usage.
-    fn test_snapshot(paths: &[&Path]) -> () {
+    fn test_snapshot(paths: &[&Path]) {
         assert!(paths.len() >= 1);
         let td_size = MIN_THIN_DEV_SIZE;
         let dm = DM::new().unwrap();
@@ -723,7 +723,7 @@ mod tests {
     /// Verify no failures when creating a thindev from a pool, mounting a
     /// filesystem on the thin device, and writing to that filesystem.
     /// Verify reasonable usage behavior.
-    fn test_filesystem(paths: &[&Path]) -> () {
+    fn test_filesystem(paths: &[&Path]) {
         assert!(paths.len() > 0);
 
         let dm = DM::new().unwrap();
@@ -793,7 +793,7 @@ mod tests {
     /// on ThindevA. Verify that setting the UUID of a snapshot causes the
     /// snapshot to consume approximately the same amount of space as its
     /// source.
-    fn test_snapshot_usage(paths: &[&Path]) -> () {
+    fn test_snapshot_usage(paths: &[&Path]) {
         assert!(paths.len() > 0);
 
         let dm = DM::new().unwrap();
@@ -876,7 +876,7 @@ mod tests {
     /// Verify that destroy() actually deallocates the space from the
     /// thinpool, by attempting to reinstantiate it using the same thin id and
     /// verifying that it fails.
-    fn test_thindev_destroy(paths: &[&Path]) -> () {
+    fn test_thindev_destroy(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -466,7 +466,7 @@ mod tests {
             .scan_devices()
             .unwrap()
             .find(|x| x.devnode().map_or(false, |d| dev_node_search == d))
-            .map_or(None, |dev| Some(device_as_map(&dev)));
+            .and_then(|dev| Some(device_as_map(&dev)));
         result
     }
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -472,7 +472,7 @@ mod tests {
 
     /// Verify that specifying a size of 0 Sectors will cause a failure.
     fn test_zero_size(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
@@ -496,7 +496,7 @@ mod tests {
     /// been informed about the thin device by messaging the value of the
     /// thin id.
     fn test_setup_without_new(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
@@ -526,7 +526,7 @@ mod tests {
     /// it has been torn down. Verify that it is possible to suspend and resume
     /// the device.
     fn test_basic(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
@@ -675,7 +675,7 @@ mod tests {
     /// the size of the snapshot is the same as the source.
     /// Verify that empty thindev has no data usage.
     fn test_snapshot(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
         let td_size = MIN_THIN_DEV_SIZE;
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
@@ -725,7 +725,7 @@ mod tests {
     /// filesystem on the thin device, and writing to that filesystem.
     /// Verify reasonable usage behavior.
     fn test_filesystem(paths: &[&Path]) {
-        assert!(paths.len() > 0);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
@@ -795,7 +795,7 @@ mod tests {
     /// snapshot to consume approximately the same amount of space as its
     /// source.
     fn test_snapshot_usage(paths: &[&Path]) {
-        assert!(paths.len() > 0);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
@@ -878,7 +878,7 @@ mod tests {
     /// thinpool, by attempting to reinstantiate it using the same thin id and
     /// verifying that it fails.
     fn test_thindev_destroy(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -225,6 +225,7 @@ impl ThinDev {
     /// If the specified thin_id is already in use by the thin pool an error
     /// is returned. If the device is already among the list of devices that
     /// dm is aware of, return an error.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         dm: &DM,
         name: &DmName,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -707,7 +707,7 @@ mod tests {
     /// Verify success when constructing a new ThinPoolDev with minimum values
     /// for data block size and metadata device. Check that the status of the
     /// device is as expected.
-    fn test_minimum_values(paths: &[&Path]) -> () {
+    fn test_minimum_values(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();
@@ -745,7 +745,7 @@ mod tests {
     }
 
     /// Verify that data block size less than minimum results in a failure.
-    fn test_low_data_block_size(paths: &[&Path]) -> () {
+    fn test_low_data_block_size(paths: &[&Path]) {
         assert!(paths.len() >= 1);
         let dev = Device::from(devnode_to_devno(paths[0]).unwrap().unwrap());
 
@@ -794,7 +794,7 @@ mod tests {
 
     /// Verify that setting the data table does not fail and results in
     /// the correct size data device.
-    fn test_set_data(paths: &[&Path]) -> () {
+    fn test_set_data(paths: &[&Path]) {
         assert!(paths.len() > 1);
 
         let dm = DM::new().unwrap();
@@ -834,7 +834,7 @@ mod tests {
 
     /// Verify that setting the meta table does not fail and results in
     /// the correct size meta device.
-    fn test_set_meta(paths: &[&Path]) -> () {
+    fn test_set_meta(paths: &[&Path]) {
         assert!(paths.len() > 1);
 
         let dm = DM::new().unwrap();
@@ -870,7 +870,7 @@ mod tests {
     }
 
     /// Just test that suspending and resuming a thinpool has no errors.
-    fn test_suspend(paths: &[&Path]) -> () {
+    fn test_suspend(paths: &[&Path]) {
         assert!(paths.len() >= 1);
 
         let dm = DM::new().unwrap();

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -343,6 +343,7 @@ impl ThinPoolDev {
     /// Returns an error if the device is already known to the kernel.
     /// Returns an error if data_block_size is not within required range.
     /// Precondition: the metadata device does not contain any pool metadata.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         dm: &DM,
         name: &DmName,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -708,7 +708,7 @@ mod tests {
     /// for data block size and metadata device. Check that the status of the
     /// device is as expected.
     fn test_minimum_values(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
@@ -746,7 +746,7 @@ mod tests {
 
     /// Verify that data block size less than minimum results in a failure.
     fn test_low_data_block_size(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
         let dev = Device::from(devnode_to_devno(paths[0]).unwrap().unwrap());
 
         let dm = DM::new().unwrap();
@@ -871,7 +871,7 @@ mod tests {
 
     /// Just test that suspending and resuming a thinpool has no errors.
     fn test_suspend(paths: &[&Path]) {
-        assert!(paths.len() >= 1);
+        assert!(!paths.is_empty());
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);

--- a/src/types.rs
+++ b/src/types.rs
@@ -381,6 +381,7 @@ macro_rules! str_id {
 
         impl $B {
             /// Create a new borrowed identifier from a `&str`.
+            #[allow(clippy::new_ret_no_self)]
             pub fn new(value: &str) -> DmResult<&$B> {
                 $check(value, $MAX - 1)?;
                 Ok(unsafe { &*(value as *const str as *const $B) })
@@ -409,6 +410,7 @@ macro_rules! str_id {
 
         impl $O {
             /// Construct a new owned identifier.
+            #[allow(clippy::new_ret_no_self)]
             pub fn new(value: String) -> DmResult<$O> {
                 $check(&value, $MAX - 1)?;
                 Ok($O { inner: value })

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,7 @@
 // I don't think that casting from usize to u64 could be lossy, unless the
 // code is running on a machine with 128 bit pointers, so this is not a
 // pressing worry.
-#![allow(cast_lossless)]
+#![allow(clippy::cast_lossless)]
 
 use consts::SECTOR_SIZE;
 


### PR DESCRIPTION
Required for newer versions of Rust/clippy.

Signed-off-by: mulhern <amulhern@redhat.com>