### PR TITLE
Increase lowest supported Rust toolchain to 1.41

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 
         # MANDATORY TESTING USING LOWEST SUPPORTED COMPILER
         - name: "Run all tests on lowest supported toolchain"
-          rust: 1.40.0
+          rust: 1.41.0
           sudo: required
           script: sudo PATH=${TRAVIS_HOME}/.cargo/bin:$PATH make -f Makefile sudo_test
 


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/146.