### PR TITLE
Make no_discard_passdown the default for thin pools

### DIFF
--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -444,8 +444,9 @@ impl ThinPoolDev {
                 data_block_size,
                 low_water_mark,
                 vec![
-                    "skip_block_zeroing".to_owned(),
                     "error_if_no_space".to_owned(),
+                    "no_discard_passdown".to_owned(),
+                    "skip_block_zeroing".to_owned(),
                 ],
             ),
         )
@@ -716,6 +717,8 @@ mod tests {
             ThinPoolStatus::Working(ref status)
                 if status.summary == ThinPoolStatusSummary::Good =>
             {
+                assert_eq!(status.discard_passdown, false);
+
                 let usage = &status.usage;
                 // Even an empty thinpool requires some metadata.
                 assert!(usage.used_meta > MetaBlocks(0));


### PR DESCRIPTION
Resolves: https://github.com/stratis-storage/stratisd/issues/1374.

See #400, for some remarks on the correct way to go about it.