### PR TITLE
test_basic: use assert_matches to check for ThinStatus non-failure

### DIFF
--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -539,7 +539,7 @@ mod tests {
         assert_eq!(table.params.pool, tp.device());
         assert_eq!(table.params.thin_id, thin_id);
 
-        assert!(!matches!(td.status(&dm).unwrap(), ThinStatus::Fail));
+        assert_matches!(td.status(&dm).unwrap(), ThinStatus::Error | ThinStatus::Working(_));
 
         assert_eq!(
             blkdev_size(&OpenOptions::new().read(true).open(td.devnode()).unwrap()),


### PR DESCRIPTION
Closes: stratis-storage/project#220