### PR TITLE
Temporarily allow beta clippy Travis task to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ jobs:
     - rust: nightly
     # Allow audit task to fail
     - env: TASK=audit
+    - env: TASK=clippy
+      rust: beta
   include:
 
     # MANDATORY CHECKS USING CURRENT DEVELOPMENT COMPILER


### PR DESCRIPTION
Related: stratis-storage/project#193