### PR TITLE
Increase lowest supported rust toolchain to 1.35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 
         # MANDATORY TESTING USING LOWEST SUPPORTED COMPILER
         # tests
-        - rust: 1.33.0
+        - rust: 1.35.0
           env: TASK=test
 
 


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/47.