### PR TITLE
Turned unused doc comments into regular comments

### DIFF
--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -16,13 +16,13 @@ fn err_func(err_msg: &str) -> DmError {
     DmError::Core(ErrorKind::InvalidArgument(err_msg.into()).into())
 }
 
-/// A devicemapper name. Really just a string, but also the argument type of
-/// DevId::Name. Used in function arguments to indicate that the function
-/// takes only a name, not a devicemapper uuid.
+// A devicemapper name. Really just a string, but also the argument type of
+// DevId::Name. Used in function arguments to indicate that the function
+// takes only a name, not a devicemapper uuid.
 str_id!(DmName, DmNameBuf, DM_NAME_LEN, err_func);
 
-/// A devicemapper uuid. A devicemapper uuid has a devicemapper-specific
-/// format.
+// A devicemapper uuid. A devicemapper uuid has a devicemapper-specific
+// format.
 str_id!(DmUuid, DmUuidBuf, DM_UUID_LEN, err_func);
 
 /// Used as a parameter for functions that take either a Device name

--- a/src/loopbacked.rs
+++ b/src/loopbacked.rs
@@ -16,7 +16,7 @@ use crate::consts::IEC;
 use crate::test_lib::clean_up;
 use crate::units::{Bytes, Sectors, SECTOR_SIZE};
 
-/// send IOCTL via blkgetsize64
+// send IOCTL via blkgetsize64
 ioctl_read!(blkgetsize64, 0x12, 114, u64);
 
 /// get the size of a given block device file


### PR DESCRIPTION
Due to a recent Rust update, several unused documentation comments were causing the beta task to fail. In this PR, I turned those documentation comments into regular comments, so that all Travis CI tasks succeed.