### PR TITLE
Revert "Temporarily allow beta clippy Travis task to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ jobs:
     - rust: nightly
     # Allow audit task to fail
     - env: TASK=audit
-    - env: TASK=clippy
-      rust: beta
   include:
 
     # MANDATORY CHECKS USING CURRENT DEVELOPMENT COMPILER


### PR DESCRIPTION
This reverts commit 3e5d4852d738b922cca99dddfb314ae03dfcb0a8.