### PR TITLE
Do not make test_lib public outside the testing module

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -5,7 +5,7 @@
 //! Modules that support testing.
 
 mod loopbacked;
-pub(self) mod test_lib;
+mod test_lib;
 
 pub use self::{
     loopbacked::test_with_spec,

--- a/src/testing/test_lib.rs
+++ b/src/testing/test_lib.rs
@@ -212,6 +212,6 @@ fn dm_test_fs_unmount() -> Result<()> {
 
 /// Unmount any filesystems or devicemapper devices which contain DM_TEST_ID
 /// in the path or name. Immediately return on first error.
-pub(super) fn clean_up() -> Result<()> {
+pub fn clean_up() -> Result<()> {
     dm_test_fs_unmount().and_then(|_| dm_test_devices_remove())
 }


### PR DESCRIPTION
This PR tries to improve encapsulation by making test_lib private in the testing submodule and removing one publicity modifier that becomes not-useful with the preceding change.