### PR TITLE
Move to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/stratis-storage/devicemapper-rs"
 readme = "README.md"
 keywords = ["Linux", "device", "mapper", "libdm", "storage"]
 license = "MPL-2.0"
+edition = "2018"
 
 [dependencies]
 libc = "0.2.36"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DENY = "-D warnings -D future-incompatible -D unused"
+DENY = "-D warnings -D future-incompatible -D unused -D ellipsis-inclusive-range-patterns"
 
 ${HOME}/.cargo/bin/cargo-expand:
 	cargo install cargo-expand

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-DENY = "-D warnings -D future-incompatible -D unused \
-        -D bare-trait-objects \
-	-D ellipsis-inclusive-range-patterns \
-	-D unused-extern-crates"
+RUST_2018_IDIOMS = -D bare-trait-objects  \
+		   -D ellipsis-inclusive-range-patterns \
+		   -D unused-extern-crates
+
+DENY = -D warnings -D future-incompatible -D unused ${RUST_2018_IDIOMS}
 
 ${HOME}/.cargo/bin/cargo-expand:
 	cargo install cargo-expand
@@ -24,13 +25,13 @@ travis_fmt:
 	cargo fmt -- --check
 
 build:
-	RUSTFLAGS=${DENY} cargo build
+	RUSTFLAGS="${DENY}" cargo build
 
 test:
-	RUSTFLAGS=${DENY} RUST_BACKTRACE=1 cargo test -- --skip sudo_ --skip loop_
+	RUSTFLAGS="${DENY}" RUST_BACKTRACE=1 cargo test -- --skip sudo_ --skip loop_
 
 sudo_test:
-	sudo env "PATH=${PATH}" RUSTFLAGS=${DENY} RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test
+	sudo env "PATH=${PATH}" RUSTFLAGS="${DENY}" RUST_BACKTRACE=1 RUST_TEST_THREADS=1 cargo test
 
 clippy:
 	cargo clippy --all-targets --all-features -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-DENY = "-D warnings -D future-incompatible -D unused -D ellipsis-inclusive-range-patterns"
+DENY = "-D warnings -D future-incompatible -D unused \
+        -D bare-trait-objects \
+	-D ellipsis-inclusive-range-patterns \
+	-D unused-extern-crates"
 
 ${HOME}/.cargo/bin/cargo-expand:
 	cargo install cargo-expand

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -233,7 +233,7 @@ impl DM {
                 // drivers/md/dm-ioctl.c:list_devices
                 let event_nr = {
                     match hdr.version[1] {
-                        0...36 => None,
+                        0..=36 => None,
                         _ => {
                             // offsetof "name" in Struct_dm_name_list.
                             // TODO: Consider using pointer::offset_to when stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,21 +69,8 @@
 extern crate bitflags;
 #[macro_use]
 extern crate error_chain;
-extern crate libc;
 #[macro_use]
 extern crate nix;
-extern crate serde;
-
-#[cfg(test)]
-extern crate libmount;
-#[cfg(test)]
-extern crate libudev;
-#[cfg(test)]
-extern crate loopdev;
-#[cfg(test)]
-extern crate tempfile;
-#[cfg(test)]
-extern crate uuid;
 
 /// Range macros
 #[macro_use]

--- a/src/range_macros.rs
+++ b/src/range_macros.rs
@@ -12,7 +12,7 @@ macro_rules! range {
         checked_add!($T);
         debug_macro!($T);
         display!($T, $display_name);
-        serde!($T);
+        serde_macro!($T);
         sum!($T);
         add!($T);
         add_assign!($T);
@@ -121,7 +121,7 @@ macro_rules! display {
     };
 }
 
-macro_rules! serde {
+macro_rules! serde_macro {
     ($T:ident) => {
         impl serde::Serialize for $T {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/testing/loopbacked.rs
+++ b/src/testing/loopbacked.rs
@@ -86,7 +86,7 @@ fn get_devices(count: u8, dir: &TempDir) -> Vec<LoopTestDev> {
 
     for index in 0..count {
         let path = dir.path().join(format!("store{}", &index));
-        let mut f = OpenOptions::new()
+        let f = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)


### PR DESCRIPTION
Please consult edition 2018 blog entry for an overview of changes:
https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html.

This PR omits enforcing two rust-2018-idioms: elided-lifetime-in-paths and explicit-outlives-requirements. Both are lints which allow the programmer to elide certain lifetime annotations. At this time, these elisions seem to me not to increase the clarity of the code, so I see no reason to enforce them.