### PR TITLE
Use v2 of mergify configuration syntax

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,12 @@
-rules:
-  default:
-    disabling_label: "do not merge"
-    protection:
-      required_status_checks:
-        strict: true
-        contexts:
-          - continuous-integration/travis-ci
-          - default
-      required_pull_request_reviews:
-        required_approving_review_count: 2
+pull_request_rules:
+- actions:
+    merge:
+      method: merge
+      rebase_fallback: merge
+      strict: true
+  conditions:
+  - label!=do not merge
+  - '#approved-reviews-by>=2'
+  - status-success=continuous-integration/travis-ci
+  - status-success=default
+  name: default


### PR DESCRIPTION
v1 will become unsupported at the end of January.

Signed-off-by: mulhern <amulhern@redhat.com>