### PR TITLE
Rename devicemapper-rs-sys to be consistent with devicemapper on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ tempfile = "3.0.2"
 version = "0.8.0"
 features = ["v4"]
 
-[dependencies.devicemapper-rs-sys]
+[dependencies.devicemapper-sys]
 version = "0.1.0"
 path = "./devicemapper-rs-sys"
 
-[build-dependencies.devicemapper-rs-sys]
+[build-dependencies.devicemapper-sys]
 version = "0.1.0"
 path = "./devicemapper-rs-sys"
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-compare-fedora-versions:
 
 check-fedora-versions: test-compare-fedora-versions
 	${COMPARE_FEDORA_VERSIONS} ${MANIFEST_PATH_ARGS} ${FEDORA_RELEASE_ARGS} ${IGNORE_ARGS} \
-        --ignore-missing devicemapper-rs-sys
+        --ignore-missing devicemapper-sys
 
 check-fedora-versions-sys: test-compare-fedora-versions
 	${COMPARE_FEDORA_VERSIONS} ${MANIFEST_PATH_ARGS} ${FEDORA_RELEASE_ARGS} ${IGNORE_ARGS}

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@
 
 use semver::Version;
 
-use devicemapper_rs_sys::{DM_VERSION_MAJOR, DM_VERSION_MINOR, DM_VERSION_PATCHLEVEL};
+use devicemapper_sys::{DM_VERSION_MAJOR, DM_VERSION_MINOR, DM_VERSION_PATCHLEVEL};
 
 static SUPPORTED_VERSIONS: &[&str] = &["4.37.0"];
 

--- a/devicemapper-rs-sys/Cargo.toml
+++ b/devicemapper-rs-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "devicemapper-rs-sys"
+name = "devicemapper-sys"
 version = "0.1.0"
 authors = ["Stratis Developers <stratis-devel@lists.fedorahosted.org>"]
 edition = "2018"

--- a/src/core/dm_ioctl.rs
+++ b/src/core/dm_ioctl.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-pub use devicemapper_rs_sys::{
+pub use devicemapper_sys::{
     dm_ioctl as Struct_dm_ioctl, dm_name_list as Struct_dm_name_list,
     dm_target_deps as Struct_dm_target_deps, dm_target_msg as Struct_dm_target_msg,
     dm_target_spec as Struct_dm_target_spec, dm_target_versions as Struct_dm_target_versions, *,


### PR DESCRIPTION
Related to stratis-storage/project#350