### PR TITLE
Use edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/stratis-storage/devicemapper-rs"
 readme = "README.md"
 keywords = ["Linux", "device", "mapper", "libdm", "storage"]
 license = "MPL-2.0"
+edition = "2018"
 
 [dependencies]
 libc = "0.2.36"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DENY = "-D warnings -D future-incompatible -D unused -D ellipsis-inclusive-range-patterns"
+DENY = "-D warnings -D future-incompatible -D unused -D bare-trait-objects -D ellipsis-inclusive-range-patterns"
 
 ${HOME}/.cargo/bin/cargo-expand:
 	cargo install cargo-expand

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DENY = "-D warnings -D future-incompatible -D unused -D bare-trait-objects -D ellipsis-inclusive-range-patterns"
+DENY = "-D warnings -D future-incompatible -D unused -D bare-trait-objects -D ellipsis-inclusive-range-patterns -D unused-extern-crates"
 
 ${HOME}/.cargo/bin/cargo-expand:
 	cargo install cargo-expand

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DENY = "-D warnings -D future-incompatible -D unused"
+DENY = "-D warnings -D future-incompatible -D unused -D ellipsis-inclusive-range-patterns"
 
 ${HOME}/.cargo/bin/cargo-expand:
 	cargo install cargo-expand

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -233,7 +233,7 @@ impl DM {
                 // drivers/md/dm-ioctl.c:list_devices
                 let event_nr = {
                     match hdr.version[1] {
-                        0...36 => None,
+                        0..=36 => None,
                         _ => {
                             // offsetof "name" in Struct_dm_name_list.
                             // TODO: Consider using pointer::offset_to when stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,21 +69,8 @@
 extern crate bitflags;
 #[macro_use]
 extern crate error_chain;
-extern crate libc;
 #[macro_use]
 extern crate nix;
-extern crate serde;
-
-#[cfg(test)]
-extern crate libmount;
-#[cfg(test)]
-extern crate libudev;
-#[cfg(test)]
-extern crate loopdev;
-#[cfg(test)]
-extern crate tempfile;
-#[cfg(test)]
-extern crate uuid;
 
 /// Range macros
 #[macro_use]

--- a/src/range_macros.rs
+++ b/src/range_macros.rs
@@ -12,7 +12,7 @@ macro_rules! range {
         checked_add!($T);
         debug_macro!($T);
         display!($T, $display_name);
-        serde!($T);
+        serde_macro!($T);
         sum!($T);
         add!($T);
         add_assign!($T);
@@ -121,7 +121,7 @@ macro_rules! display {
     };
 }
 
-macro_rules! serde {
+macro_rules! serde_macro {
     ($T:ident) => {
         impl serde::Serialize for $T {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/testing/loopbacked.rs
+++ b/src/testing/loopbacked.rs
@@ -86,7 +86,7 @@ fn get_devices(count: u8, dir: &TempDir) -> Vec<LoopTestDev> {
 
     for index in 0..count {
         let path = dir.path().join(format!("store{}", &index));
-        let mut f = OpenOptions::new()
+        let f = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)


### PR DESCRIPTION
Set the edition to 2018.

Run "cargo fix" on the source code and accept the changes.
Remove extern declarations that the compiler complains about.
Also, remove some extern declarations that the compiler does not complain about, but which
can be removed anyway.