### PR TITLE
Modify assert!(match {}) calls in test cases to use assert_matches!()…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ newtype_derive = "0.1"
 macro-attr = "0.2.0"
 serde = "1"
 error-chain = "0.12"
+assert_matches = "1.3.0"
 
 [dev-dependencies]
 loopdev = "0.2"

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -428,7 +428,7 @@ impl FromStr for CacheDevStatus {
                     rest_start_index + 1,
                     val,
                     "needs check",
-                ))
+                ));
             }
         };
 

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -794,10 +794,11 @@ mod tests {
             .unwrap();
 
         let new_uuid = test_uuid("example-9999999999").expect("is valid DM uuid");
-        assert!(match dm.device_rename(&name, &DevId::Uuid(&new_uuid)) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+
+        // Note: this fix is unverified because the test has already failed by this point
+        assert_matches!(dm.device_rename(&name, &DevId::Uuid(&new_uuid)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
@@ -810,10 +811,11 @@ mod tests {
         let uuid = test_uuid("example-363333333333333").expect("is valid DM uuid");
         dm.device_create(&name, Some(&uuid), &DmOptions::new())
             .unwrap();
-        assert!(match dm.device_rename(&name, &DevId::Uuid(&uuid)) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+
+        // Note: this fix is unverified because the test has already failed by this point
+        assert_matches!(dm.device_rename(&name, &DevId::Uuid(&uuid)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
@@ -845,10 +847,11 @@ mod tests {
         let dm = DM::new().unwrap();
         let name = test_name("example-dev").expect("is valid DM name");
         dm.device_create(&name, None, &DmOptions::new()).unwrap();
-        assert!(match dm.device_rename(&name, &DevId::Name(&name)) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+
+        // Note: this fix is unverified because the test has already failed by this point
+        assert_matches!(dm.device_rename(&name, &DevId::Name(&name)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
@@ -865,10 +868,10 @@ mod tests {
         let new_name = test_name("example-dev-2").expect("is valid DM name");
         dm.device_rename(&name, &DevId::Name(&new_name)).unwrap();
 
-        assert!(match dm.device_info(&DevId::Name(&name)) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+        // Note: this fix is unverified because the test has already failed by this point
+        assert_matches!(dm.device_info(&DevId::Name(&name)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+
         assert!(dm.device_info(&DevId::Name(&new_name)).is_ok());
 
         let devices = dm.list_devices().unwrap();
@@ -878,12 +881,13 @@ mod tests {
         let third_name = test_name("example-dev-3").expect("is valid DM name");
         dm.device_create(&third_name, None, &DmOptions::new())
             .unwrap();
-        assert!(
-            match dm.device_rename(&new_name, &DevId::Name(&third_name)) {
-                Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-                _ => false,
-            }
+
+        // Note: this fix is unverified because the test has already failed by this point
+        assert_matches!(
+            dm.device_rename(&new_name, &DevId::Name(&third_name)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
         );
+
         dm.device_remove(&DevId::Name(&third_name), &DmOptions::new())
             .unwrap();
         dm.device_remove(&DevId::Name(&new_name), &DmOptions::new())
@@ -894,25 +898,21 @@ mod tests {
     /// Renaming a device that does not exist yields an error.
     fn sudo_test_rename_non_existant() {
         let new_name = test_name("new_name").expect("is valid DM name");
-        assert!(match DM::new().unwrap().device_rename(
+        assert_matches!(DM::new().unwrap().device_rename(
             &test_name("old_name").expect("is valid DM name"),
-            &DevId::Name(&new_name)
-        ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+            &DevId::Name(&new_name)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
     }
 
     #[test]
     /// Removing a device that does not exist yields an error, unfortunately.
     fn sudo_test_remove_non_existant() {
-        assert!(match DM::new().unwrap().device_remove(
+        assert_matches!(DM::new().unwrap().device_remove(
             &DevId::Name(&test_name("junk").expect("is valid DM name")),
-            &DmOptions::new()
-        ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+            &DmOptions::new()),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
     }
 
     #[test]
@@ -933,26 +933,22 @@ mod tests {
     #[test]
     /// Table status on a non-existant name should return an error.
     fn sudo_test_table_status_non_existant() {
-        assert!(match DM::new().unwrap().table_status(
+        assert_matches!(DM::new().unwrap().table_status(
             &DevId::Name(&test_name("junk").expect("is valid DM name")),
-            &DmOptions::new()
-        ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+            &DmOptions::new()),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
     }
 
     #[test]
     /// Table status on a non-existant name with TABLE_STATUS flag errors.
     fn sudo_test_table_status_non_existant_table() {
         let name = test_name("junk").expect("is valid DM name");
-        assert!(match DM::new().unwrap().table_status(
+        assert_matches!(DM::new().unwrap().table_status(
             &DevId::Name(&name),
-            &DmOptions::new().set_flags(DmFlags::DM_STATUS_TABLE)
-        ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+            &DmOptions::new().set_flags(DmFlags::DM_STATUS_TABLE)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
     }
 
     #[test]
@@ -981,10 +977,8 @@ mod tests {
     /// by name returns an error.
     fn sudo_status_no_name() {
         let name = test_name("example_dev").expect("is valid DM name");
-        assert!(match DM::new().unwrap().device_info(&DevId::Name(&name)) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+        assert_matches!(DM::new().unwrap().device_info(&DevId::Name(&name)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
     }
 
     #[test]
@@ -1000,28 +994,17 @@ mod tests {
 
         dm.device_create(&name, Some(&uuid), &DmOptions::new())
             .unwrap();
-        assert!(
-            match dm.device_create(&name, Some(&uuid), &DmOptions::new()) {
-                Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-                _ => false,
-            }
-        );
-        assert!(match dm.device_create(&name, None, &DmOptions::new()) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
-        assert!(
-            match dm.device_create(&name, Some(&uuid_alt), &DmOptions::new()) {
-                Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-                _ => false,
-            }
-        );
-        assert!(
-            match dm.device_create(&name_alt, Some(&uuid), &DmOptions::new()) {
-                Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-                _ => false,
-            }
-        );
+        assert_matches!(
+            dm.device_create(&name, Some(&uuid), &DmOptions::new()),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(dm.device_create(&name, None, &DmOptions::new()),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(
+            dm.device_create(&name, Some(&uuid_alt), &DmOptions::new()),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))) ;
+        assert_matches!(
+            dm.device_create(&name_alt, Some(&uuid), &DmOptions::new()),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -796,8 +796,10 @@ mod tests {
         let new_uuid = test_uuid("example-9999999999").expect("is valid DM uuid");
 
         // Note: this fix is unverified because the test has already failed by this point
-        assert_matches!(dm.device_rename(&name, &DevId::Uuid(&new_uuid)),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(
+            dm.device_rename(&name, &DevId::Uuid(&new_uuid)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
 
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
@@ -813,8 +815,10 @@ mod tests {
             .unwrap();
 
         // Note: this fix is unverified because the test has already failed by this point
-        assert_matches!(dm.device_rename(&name, &DevId::Uuid(&uuid)),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(
+            dm.device_rename(&name, &DevId::Uuid(&uuid)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
 
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
@@ -849,8 +853,10 @@ mod tests {
         dm.device_create(&name, None, &DmOptions::new()).unwrap();
 
         // Note: this fix is unverified because the test has already failed by this point
-        assert_matches!(dm.device_rename(&name, &DevId::Name(&name)),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(
+            dm.device_rename(&name, &DevId::Name(&name)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
 
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
@@ -869,8 +875,10 @@ mod tests {
         dm.device_rename(&name, &DevId::Name(&new_name)).unwrap();
 
         // Note: this fix is unverified because the test has already failed by this point
-        assert_matches!(dm.device_info(&DevId::Name(&name)),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(
+            dm.device_info(&DevId::Name(&name)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
 
         assert!(dm.device_info(&DevId::Name(&new_name)).is_ok());
 
@@ -898,9 +906,11 @@ mod tests {
     /// Renaming a device that does not exist yields an error.
     fn sudo_test_rename_non_existant() {
         let new_name = test_name("new_name").expect("is valid DM name");
-        assert_matches!(DM::new().unwrap().device_rename(
-            &test_name("old_name").expect("is valid DM name"),
-            &DevId::Name(&new_name)),
+        assert_matches!(
+            DM::new().unwrap().device_rename(
+                &test_name("old_name").expect("is valid DM name"),
+                &DevId::Name(&new_name)
+            ),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
         );
     }
@@ -908,9 +918,11 @@ mod tests {
     #[test]
     /// Removing a device that does not exist yields an error, unfortunately.
     fn sudo_test_remove_non_existant() {
-        assert_matches!(DM::new().unwrap().device_remove(
-            &DevId::Name(&test_name("junk").expect("is valid DM name")),
-            &DmOptions::new()),
+        assert_matches!(
+            DM::new().unwrap().device_remove(
+                &DevId::Name(&test_name("junk").expect("is valid DM name")),
+                &DmOptions::new()
+            ),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
         );
     }
@@ -933,9 +945,11 @@ mod tests {
     #[test]
     /// Table status on a non-existant name should return an error.
     fn sudo_test_table_status_non_existant() {
-        assert_matches!(DM::new().unwrap().table_status(
-            &DevId::Name(&test_name("junk").expect("is valid DM name")),
-            &DmOptions::new()),
+        assert_matches!(
+            DM::new().unwrap().table_status(
+                &DevId::Name(&test_name("junk").expect("is valid DM name")),
+                &DmOptions::new()
+            ),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
         );
     }
@@ -944,9 +958,11 @@ mod tests {
     /// Table status on a non-existant name with TABLE_STATUS flag errors.
     fn sudo_test_table_status_non_existant_table() {
         let name = test_name("junk").expect("is valid DM name");
-        assert_matches!(DM::new().unwrap().table_status(
-            &DevId::Name(&name),
-            &DmOptions::new().set_flags(DmFlags::DM_STATUS_TABLE)),
+        assert_matches!(
+            DM::new().unwrap().table_status(
+                &DevId::Name(&name),
+                &DmOptions::new().set_flags(DmFlags::DM_STATUS_TABLE)
+            ),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
         );
     }
@@ -977,8 +993,10 @@ mod tests {
     /// by name returns an error.
     fn sudo_status_no_name() {
         let name = test_name("example_dev").expect("is valid DM name");
-        assert_matches!(DM::new().unwrap().device_info(&DevId::Name(&name)),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(
+            DM::new().unwrap().device_info(&DevId::Name(&name)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
     }
 
     #[test]
@@ -996,15 +1014,20 @@ mod tests {
             .unwrap();
         assert_matches!(
             dm.device_create(&name, Some(&uuid), &DmOptions::new()),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
-        assert_matches!(dm.device_create(&name, None, &DmOptions::new()),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
+        assert_matches!(
+            dm.device_create(&name, None, &DmOptions::new()),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
         assert_matches!(
             dm.device_create(&name, Some(&uuid_alt), &DmOptions::new()),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))) ;
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
         assert_matches!(
             dm.device_create(&name_alt, Some(&uuid), &DmOptions::new()),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -795,7 +795,6 @@ mod tests {
 
         let new_uuid = test_uuid("example-9999999999").expect("is valid DM uuid");
 
-        // Note: this fix is unverified because the test has already failed by this point
         assert_matches!(
             dm.device_rename(&name, &DevId::Uuid(&new_uuid)),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
@@ -813,8 +812,6 @@ mod tests {
         let uuid = test_uuid("example-363333333333333").expect("is valid DM uuid");
         dm.device_create(&name, Some(&uuid), &DmOptions::new())
             .unwrap();
-
-        // Note: this fix is unverified because the test has already failed by this point
         assert_matches!(
             dm.device_rename(&name, &DevId::Uuid(&uuid)),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
@@ -874,7 +871,6 @@ mod tests {
         let new_name = test_name("example-dev-2").expect("is valid DM name");
         dm.device_rename(&name, &DevId::Name(&new_name)).unwrap();
 
-        // Note: this fix is unverified because the test has already failed by this point
         assert_matches!(
             dm.device_info(&DevId::Name(&name)),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
@@ -890,7 +886,6 @@ mod tests {
         dm.device_create(&third_name, None, &DmOptions::new())
             .unwrap();
 
-        // Note: this fix is unverified because the test has already failed by this point
         assert_matches!(
             dm.device_rename(&new_name, &DevId::Name(&third_name)),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -849,7 +849,6 @@ mod tests {
         let name = test_name("example-dev").expect("is valid DM name");
         dm.device_create(&name, None, &DmOptions::new()).unwrap();
 
-        // Note: this fix is unverified because the test has already failed by this point
         assert_matches!(
             dm.device_rename(&name, &DevId::Name(&name)),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))

--- a/src/id_macros.rs
+++ b/src/id_macros.rs
@@ -130,28 +130,20 @@ mod tests {
     #[test]
     /// Test for errors on an empty name.
     fn test_empty_name() {
-        assert!(match Id::new("") {
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _))) => true,
-            _ => false,
-        });
-        assert!(match IdBuf::new("".into()) {
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _))) => true,
-            _ => false,
-        })
+        assert_matches!(Id::new(""),
+            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))) ;
+        assert_matches!(IdBuf::new("".into()),
+            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))) ;
     }
 
     #[test]
     /// Test for errors on an overlong name.
     fn test_too_long_name() {
         let name = iter::repeat('a').take(TYPE_LEN + 1).collect::<String>();
-        assert!(match Id::new(&name) {
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _))) => true,
-            _ => false,
-        });
-        assert!(match IdBuf::new(name) {
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _))) => true,
-            _ => false,
-        })
+        assert_matches!(Id::new(&name),
+            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))) ;
+        assert_matches!(IdBuf::new(name),
+            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))) ;
     }
 
     #[test]

--- a/src/id_macros.rs
+++ b/src/id_macros.rs
@@ -130,20 +130,28 @@ mod tests {
     #[test]
     /// Test for errors on an empty name.
     fn test_empty_name() {
-        assert_matches!(Id::new(""),
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))) ;
-        assert_matches!(IdBuf::new("".into()),
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))) ;
+        assert_matches!(
+            Id::new(""),
+            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))
+        );
+        assert_matches!(
+            IdBuf::new("".into()),
+            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))
+        );
     }
 
     #[test]
     /// Test for errors on an overlong name.
     fn test_too_long_name() {
         let name = iter::repeat('a').take(TYPE_LEN + 1).collect::<String>();
-        assert_matches!(Id::new(&name),
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))) ;
-        assert_matches!(IdBuf::new(name),
-            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))) ;
+        assert_matches!(
+            Id::new(&name),
+            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))
+        );
+        assert_matches!(
+            IdBuf::new(name),
+            Err(DmError::Core(Error(ErrorKind::InvalidArgument(_), _)))
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,11 @@ mod loopbacked;
 #[cfg(test)]
 mod test_lib;
 
+/// More useful test output for match cases
+#[cfg(test)]
+#[macro_use]
+extern crate assert_matches;
+
 pub use crate::cachedev::{
     CacheDev, CacheDevPerformance, CacheDevStatus, CacheDevUsage, CacheDevWorkingStatus,
     MAX_CACHE_BLOCK_SIZE, MIN_CACHE_BLOCK_SIZE,

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -542,13 +542,10 @@ mod tests {
         assert_eq!(table.params.pool, tp.device());
         assert_eq!(table.params.thin_id, thin_id);
 
-        // Note: assert_matches cannot do a negative assertion, thus the following workaround
-        let status: bool = match td.status(&dm).unwrap() {
+        assert!(match td.status(&dm).unwrap() {
             ThinStatus::Fail => false,
             _ => true,
-        };
-
-        assert_eq!(status, true);
+        });
 
         assert_eq!(
             blkdev_size(&OpenOptions::new().read(true).open(td.devnode()).unwrap()),

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -499,14 +499,17 @@ mod tests {
         let mut tp = minimal_thinpool(&dm, paths[0]);
 
         let td_size = MIN_THIN_DEV_SIZE;
-        assert_matches!(ThinDev::setup(
-            &dm,
-            &test_name("name").expect("is valid DM name"),
-            None,
-            td_size,
-            &tp,
-            ThinDevId::new_u64(0).expect("is below limit")
-        ),Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(
+            ThinDev::setup(
+                &dm,
+                &test_name("name").expect("is valid DM name"),
+                None,
+                td_size,
+                &tp,
+                ThinDevId::new_u64(0).expect("is below limit")
+            ),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
 
         tp.teardown(&dm).unwrap();
     }
@@ -545,7 +548,7 @@ mod tests {
             _ => true,
         };
 
-        assert_eq!(status,true);
+        assert_eq!(status, true);
 
         assert_eq!(
             blkdev_size(&OpenOptions::new().read(true).open(td.devnode()).unwrap()),
@@ -553,8 +556,10 @@ mod tests {
         );
 
         // New thindev w/ same id fails.
-        assert_matches!(ThinDev::new(&dm, &id, None, td_size, &tp, thin_id),
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))));
+        assert_matches!(
+            ThinDev::new(&dm, &id, None, td_size, &tp, thin_id),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
 
         // Verify that the device of that name does exist.
         assert!(device_exists(&dm, &id).unwrap());

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -752,14 +752,16 @@ mod tests {
         )];
         let data = LinearDev::setup(&dm, &data_name, None, data_table).unwrap();
 
-        assert_matches!(ThinPoolDev::new(
-            &dm,
-            &test_name("pool").expect("valid format"),
-            None,
-            meta,
-            data,
-            MIN_DATA_BLOCK_SIZE / 2u64,
-            DataBlocks(1)),
+        assert_matches!(
+            ThinPoolDev::new(
+                &dm,
+                &test_name("pool").expect("valid format"),
+                None,
+                meta,
+                data,
+                MIN_DATA_BLOCK_SIZE / 2u64,
+                DataBlocks(1)
+            ),
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
         );
         dm.device_remove(&DevId::Name(&meta_name), &DmOptions::new())

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -752,18 +752,16 @@ mod tests {
         )];
         let data = LinearDev::setup(&dm, &data_name, None, data_table).unwrap();
 
-        assert!(match ThinPoolDev::new(
+        assert_matches!(ThinPoolDev::new(
             &dm,
             &test_name("pool").expect("valid format"),
             None,
             meta,
             data,
             MIN_DATA_BLOCK_SIZE / 2u64,
-            DataBlocks(1)
-        ) {
-            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _))) => true,
-            _ => false,
-        });
+            DataBlocks(1)),
+            Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
+        );
         dm.device_remove(&DevId::Name(&meta_name), &DmOptions::new())
             .unwrap();
         dm.device_remove(&DevId::Name(&data_name), &DmOptions::new())


### PR DESCRIPTION
… from crate::assert_matches.

One notable exception: src/thindev.rs:test_basic().
Explanation of the workaround can be found inline at src/thindev.rs:543