### PR TITLE
Enable build for android targets

### DIFF
--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -28,8 +28,12 @@ use crate::{
 
 /// Indicator to send IOCTL to DM
 const DM_IOCTL: u8 = 0xfd;
+#[cfg(target_os = "linux")]
 /// Control path for user space to pass IOCTL to kernel DM
 const DM_CTL_PATH: &str = "/dev/mapper/control";
+#[cfg(target_os = "android")]
+/// Control path for user space to pass IOCTL to kernel DM
+const DM_CTL_PATH: &str = "/dev/device-mapper";
 /// Major version
 const DM_VERSION_MAJOR: u32 = 4;
 /// Minor version

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -147,6 +147,8 @@ impl DM {
         };
         let op = request_code_readwrite!(DM_IOCTL, ioctl, size_of::<dmi::Struct_dm_ioctl>());
         loop {
+            #[cfg(target_os = "android")]
+            let op = op as i32;
             if let Err(err) =
                 unsafe { convert_ioctl_res!(nix_ioctl(self.file.as_raw_fd(), op, v.as_mut_ptr())) }
             {


### PR DESCRIPTION
The android target needs some minor adjustments:

* The device mapper control file is located at `/dev/device-mapper` instead of `/dev/mapper/control`
* `major` and `minor` types differ
* `ioctl op code differs in type (`i32` vs `u32`)
* The android target lacks `MetadataExt`. The `metadata` call is replaced with a plan `stat` from `nix`. The error type slightly   changed to a wrapped `nix::Error` in an `io::Error`. Not sure if this is ok or not.