### PR TITLE
Update nix to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.36"
-nix = "0.13"
+nix = "0.14"
 bitflags = "1"
 serde = "1"
 error-chain = "0.12"


### PR DESCRIPTION
This is needed to fix breaking changes in libc on arm and s390x.
See: https://github.com/nix-rust/nix/pull/1055