### PR TITLE
Removed the macro_attr and newtype_derive dependencies from definition of units

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ license = "MPL-2.0"
 libc = "0.2.36"
 nix = "0.13"
 bitflags = "1"
-newtype_derive = "0.1"
-macro-attr = "0.2.0"
 serde = "1"
 error-chain = "0.12"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,11 +66,6 @@
 #![warn(missing_docs)]
 
 #[macro_use]
-extern crate macro_attr;
-#[macro_use]
-extern crate newtype_derive;
-
-#[macro_use]
 extern crate bitflags;
 #[macro_use]
 extern crate error_chain;

--- a/src/range_macros.rs
+++ b/src/range_macros.rs
@@ -5,29 +5,24 @@
 // An omnibus macro that includes all simple macros.
 macro_rules! range {
     ($T: ident, $display_name: expr) => {
-        macro_attr! {
-            #[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
-            /// A type for $T
-            pub struct $T(pub u64);
-        }
+        #[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
+        /// A type for $T
+        pub struct $T(pub u64);
 
         checked_add!($T);
-
-        NewtypeAdd! { () pub struct $T(u64); }
-        NewtypeAddAssign! { () pub struct $T(u64); }
-        NewtypeDeref! { () pub struct $T(u64); }
-        NewtypeFrom! { () pub struct $T(u64); }
-        NewtypeSub! { () pub struct $T(u64); }
-        NewtypeSubAssign! { () pub struct $T(u64); }
-
         debug_macro!($T);
         display!($T, $display_name);
         serde!($T);
         sum!($T);
-
+        add!($T);
+        add_assign!($T);
+        sub!($T);
+        sub_assign!($T);
         mul!($T);
         div!($T);
         rem!($T);
+        deref!($T);
+        from!($T);
     };
 }
 
@@ -37,6 +32,69 @@ macro_rules! self_div {
             type Output = u64;
             fn div(self, rhs: $T) -> u64 {
                 self.0 / *rhs
+            }
+        }
+    };
+}
+
+macro_rules! add {
+    ($T:ident) => {
+        impl Add<$T> for $T {
+            type Output = $T;
+            fn add(self, rhs: $T) -> $T {
+                $T(self.0 + *rhs)
+            }
+        }
+    };
+}
+
+macro_rules! sub {
+    ($T:ident) => {
+        impl Sub<$T> for $T {
+            type Output = $T;
+            fn sub(self, rhs: $T) -> $T {
+                $T(self.0 - *rhs)
+            }
+        }
+    };
+}
+
+macro_rules! add_assign {
+    ($T:ident) => {
+        impl AddAssign<$T> for $T {
+            fn add_assign(&mut self, rhs: $T) {
+                *self = $T(self.0 + *rhs)
+            }
+        }
+    };
+}
+
+macro_rules! sub_assign {
+    ($T:ident) => {
+        impl SubAssign<$T> for $T {
+            fn sub_assign(&mut self, rhs: $T) {
+                *self = $T(self.0 - *rhs)
+            }
+        }
+    };
+}
+
+macro_rules! deref {
+    ($T:ident) => {
+        impl Deref for $T {
+            type Target = u64;
+            fn deref(&self) -> &u64 {
+                &self.0
+            }
+        }
+    };
+}
+
+macro_rules! from {
+    ($T:ident) => {
+        impl From<u64> for $T {
+            fn from(t: u64) -> $T {
+                $T(t)
             }
         }
     };
@@ -241,7 +299,7 @@ mod tests {
 
     use std::fmt;
     use std::iter::Sum;
-    use std::ops::{Add, Div, Mul, Rem};
+    use std::ops::{Add, AddAssign, Deref, Div, Mul, Rem, Sub, SubAssign};
     use std::u64;
 
     range!(Units, "units");

--- a/src/units.rs
+++ b/src/units.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 use std::iter::Sum;
-use std::ops::{Add, Div, Mul, Rem};
+use std::ops::{Add, AddAssign, Deref, Div, Mul, Rem, Sub, SubAssign};
 
 use serde;
 


### PR DESCRIPTION
-Wrote macros to implement the traits Add, Sub, AddAssign, SubAssign, Deref, From
-Replaced calls to Newtype macros with these new macros
-Removed the macro_attr and newtype_derive dependencies from definition of units
-Build size reduced by 2.36% (was 9241466, is now 9023322)