### PR TITLE
Increase lowest supported Rust toolchain to 1.38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
 
         # MANDATORY TESTING USING LOWEST SUPPORTED COMPILER
         # tests
-        - rust: 1.37.0
+        - rust: 1.38.0
           env: TASK=test
 
 


### PR DESCRIPTION
Related: stratis-storage/project#112.