### PR TITLE
Migrate Bytes to u128 internally

### DIFF
--- a/src/testing/test_lib.rs
+++ b/src/testing/test_lib.rs
@@ -55,7 +55,7 @@ pub fn blkdev_size(file: &File) -> Bytes {
     let mut val: u64 = 0;
 
     unsafe { blkgetsize64(file.as_raw_fd(), &mut val) }.unwrap();
-    Bytes(val)
+    Bytes(u128::from(val))
 }
 
 fn get_dm() -> &'static DM {

--- a/src/units.rs
+++ b/src/units.rs
@@ -19,17 +19,15 @@ const META_BLOCK_SIZE: Sectors = Sectors(8);
 #[allow(dead_code)]
 const MAX_META_DEV_SIZE: MetaBlocks = MetaBlocks(255 * ((1 << 14) - 64));
 
-range!(
+range_u64!(
     /// A type for data blocks
     DataBlocks,
-    u64,
     "data blocks"
 );
 
-range!(
+range_u64!(
     /// A type for meta blocks
     MetaBlocks,
-    u64,
     "meta blocks"
 );
 
@@ -40,10 +38,9 @@ impl MetaBlocks {
     }
 }
 
-range!(
+range_u128!(
     /// A type for bytes
     Bytes,
-    u128,
     "bytes"
 );
 
@@ -54,10 +51,9 @@ impl Bytes {
     }
 }
 
-range!(
+range_u64!(
     /// A type for sectors
     Sectors,
-    u64,
     "sectors"
 );
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -22,12 +22,14 @@ const MAX_META_DEV_SIZE: MetaBlocks = MetaBlocks(255 * ((1 << 14) - 64));
 range!(
     /// A type for data blocks
     DataBlocks,
+    u64,
     "data blocks"
 );
 
 range!(
     /// A type for meta blocks
     MetaBlocks,
+    u64,
     "meta blocks"
 );
 
@@ -41,26 +43,29 @@ impl MetaBlocks {
 range!(
     /// A type for bytes
     Bytes,
+    u128,
     "bytes"
 );
 
 impl Bytes {
     /// Return the number of Sectors fully contained in these bytes.
     pub fn sectors(self) -> Sectors {
-        Sectors(self.0 / SECTOR_SIZE as u64)
+        Sectors((self.0 / SECTOR_SIZE as u128) as u64)
     }
 }
 
 range!(
     /// A type for sectors
     Sectors,
+    u64,
     "sectors"
 );
 
 impl Sectors {
     /// The number of bytes in these sectors.
     pub fn bytes(self) -> Bytes {
-        Bytes(self.0 * SECTOR_SIZE as u64)
+        // Keep both as u128 before multiplication or overflow could occur
+        Bytes(u128::from(self.0) * SECTOR_SIZE as u128)
     }
 
     /// The number of whole metablocks contained in these sectors.


### PR DESCRIPTION
Add support in macros for u128 internal representation in unit structs. Move `Bytes` over to u128.

There is a fair amount of added code and duplication in the macros as you cannot capture a type as a variable and then pattern match on it in a submacro so the types must be literals throughout the path travelled by the macro call stack. I would keep them all as variables if I didn't need to differentiate between `.serialize_u64()` and `.serialize_u128()` in the `serde_macro!()` body.