### PR TITLE
Turn off bindgens default features and enable feature runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,7 @@ tempfile = "3.0.2"
 version = "0.8.0"
 features = ["v4"]
 
-[build-dependencies]
-bindgen = "0.57.0"
+[build-dependencies.bindgen]
+default_features = false
+features = ["runtime"]
+version = "0.57.0"


### PR DESCRIPTION
`bindgen` is used for generating ffi bindings from a build script. The bindgen feature to create bindings with the `bindgen` CLI is not needed and can be turned off when depending on `bindgen`. Turning off the default features reduces the number of (build) dependencies of `devicemapper-rs`.

A diff of the output of `cargo tree` with and without this patch shows the removal of `clap`, `regex` (features), `env_logger`, `log`, `which` and their dependencies:

```diff
44,64d43
<     ├── clap v2.33.3
<     │   ├── ansi_term v0.11.0
<     │   ├── atty v0.2.14
<     │   │   └── libc v0.2.94
<     │   ├── bitflags v1.2.1
<     │   ├── strsim v0.8.0
<     │   ├── textwrap v0.11.0
<     │   │   └── unicode-width v0.1.8
<     │   ├── unicode-width v0.1.8
<     │   └── vec_map v0.8.2
<     ├── env_logger v0.8.4
<     │   ├── atty v0.2.14 (*)
<     │   ├── humantime v2.1.0
<     │   ├── log v0.4.14
<     │   │   └── cfg-if v1.0.0
<     │   ├── regex v1.5.4
<     │   │   ├── aho-corasick v0.7.18
<     │   │   │   └── memchr v2.4.0
<     │   │   ├── memchr v2.4.0
<     │   │   └── regex-syntax v0.6.25
<     │   └── termcolor v1.1.2
67d45
<     ├── log v0.4.14 (*)
73c51,52
<     ├── regex v1.5.4 (*)
---
>     ├── regex v1.5.4
>     │   └── regex-syntax v0.6.25
75,77c54
<     ├── shlex v0.1.1
<     └── which v3.1.1
<         └── libc v0.2.94
---
>     └── shlex v0.1.1
```