### PR TITLE
Get rid of a TODO

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -177,11 +177,9 @@ pub fn device_match<T: TargetTable, D: DmDevice<T>>(
 
 /// Check if a device of the given name exists.
 pub fn device_exists(dm: &DM, name: &DmName) -> DmResult<bool> {
-    // TODO: Why do we have to call .as_ref() here instead of relying on deref
-    // coercion?
     Ok(dm
         .list_devices()
-        .map(|l| l.iter().any(|&(ref n, _, _)| n.as_ref() == name))?)
+        .map(|l| l.iter().any(|&(ref n, _, _)| &**n == name))?)
 }
 
 /// Parse a device from either of a path or a maj:min pair


### PR DESCRIPTION
First we must dereference the value, because it is a reference to a
DmNameBuf. Then we dereference it again, so that the deref can be invoked.
Then, we make it a reference again so that its type matches the type
of the value on RHS of the equal sign.

Signed-off-by: mulhern <amulhern@redhat.com>