### PR TITLE
Tidy up *dev status methods more (final)

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -14,8 +14,8 @@ use crate::dm_options::DmOptions;
 use crate::lineardev::{LinearDev, LinearDevTargetParams};
 use crate::result::{DmError, DmResult, ErrorEnum};
 use crate::shared::{
-    device_create, device_exists, device_match, parse_device, parse_value, DmDevice, TargetLine,
-    TargetParams, TargetTable,
+    device_create, device_exists, device_match, get_status_line_fields, parse_device, parse_value,
+    DmDevice, TargetLine, TargetParams, TargetTable,
 };
 use crate::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetTypeBuf};
 
@@ -371,11 +371,7 @@ impl FromStr for CacheDevStatus {
             return Ok(CacheDevStatus::Fail);
         }
 
-        let status_vals = status_line.split(' ').collect::<Vec<_>>();
-        assert!(
-            status_vals.len() >= 17,
-            "Kernel must return at least 17 values from cache dev status"
-        );
+        let status_vals = get_status_line_fields(status_line, 17)?;
 
         let usage = {
             let meta_block_size = status_vals[0];

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -361,6 +361,106 @@ pub enum CacheDevStatus {
     Fail,
 }
 
+impl FromStr for CacheDevStatus {
+    type Err = DmError;
+
+    // Note: This method is not entirely complete. In particular, *_args values
+    // may require more or better checking or processing.
+    fn from_str(status_line: &str) -> DmResult<CacheDevStatus> {
+        if status_line.starts_with("Fail") {
+            return Ok(CacheDevStatus::Fail);
+        }
+
+        let status_vals = status_line.split(' ').collect::<Vec<_>>();
+        assert!(
+            status_vals.len() >= 17,
+            "Kernel must return at least 17 values from cache dev status"
+        );
+
+        let usage = {
+            let meta_block_size = status_vals[0];
+            let meta_usage = status_vals[1].split('/').collect::<Vec<_>>();
+            let cache_block_size = status_vals[2];
+            let cache_usage = status_vals[3].split('/').collect::<Vec<_>>();
+            CacheDevUsage::new(
+                Sectors(parse_value(meta_block_size, "meta block size")?),
+                MetaBlocks(parse_value(meta_usage[0], "used meta")?),
+                MetaBlocks(parse_value(meta_usage[1], "total meta")?),
+                Sectors(parse_value(cache_block_size, "cache block size")?),
+                DataBlocks(parse_value(cache_usage[0], "used cache")?),
+                DataBlocks(parse_value(cache_usage[1], "total cache")?),
+            )
+        };
+
+        let performance = CacheDevPerformance::new(
+            parse_value(status_vals[4], "read hits")?,
+            parse_value(status_vals[5], "read misses")?,
+            parse_value(status_vals[6], "write hits")?,
+            parse_value(status_vals[7], "write misses")?,
+            parse_value(status_vals[8], "demotions")?,
+            parse_value(status_vals[9], "promotions")?,
+            parse_value(status_vals[10], "dirty")?,
+        );
+
+        let num_feature_args: usize = parse_value(status_vals[11], "number of feature args")?;
+        let core_args_start_index = 12usize + num_feature_args;
+        let feature_args: Vec<String> = status_vals[12..core_args_start_index]
+            .iter()
+            .map(|x| x.to_string())
+            .collect();
+
+        let (policy_start_index, core_args) =
+            CacheDev::parse_pairs(core_args_start_index, &status_vals)?;
+
+        let policy = status_vals[policy_start_index].to_string();
+        let (rest_start_index, policy_args) =
+            CacheDev::parse_pairs(policy_start_index + 1, &status_vals)?;
+
+        let cache_metadata_mode = match status_vals[rest_start_index] {
+            "rw" => CacheDevMetadataMode::Good,
+            "ro" => CacheDevMetadataMode::ReadOnly,
+            val => {
+                return Err(DmError::Dm(
+                    ErrorEnum::Invalid,
+                    format!(
+                        "Kernel returned unexpected {}th value \"{}\" in thin pool status",
+                        rest_start_index + 1,
+                        val,
+                    ),
+                ))
+            }
+        };
+
+        let needs_check = match status_vals[rest_start_index + 1] {
+            "-" => false,
+            "needs_check" => true,
+            val => {
+                return Err(DmError::Dm(
+                    ErrorEnum::Invalid,
+                    format!(
+                        "Kernel returned unexpected {}th value \"{}\" in thin pool status",
+                        rest_start_index + 1,
+                        val,
+                    ),
+                ))
+            }
+        };
+
+        Ok(CacheDevStatus::Working(Box::new(
+            CacheDevWorkingStatus::new(
+                usage,
+                performance,
+                feature_args,
+                core_args,
+                policy,
+                policy_args,
+                cache_metadata_mode,
+                needs_check,
+            ),
+        )))
+    }
+}
+
 /// DM Cache device
 #[derive(Debug)]
 pub struct CacheDev {
@@ -625,8 +725,6 @@ impl CacheDev {
     }
 
     /// Get the current status of the cache device.
-    // Note: This method is not entirely complete. In particular, *_args values
-    // may require more or better checking or processing.
     pub fn status(&self, dm: &DM) -> DmResult<CacheDevStatus> {
         let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
 
@@ -636,98 +734,7 @@ impl CacheDev {
             "Kernel must return 1 line from cache dev status"
         );
 
-        let status_line = &status.first().expect("assertion above holds").3;
-        if status_line.starts_with("Fail") {
-            return Ok(CacheDevStatus::Fail);
-        }
-
-        let status_vals = status_line.split(' ').collect::<Vec<_>>();
-        assert!(
-            status_vals.len() >= 17,
-            "Kernel must return at least 17 values from cache dev status"
-        );
-
-        let usage = {
-            let meta_block_size = status_vals[0];
-            let meta_usage = status_vals[1].split('/').collect::<Vec<_>>();
-            let cache_block_size = status_vals[2];
-            let cache_usage = status_vals[3].split('/').collect::<Vec<_>>();
-            CacheDevUsage::new(
-                Sectors(parse_value(meta_block_size, "meta block size")?),
-                MetaBlocks(parse_value(meta_usage[0], "used meta")?),
-                MetaBlocks(parse_value(meta_usage[1], "total meta")?),
-                Sectors(parse_value(cache_block_size, "cache block size")?),
-                DataBlocks(parse_value(cache_usage[0], "used cache")?),
-                DataBlocks(parse_value(cache_usage[1], "total cache")?),
-            )
-        };
-
-        let performance = CacheDevPerformance::new(
-            parse_value(status_vals[4], "read hits")?,
-            parse_value(status_vals[5], "read misses")?,
-            parse_value(status_vals[6], "write hits")?,
-            parse_value(status_vals[7], "write misses")?,
-            parse_value(status_vals[8], "demotions")?,
-            parse_value(status_vals[9], "promotions")?,
-            parse_value(status_vals[10], "dirty")?,
-        );
-
-        let num_feature_args: usize = parse_value(status_vals[11], "number of feature args")?;
-        let core_args_start_index = 12usize + num_feature_args;
-        let feature_args: Vec<String> = status_vals[12..core_args_start_index]
-            .iter()
-            .map(|x| x.to_string())
-            .collect();
-
-        let (policy_start_index, core_args) =
-            CacheDev::parse_pairs(core_args_start_index, &status_vals)?;
-
-        let policy = status_vals[policy_start_index].to_string();
-        let (rest_start_index, policy_args) =
-            CacheDev::parse_pairs(policy_start_index + 1, &status_vals)?;
-
-        let cache_metadata_mode = match status_vals[rest_start_index] {
-            "rw" => CacheDevMetadataMode::Good,
-            "ro" => CacheDevMetadataMode::ReadOnly,
-            val => {
-                return Err(DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "Kernel returned unexpected {}th value \"{}\" in thin pool status",
-                        rest_start_index + 1,
-                        val,
-                    ),
-                ))
-            }
-        };
-
-        let needs_check = match status_vals[rest_start_index + 1] {
-            "-" => false,
-            "needs_check" => true,
-            val => {
-                return Err(DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "Kernel returned unexpected {}th value \"{}\" in thin pool status",
-                        rest_start_index + 1,
-                        val,
-                    ),
-                ))
-            }
-        };
-
-        Ok(CacheDevStatus::Working(Box::new(
-            CacheDevWorkingStatus::new(
-                usage,
-                performance,
-                feature_args,
-                core_args,
-                policy,
-                policy_args,
-                cache_metadata_mode,
-                needs_check,
-            ),
-        )))
+        status.first().expect("assertion above holds").3.parse()
     }
 }
 

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -14,8 +14,9 @@ use crate::dm_options::DmOptions;
 use crate::lineardev::{LinearDev, LinearDevTargetParams};
 use crate::result::{DmError, DmResult, ErrorEnum};
 use crate::shared::{
-    device_create, device_exists, device_match, get_status_line_fields, parse_device, parse_value,
-    DmDevice, TargetLine, TargetParams, TargetTable,
+    device_create, device_exists, device_match, get_status_line_fields,
+    make_unexpected_value_error, parse_device, parse_value, DmDevice, TargetLine, TargetParams,
+    TargetTable,
 };
 use crate::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetTypeBuf};
 
@@ -416,14 +417,11 @@ impl FromStr for CacheDevStatus {
             "rw" => CacheDevMetadataMode::Good,
             "ro" => CacheDevMetadataMode::ReadOnly,
             val => {
-                return Err(DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "Kernel returned unexpected {}th value \"{}\" in thin pool status",
-                        rest_start_index + 1,
-                        val,
-                    ),
-                ))
+                return Err(make_unexpected_value_error(
+                    rest_start_index + 1,
+                    val,
+                    "cache metadata mode",
+                ));
             }
         };
 
@@ -431,13 +429,10 @@ impl FromStr for CacheDevStatus {
             "-" => false,
             "needs_check" => true,
             val => {
-                return Err(DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "Kernel returned unexpected {}th value \"{}\" in thin pool status",
-                        rest_start_index + 1,
-                        val,
-                    ),
+                return Err(make_unexpected_value_error(
+                    rest_start_index + 1,
+                    val,
+                    "needs check",
                 ))
             }
         };

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -216,3 +216,23 @@ where
         )
     })
 }
+
+/// Get fields for a single status line.
+/// Return an error if an insufficient number of fields are obtained.
+pub fn get_status_line_fields<'a>(
+    status_line: &'a str,
+    number_required: usize,
+) -> DmResult<Vec<&'a str>> {
+    let status_vals = status_line.split(' ').collect::<Vec<_>>();
+    let length = status_vals.len();
+    if length < number_required {
+        return Err(DmError::Dm(
+            ErrorEnum::Invalid,
+            format!(
+                "Insufficient number of fields for status; requires at least {}, found only {} in status line \"{}\"",
+                number_required, length, status_line
+            ),
+        ));
+    }
+    Ok(status_vals)
+}

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -236,3 +236,16 @@ pub fn get_status_line_fields<'a>(
     }
     Ok(status_vals)
 }
+
+/// Construct an error when parsing yields an unexpected value.
+/// Indicate the location of the unexpected value, 1-indexed, its actual
+/// value, and the name of the expected thing.
+pub fn make_unexpected_value_error(value_index: usize, value: &str, item_name: &str) -> DmError {
+    DmError::Dm(
+        ErrorEnum::Invalid,
+        format!(
+            "Kernel returned unexpected {}th value \"{}\" for item representing {} in status result",
+            value_index, value, item_name
+        ),
+    )
+}

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -13,8 +13,8 @@ use crate::dm_flags::{DmCookie, DmFlags};
 use crate::dm_options::DmOptions;
 use crate::result::{DmError, DmResult, ErrorEnum};
 use crate::shared::{
-    device_create, device_exists, device_match, message, parse_device, parse_value, DmDevice,
-    TargetLine, TargetParams, TargetTable,
+    device_create, device_exists, device_match, get_status_line_fields, message, parse_device,
+    parse_value, DmDevice, TargetLine, TargetParams, TargetTable,
 };
 use crate::thindevid::ThinDevId;
 use crate::thinpooldev::ThinPoolDev;
@@ -227,11 +227,7 @@ impl FromStr for ThinStatus {
             return Ok(ThinStatus::Fail);
         }
 
-        let status_vals = status_line.split(' ').collect::<Vec<_>>();
-        assert!(
-            status_vals.len() >= 2,
-            "Kernel must return at least 2 values from thin pool status"
-        );
+        let status_vals = get_status_line_fields(status_line, 2)?;
 
         let count = Sectors(parse_value(status_vals[0], "sector count")?);
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -219,6 +219,34 @@ pub enum ThinStatus {
     Fail,
 }
 
+impl FromStr for ThinStatus {
+    type Err = DmError;
+
+    fn from_str(status_line: &str) -> DmResult<ThinStatus> {
+        if status_line.starts_with("Fail") {
+            return Ok(ThinStatus::Fail);
+        }
+
+        let status_vals = status_line.split(' ').collect::<Vec<_>>();
+        assert!(
+            status_vals.len() >= 2,
+            "Kernel must return at least 2 values from thin pool status"
+        );
+
+        let count = Sectors(parse_value(status_vals[0], "sector count")?);
+
+        let highest = if count == Sectors(0) {
+            None
+        } else {
+            Some(Sectors(parse_value(status_vals[1], "highest used sector")?))
+        };
+
+        Ok(ThinStatus::Working(Box::new(ThinDevWorkingStatus::new(
+            count, highest,
+        ))))
+    }
+}
+
 /// support use of DM for thin provisioned devices over pools
 impl ThinDev {
     /// Create a ThinDev using thin_pool as the backing store.
@@ -368,28 +396,7 @@ impl ThinDev {
             "Kernel must return 1 line table for thin status"
         );
 
-        let status_line = &table.first().expect("assertion above holds").3;
-        if status_line.starts_with("Fail") {
-            return Ok(ThinStatus::Fail);
-        }
-
-        let status_vals = status_line.split(' ').collect::<Vec<_>>();
-        assert!(
-            status_vals.len() >= 2,
-            "Kernel must return at least 2 values from thin pool status"
-        );
-
-        let count = Sectors(parse_value(status_vals[0], "sector count")?);
-
-        let highest = if count == Sectors(0) {
-            None
-        } else {
-            Some(Sectors(parse_value(status_vals[1], "highest used sector")?))
-        };
-
-        Ok(ThinStatus::Working(Box::new(ThinDevWorkingStatus::new(
-            count, highest,
-        ))))
+        table.first().expect("assertion above holds").3.parse()
     }
 
     /// Set the table for the thin device's target

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -565,8 +565,6 @@ impl ThinPoolDev {
 
     /// Get the current status of the thinpool.
     /// Returns an error if there was an error getting the status value.
-    /// Panics if there is an error parsing the status value.
-    // Justification: see comment above DM::parse_table_status.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
         let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -14,8 +14,8 @@ use crate::dm_options::DmOptions;
 use crate::lineardev::{LinearDev, LinearDevTargetParams};
 use crate::result::{DmError, DmResult, ErrorEnum};
 use crate::shared::{
-    device_create, device_exists, device_match, parse_device, parse_value, DmDevice, TargetLine,
-    TargetParams, TargetTable,
+    device_create, device_exists, device_match, get_status_line_fields, parse_device, parse_value,
+    DmDevice, TargetLine, TargetParams, TargetTable,
 };
 use crate::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetTypeBuf};
 
@@ -341,11 +341,7 @@ impl FromStr for ThinPoolStatus {
             return Ok(ThinPoolStatus::Fail);
         }
 
-        let status_vals = status_line.split(' ').collect::<Vec<_>>();
-        assert!(
-            status_vals.len() >= 8,
-            "Kernel must return at least 8 values from thin pool status"
-        );
+        let status_vals = get_status_line_fields(status_line, 8)?;
 
         let transaction_id = parse_value(status_vals[0], "transaction id")?;
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -14,8 +14,9 @@ use crate::dm_options::DmOptions;
 use crate::lineardev::{LinearDev, LinearDevTargetParams};
 use crate::result::{DmError, DmResult, ErrorEnum};
 use crate::shared::{
-    device_create, device_exists, device_match, get_status_line_fields, parse_device, parse_value,
-    DmDevice, TargetLine, TargetParams, TargetTable,
+    device_create, device_exists, device_match, get_status_line_fields,
+    make_unexpected_value_error, parse_device, parse_value, DmDevice, TargetLine, TargetParams,
+    TargetTable,
 };
 use crate::types::{DataBlocks, DevId, DmName, DmUuid, MetaBlocks, Sectors, TargetTypeBuf};
 
@@ -368,13 +369,7 @@ impl FromStr for ThinPoolStatus {
             "ro" => ThinPoolStatusSummary::ReadOnly,
             "out_of_data_space" => ThinPoolStatusSummary::OutOfSpace,
             val => {
-                return Err(DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "Kernel returned unexpected 5th value \"{}\" in thin pool status",
-                        val
-                    ),
-                ))
+                return Err(make_unexpected_value_error(5, val, "summary"));
             }
         };
 
@@ -382,13 +377,7 @@ impl FromStr for ThinPoolStatus {
             "discard_passdown" => true,
             "no_discard_passdown" => false,
             val => {
-                return Err(DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "Kernel returned unexpected 6th value \"{}\" in thin pool status",
-                        val
-                    ),
-                ))
+                return Err(make_unexpected_value_error(6, val, "discard passdown"));
             }
         };
 
@@ -396,13 +385,7 @@ impl FromStr for ThinPoolStatus {
             "error_if_no_space" => ThinPoolNoSpacePolicy::Error,
             "queue_if_no_space" => ThinPoolNoSpacePolicy::Queue,
             val => {
-                return Err(DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "Kernel returned unexpected 7th value \"{}\" in thin pool status",
-                        val
-                    ),
-                ))
+                return Err(make_unexpected_value_error(7, val, "no space policy"));
             }
         };
 
@@ -410,13 +393,7 @@ impl FromStr for ThinPoolStatus {
             "-" => false,
             "needs_check" => true,
             val => {
-                return Err(DmError::Dm(
-                    ErrorEnum::Invalid,
-                    format!(
-                        "Kernel returned unexpected 8th value \"{}\" in thin pool status",
-                        val
-                    ),
-                ))
+                return Err(make_unexpected_value_error(8, val, "needs checK"));
             }
         };
 


### PR DESCRIPTION
The objects of this PR are:
* Better encapsulation.
* To be better prepared for a possible future refactoring that eliminates the concept of distinct kinds of devices entirely.
* To eliminate some needless boiler plate.
* To get rid of the last risky assertion involved in reading a single status line.
* To get rid of some obsoleted comments.
* To parse one last thinpool status value, held metadata root.

This is a continuation of #387 and really resolves #221. It supercedes #410.