### PR TITLE
Abstract getting unique status result into a single method

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -722,8 +722,7 @@ impl CacheDev {
 
     /// Get the current status of the cache device.
     pub fn status(&self, dm: &DM) -> DmResult<CacheDevStatus> {
-        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
-        get_status(&status)?.parse()
+        status!(self, dm)
     }
 }
 

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -14,7 +14,7 @@ use crate::{
     lineardev::{LinearDev, LinearDevTargetParams},
     result::{DmError, DmResult, ErrorEnum},
     shared::{
-        device_create, device_exists, device_match, get_status_line_fields,
+        device_create, device_exists, device_match, get_status, get_status_line_fields,
         make_unexpected_value_error, parse_device, parse_value, DmDevice, TargetLine, TargetParams,
         TargetTable, TargetTypeBuf,
     },
@@ -723,14 +723,7 @@ impl CacheDev {
     /// Get the current status of the cache device.
     pub fn status(&self, dm: &DM) -> DmResult<CacheDevStatus> {
         let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
-
-        assert_eq!(
-            status.len(),
-            1,
-            "Kernel must return 1 line from cache dev status"
-        );
-
-        status.first().expect("assertion above holds").3.parse()
+        get_status(&status)?.parse()
     }
 }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -246,6 +246,27 @@ pub fn get_status_line_fields<'a>(
     Ok(status_vals)
 }
 
+/// Get unique status element from a status result.
+/// Return an error if an incorrect number of lines is obtained.
+pub fn get_status(status_lines: &[(u64, u64, String, String)]) -> DmResult<String> {
+    let length = status_lines.len();
+    if length != 1 {
+        return Err(DmError::Dm(
+            ErrorEnum::Invalid,
+            format!(
+                "Incorrect number of lines for status; expected 1, found {} in status result \"{}\"",
+                length,
+                status_lines.iter().map(|(s, l, t, v)| format!("{} {} {} {}", s, l, t, v)).collect::<Vec<String>>().join(", ")
+            ),
+        ));
+    }
+    Ok(status_lines
+        .first()
+        .expect("if length != 1, already returned")
+        .3
+        .to_owned())
+}
+
 /// Construct an error when parsing yields an unexpected value.
 /// Indicate the location of the unexpected value, 1-indexed, its actual
 /// value, and the name of the expected thing.

--- a/src/shared_macros.rs
+++ b/src/shared_macros.rs
@@ -47,3 +47,13 @@ macro_rules! table {
         &$s.table
     };
 }
+
+macro_rules! status {
+    ($s:ident, $dm:ident) => {
+        get_status(
+            &$dm.table_status(&DevId::Name($s.name()), &DmOptions::new())?
+                .1,
+        )?
+        .parse()
+    };
+}

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -8,8 +8,8 @@ use crate::{
     core::{DevId, Device, DeviceInfo, DmCookie, DmFlags, DmName, DmOptions, DmUuid, DM},
     result::{DmError, DmResult, ErrorEnum},
     shared::{
-        device_create, device_exists, device_match, get_status_line_fields, message, parse_device,
-        parse_value, DmDevice, TargetLine, TargetParams, TargetTable, TargetTypeBuf,
+        device_create, device_exists, device_match, get_status, get_status_line_fields, message,
+        parse_device, parse_value, DmDevice, TargetLine, TargetParams, TargetTable, TargetTypeBuf,
     },
     thindevid::ThinDevId,
     thinpooldev::ThinPoolDev,
@@ -385,14 +385,7 @@ impl ThinDev {
     /// Get the current status of the thin device.
     pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
         let (_, table) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
-
-        assert_eq!(
-            table.len(),
-            1,
-            "Kernel must return 1 line table for thin status"
-        );
-
-        table.first().expect("assertion above holds").3.parse()
+        get_status(&table)?.parse()
     }
 
     /// Set the table for the thin device's target

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -384,8 +384,7 @@ impl ThinDev {
 
     /// Get the current status of the thin device.
     pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
-        let (_, table) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
-        get_status(&table)?.parse()
+        status!(self, dm)
     }
 
     /// Set the table for the thin device's target

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -9,7 +9,7 @@ use crate::{
     lineardev::{LinearDev, LinearDevTargetParams},
     result::{DmError, DmResult, ErrorEnum},
     shared::{
-        device_create, device_exists, device_match, get_status_line_fields,
+        device_create, device_exists, device_match, get_status, get_status_line_fields,
         make_unexpected_value_error, parse_device, parse_value, DmDevice, TargetLine, TargetParams,
         TargetTable, TargetTypeBuf,
     },
@@ -553,14 +553,7 @@ impl ThinPoolDev {
     /// Returns an error if there was an error getting the status value.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
         let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
-
-        assert_eq!(
-            status.len(),
-            1,
-            "Kernel must return 1 line from thin pool status"
-        );
-
-        status.first().expect("assertion above holds").3.parse()
+        get_status(&status)?.parse()
     }
 
     /// Set the table for the existing metadata device.

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -552,8 +552,7 @@ impl ThinPoolDev {
     /// Get the current status of the thinpool.
     /// Returns an error if there was an error getting the status value.
     pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
-        let (_, status) = dm.table_status(&DevId::Name(self.name()), &DmOptions::new())?;
-        get_status(&status)?.parse()
+        status!(self, dm)
     }
 
     /// Set the table for the existing metadata device.


### PR DESCRIPTION
The two contributions of this PR are:
* It eliminates three assertions that aren't logically necessary.
* It abstracts what is one action into a single method.

Related: https://github.com/stratis-storage/project/issues/29