### PR TITLE
Replace assert! with assert_matches!

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -916,7 +916,7 @@ mod tests {
             extra_length,
             LinearDevTargetParams::Linear(cache_params),
         ));
-        assert!(cache.set_meta_table(&dm, table.clone()).is_ok());
+        assert_matches!(cache.set_meta_table(&dm, table.clone()), Ok(_));
         cache.resume(&dm).unwrap();
 
         match cache.status(&dm).unwrap() {
@@ -970,7 +970,7 @@ mod tests {
             extra_length,
             LinearDevTargetParams::Linear(cache_params),
         ));
-        assert!(cache.set_cache_table(&dm, cache_table.clone()).is_ok());
+        assert_matches!(cache.set_cache_table(&dm, cache_table.clone()), Ok(_));
         cache.resume(&dm).unwrap();
 
         match cache.status(&dm).unwrap() {
@@ -987,7 +987,7 @@ mod tests {
 
         cache_table.pop();
 
-        assert!(cache.set_cache_table(&dm, cache_table).is_ok());
+        assert_matches!(cache.set_cache_table(&dm, cache_table), Ok(_));
         cache.resume(&dm).unwrap();
 
         match cache.status(&dm).unwrap() {

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -724,7 +724,7 @@ mod tests {
     #[test]
     /// Test that some version can be obtained.
     fn sudo_test_version() {
-        assert!(DM::new().unwrap().version().is_ok());
+        assert_matches!(DM::new().unwrap().version(), Ok(_));
     }
 
     #[test]
@@ -836,7 +836,7 @@ mod tests {
             dm.device_info(&DevId::Name(&name)).unwrap().uuid().unwrap(),
             &*uuid
         );
-        assert!(dm.device_info(&DevId::Uuid(&uuid)).is_ok());
+        assert_matches!(dm.device_info(&DevId::Uuid(&uuid)), Ok(_));
         dm.device_remove(&DevId::Name(&name), &DmOptions::new())
             .unwrap();
     }
@@ -875,7 +875,7 @@ mod tests {
             Err(DmError::Core(Error(ErrorKind::IoctlError(_, _), _)))
         );
 
-        assert!(dm.device_info(&DevId::Name(&new_name)).is_ok());
+        assert_matches!(dm.device_info(&DevId::Name(&new_name)), Ok(_));
 
         let devices = dm.list_devices().unwrap();
         assert_eq!(devices.len(), 1);

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -489,13 +489,15 @@ mod tests {
 
     /// Verify that a new linear dev with 0 segments fails.
     fn test_empty(_paths: &[&Path]) {
-        assert!(LinearDev::setup(
-            &DM::new().unwrap(),
-            &test_name("new").expect("valid format"),
-            None,
-            vec![],
-        )
-        .is_err());
+        assert_matches!(
+            LinearDev::setup(
+                &DM::new().unwrap(),
+                &test_name("new").expect("valid format"),
+                None,
+                vec![],
+            ),
+            Err(_)
+        );
     }
 
     /// Verify that setting an empty table on an existing DM device fails.
@@ -513,7 +515,7 @@ mod tests {
         )];
         let mut ld = LinearDev::setup(&dm, &name, None, table).unwrap();
 
-        assert!(ld.set_table(&dm, vec![]).is_err());
+        assert_matches!(ld.set_table(&dm, vec![]), Err(_));
         ld.resume(&dm).unwrap();
         ld.teardown(&dm).unwrap();
     }
@@ -657,8 +659,8 @@ mod tests {
             Sectors(1),
             LinearDevTargetParams::Linear(params2),
         )];
-        assert!(LinearDev::setup(&dm, &name, None, table2).is_err());
-        assert!(LinearDev::setup(&dm, &name, None, table).is_ok());
+        assert_matches!(LinearDev::setup(&dm, &name, None, table2), Err(_));
+        assert_matches!(LinearDev::setup(&dm, &name, None, table), Ok(_));
         ld.teardown(&dm).unwrap();
     }
 
@@ -678,7 +680,7 @@ mod tests {
         )];
         let mut ld = LinearDev::setup(&dm, &name, None, table.clone()).unwrap();
         let ld2 = LinearDev::setup(&dm, &ersatz, None, table);
-        assert!(ld2.is_ok());
+        assert_matches!(ld2, Ok(_));
 
         ld2.unwrap().teardown(&dm).unwrap();
         ld.teardown(&dm).unwrap();

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -475,15 +475,17 @@ mod tests {
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
 
-        assert!(ThinDev::new(
-            &dm,
-            &test_name("name").expect("is valid DM name"),
-            None,
-            Sectors(0),
-            &tp,
-            ThinDevId::new_u64(0).expect("is below limit")
-        )
-        .is_err());
+        assert_matches!(
+            ThinDev::new(
+                &dm,
+                &test_name("name").expect("is valid DM name"),
+                None,
+                Sectors(0),
+                &tp,
+                ThinDevId::new_u64(0).expect("is below limit")
+            ),
+            Err(_)
+        );
 
         udev_settle().unwrap();
         tp.teardown(&dm).unwrap();
@@ -563,11 +565,11 @@ mod tests {
         assert!(device_exists(&dm, &id).unwrap());
 
         // Setting up the just created thin dev succeeds.
-        assert!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).is_ok());
+        assert_matches!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id), Ok(_));
         udev_settle().unwrap();
 
         // Setting up the just created thin dev once more succeeds.
-        assert!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id).is_ok());
+        assert_matches!(ThinDev::setup(&dm, &id, None, td_size, &tp, thin_id), Ok(_));
 
         // Teardown the thindev, then set it back up.
         td.teardown(&dm).unwrap();

--- a/src/thindevid.rs
+++ b/src/thindevid.rs
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     /// Verify that new_checked_u64 discriminates.
     fn test_new_checked_u64() {
-        assert!(ThinDevId::new_u64(2u64.pow(32)).is_err());
-        assert!(ThinDevId::new_u64(THIN_DEV_ID_LIMIT - 1).is_ok());
+        assert_matches!(ThinDevId::new_u64(2u64.pow(32)), Err(_));
+        assert_matches!(ThinDevId::new_u64(THIN_DEV_ID_LIMIT - 1), Ok(_));
     }
 }


### PR DESCRIPTION
Changes:

- Replace assert!(<expr>.is_ok()) with assert_matches!(<expr>, Ok(_))
- Replace assert!(<expr>.is_err()) with assert_matches!(<expr>, Err(_))

Additional information:

- The purpose of these modifications is to provide more useful information
upon assertion failure.