### PR TITLE
beta clippy: remove unneeded unit return type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ jobs:
     - rust: nightly
     # Allow audit task to fail
     - env: TASK=audit
-    - env: TASK=clippy
-      rust: beta
   include:
 
     # MANDATORY CHECKS USING CURRENT DEVELOPMENT COMPILER

--- a/src/testing/loopbacked.rs
+++ b/src/testing/loopbacked.rs
@@ -112,7 +112,7 @@ fn get_devices(count: u8, dir: &TempDir) -> Vec<LoopTestDev> {
 /// Then, take down the loop devices.
 pub fn test_with_spec<F>(count: u8, test: F)
 where
-    F: Fn(&[&Path]) -> () + panic::RefUnwindSafe,
+    F: Fn(&[&Path]) + panic::RefUnwindSafe,
 {
     clean_up().unwrap();
 


### PR DESCRIPTION
Signed-off-by: Bryan Gurney <bgurney@redhat.com>