### PR TITLE
Show expanded macros on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     allow_failures:
         # Allow beta tasks to fail
         - rust: beta
+        # Allow macro-expansion test to fail
+        - rust: nightly
     include:
         # Run rustfmt on the compiler currently recommended for development
         - rust: 1.31.0
@@ -39,6 +41,12 @@ matrix:
         - rust: beta
           sudo: required
           env: TASK=sudo_test
+        # Run "cargo expand" on rust nightly, in order to see expanded macros
+        # that happen to be of interest.
+        - rust: nightly
+          before_script:
+              - rustup component add rustfmt
+          env: TASK=expand
 
 branches:
     only: master

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 DENY = "-D warnings -D future-incompatible -D unused"
 
+${HOME}/.cargo/bin/cargo-expand:
+	cargo install cargo-expand
+
 ${HOME}/.cargo/bin/cargo-tree:
 	cargo install cargo-tree
+
+expand: ${HOME}/.cargo/bin/cargo-expand
+	PATH=${HOME}/.cargo/bin:${PATH} cargo expand core::errors
+	PATH=${HOME}/.cargo/bin:${PATH} cargo expand core::types
+	PATH=${HOME}/.cargo/bin:${PATH} cargo expand units
 
 tree: ${HOME}/.cargo/bin/cargo-tree
 	PATH=${HOME}/.cargo/bin:${PATH} cargo tree


### PR DESCRIPTION
This is a convenience rather than a check, although it may be moved up to a check at some time. It is the case that cargo-expand takes longer than any other of the Travis tasks, however, the configuration file is set up so that the cumulative result is reported as soon as the required tasks are done, so this should not slow work at all.