### PR TITLE
Use #[cfg(test)] for range_macros tests

### DIFF
--- a/src/range_macros.rs
+++ b/src/range_macros.rs
@@ -236,6 +236,7 @@ macro_rules! checked_add {
     };
 }
 
+#[cfg(test)]
 mod tests {
 
     use std::fmt;


### PR DESCRIPTION
This was missing from commit f4f2fdd53940d94431c5022798360b4ea7.