### PR TITLE
Increase recommended development rust toolchain verson to 1.35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ matrix:
 
         # MANDATORY CHECKS USING CURRENT DEVELOPMENT COMPILER
         # rustfmt
-        - rust: 1.33.0
+        - rust: 1.35.0
           before_script:
               - rustup component add rustfmt
           env: TASK=travis_fmt
         # clippy
-        - rust: 1.33.0
+        - rust: 1.35.0
           before_script:
               - rustup component add clippy
           env: TASK=clippy

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -860,7 +860,7 @@ mod tests {
 
                 assert_eq!(status.needs_check, false);
             }
-            _ => assert!(false),
+            status => panic!("unexpected thinpool status: {:?}", status),
         }
 
         let table = CacheDev::read_kernel_table(&dm, &DevId::Name(cache.name()))

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -707,7 +707,7 @@ mod tests {
                     DataBlocks(tp.data_dev().size() / tp.data_block_size())
                 );
             }
-            _ => assert!(false),
+            status => panic!("unexpected thinpool status: {:?}", status),
         }
 
         let table = ThinPoolDev::read_kernel_table(&dm, &DevId::Name(tp.name()))


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/46.