### PR TITLE
Remove note about discrepancy between devicemapper code and kernel docs

### DIFF
--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -468,9 +468,6 @@ impl ThinPoolDev {
     /// Get the current status of the thinpool.
     /// Returns an error if there was an error getting the status value.
     /// Panics if there is an error parsing the status value.
-    /// Note: Kernel docs show the ordering of the discard_passdown and the
-    /// summary field opposite to the code below. But this code couldn't
-    /// pass tests unless it were correct and the kernel docs wrong.
     // Justification: see comment above DM::parse_table_status.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
         let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;


### PR DESCRIPTION
Since my doc fix commit cc3ff0af19499f0aaa587f42d3091b4dff49208f
was merged in the kernel the items are listed in the correct order, so
there is nothing to explain.

Signed-off-by: mulhern <amulhern@redhat.com>