### PR TITLE
Allow deprecated usage in the code produced by an error-chain macro

### DIFF
--- a/src/test_lib.rs
+++ b/src/test_lib.rs
@@ -95,6 +95,10 @@ pub fn test_uuid(name: &str) -> DmResult<DmUuidBuf> {
     DmUuidBuf::new(test_string(name))
 }
 
+// For an explanation see:
+// https://github.com/rust-lang-nursery/error-chain/issues/254.
+// FIXME: Drop dependence on error-chain entirely.
+#[allow(deprecated)]
 mod cleanup_errors {
     use libmount;
     use nix;


### PR DESCRIPTION
error-chain is in maintenance mode and may not fix the problem.
In any case, we would like to move away from error chain.

Signed-off-by: mulhern <amulhern@redhat.com>