### PR TITLE
Replace trim_right with trim_end

### DIFF
--- a/src/dm.rs
+++ b/src/dm.rs
@@ -580,7 +580,7 @@ impl DM {
                 let params = {
                     let slc = slice_to_null(&result[size_of::<dmi::Struct_dm_target_spec>()..])
                         .expect("assume all parsing succeeds");
-                    String::from_utf8_lossy(slc).trim_right().to_owned()
+                    String::from_utf8_lossy(slc).trim_end().to_owned()
                 };
 
                 targets.push((


### PR DESCRIPTION
trim_right is deprecated in 1.33.0.

trim_end just transitively calls trim_right in current code base, so there
is no semantic change.

Signed-off-by: mulhern <amulhern@redhat.com>