### PR TITLE
Add flags option to table loading

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -626,7 +626,7 @@ impl CacheDev {
 
         let mut table = self.table.clone();
         table.table.length = self.origin_dev.size();
-        self.table_load(dm, &table)?;
+        self.table_load(dm, &table, &DmOptions::default())?;
 
         self.table = table;
 
@@ -651,7 +651,7 @@ impl CacheDev {
         // Reload the table, even though it is unchanged. Otherwise, we
         // suffer from whacky smq bug documented in the following PR:
         // https://github.com/stratis-storage/devicemapper-rs/pull/279.
-        self.table_load(dm, self.table())?;
+        self.table_load(dm, self.table(), &DmOptions::default())?;
 
         Ok(())
     }
@@ -674,7 +674,7 @@ impl CacheDev {
         // Reload the table, even though it is unchanged. Otherwise, we
         // suffer from whacky smq bug documented in the following PR:
         // https://github.com/stratis-storage/devicemapper-rs/pull/279.
-        self.table_load(dm, self.table())?;
+        self.table_load(dm, self.table(), &DmOptions::default())?;
 
         Ok(())
     }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -565,7 +565,7 @@ impl LinearDev {
     ) -> DmResult<()> {
         let table = LinearDevTargetTable::new(table);
         self.suspend(dm, false)?;
-        self.table_load(dm, &table)?;
+        self.table_load(dm, &table, &DmOptions::default())?;
         self.table = table;
         Ok(())
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -113,8 +113,8 @@ pub trait DmDevice<T: TargetTable> {
     fn table(&self) -> &T;
 
     /// Load a table
-    fn table_load(&self, dm: &DM, table: &T) -> DmResult<()> {
-        dm.table_load(&DevId::Name(self.name()), &table.to_raw_table())?;
+    fn table_load(&self, dm: &DM, table: &T, options: &DmOptions) -> DmResult<()> {
+        dm.table_load(&DevId::Name(self.name()), &table.to_raw_table(), options)?;
         Ok(())
     }
 
@@ -144,7 +144,7 @@ pub fn device_create<T: TargetTable>(
     dm.device_create(name, uuid, &DmOptions::new())?;
 
     let id = DevId::Name(name);
-    let dev_info = match dm.table_load(&id, &table.to_raw_table()) {
+    let dev_info = match dm.table_load(&id, &table.to_raw_table(), &DmOptions::default()) {
         Err(e) => {
             dm.device_remove(&id, &DmOptions::new())?;
             return Err(e);

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -390,7 +390,7 @@ impl ThinDev {
     pub fn set_table(&mut self, dm: &DM, table: TargetLine<ThinTargetParams>) -> DmResult<()> {
         let table = ThinDevTargetTable::new(table.start, table.length, table.params);
         self.suspend(dm, false)?;
-        self.table_load(dm, &table)?;
+        self.table_load(dm, &table, &DmOptions::default())?;
         self.resume(dm)?;
 
         self.table = table;

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -545,7 +545,7 @@ impl ThinPoolDev {
         new_table.table.params.low_water_mark = low_water_mark;
 
         self.suspend(dm, false)?;
-        self.table_load(dm, &new_table)?;
+        self.table_load(dm, &new_table, &DmOptions::default())?;
 
         self.table = new_table;
         Ok(())
@@ -574,7 +574,7 @@ impl ThinPoolDev {
 
         // Reload the table even though it is unchanged.
         // See comment on CacheDev::set_cache_table for reason.
-        self.table_load(dm, self.table())?;
+        self.table_load(dm, self.table(), &DmOptions::default())?;
 
         Ok(())
     }
@@ -597,7 +597,7 @@ impl ThinPoolDev {
 
         let mut table = self.table.clone();
         table.table.length = self.data_dev.size();
-        self.table_load(dm, &table)?;
+        self.table_load(dm, &table, &DmOptions::default())?;
 
         self.table = table;
 


### PR DESCRIPTION
When loading a verity table the device *must* be a readonly. The dm driver requires the flags for the `DM_TABLE_LOAD_CMD` ioctl to include at least `DM_READONLY` - otherwise it complains:

```
May 25 19:32:42 XXX kernel: [ 7763.805044] device-mapper: table: 254:7: verity: Device must be readonly
May 25 19:32:42 XXX kernel: [ 7763.805049] device-mapper: ioctl: error adding target to table
```

Add `core::dm::table_load_flags` that enables any user to pass `DmFlags::DM_READONLY` to the `DM_TABLE_LOAD_CMD` operation.

An Option could be to extend `table_load` with an `Option<DmFlags>`. This changes the API in a breaking way, so I decided to add `table_load_flags`. Let me know if you prefer the `Option` argument.

It's possible that other options than `DM_READONLY` are allowed for the `DM_TABLE_LOAD`. Would be easy to add to `allowed_flags`.