### PR TITLE
Generalize DmDevice::suspend and status() functions to take a DmOptions argument

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -727,8 +727,8 @@ impl CacheDev {
     }
 
     /// Get the current status of the cache device.
-    pub fn status(&self, dm: &DM) -> DmResult<CacheDevStatus> {
-        status!(self, dm)
+    pub fn status(&self, dm: &DM, options: DmOptions) -> DmResult<CacheDevStatus> {
+        status!(self, dm, options)
     }
 }
 
@@ -814,7 +814,7 @@ mod tests {
         let dm = DM::new().unwrap();
         let mut cache = minimal_cachedev(&dm, paths);
 
-        match cache.status(&dm).unwrap() {
+        match cache.status(&dm, DmOptions::default()).unwrap() {
             CacheDevStatus::Working(ref status) => {
                 let usage = &status.usage;
 
@@ -899,7 +899,7 @@ mod tests {
         let cache_params = LinearTargetParams::new(dev3, Sectors(0));
         let current_length = cache.meta_dev.size();
 
-        match cache.status(&dm).unwrap() {
+        match cache.status(&dm, DmOptions::default()).unwrap() {
             CacheDevStatus::Working(ref status) => {
                 let usage = &status.usage;
                 assert_eq!(*usage.total_meta * usage.meta_block_size, current_length);
@@ -916,7 +916,7 @@ mod tests {
         assert_matches!(cache.set_meta_table(&dm, table), Ok(_));
         cache.resume(&dm).unwrap();
 
-        match cache.status(&dm).unwrap() {
+        match cache.status(&dm, DmOptions::default()).unwrap() {
             CacheDevStatus::Working(ref status) => {
                 let usage = &status.usage;
                 let assigned_length = current_length + extra_length;
@@ -953,7 +953,7 @@ mod tests {
         let cache_params = LinearTargetParams::new(dev3, Sectors(0));
         let current_length = cache.cache_dev.size();
 
-        match cache.status(&dm).unwrap() {
+        match cache.status(&dm, DmOptions::default()).unwrap() {
             CacheDevStatus::Working(ref status) => {
                 let usage = &status.usage;
                 assert_eq!(*usage.total_cache * usage.cache_block_size, current_length);
@@ -970,7 +970,7 @@ mod tests {
         assert_matches!(cache.set_cache_table(&dm, cache_table.clone()), Ok(_));
         cache.resume(&dm).unwrap();
 
-        match cache.status(&dm).unwrap() {
+        match cache.status(&dm, DmOptions::default()).unwrap() {
             CacheDevStatus::Working(ref status) => {
                 let usage = &status.usage;
                 assert_eq!(
@@ -987,7 +987,7 @@ mod tests {
         assert_matches!(cache.set_cache_table(&dm, cache_table), Ok(_));
         cache.resume(&dm).unwrap();
 
-        match cache.status(&dm).unwrap() {
+        match cache.status(&dm, DmOptions::default()).unwrap() {
             CacheDevStatus::Working(ref status) => {
                 let usage = &status.usage;
                 assert_eq!(*usage.total_cache * usage.cache_block_size, current_length);

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -11,7 +11,7 @@ use std::{
 
 use crate::{
     consts::IEC,
-    core::{DevId, Device, DeviceInfo, DmName, DmOptions, DmUuid, DM},
+    core::{DevId, Device, DeviceInfo, DmFlags, DmName, DmOptions, DmUuid, DM},
     lineardev::{LinearDev, LinearDevTargetParams},
     result::{DmError, DmResult, ErrorEnum},
     shared::{
@@ -619,7 +619,7 @@ impl CacheDev {
         dm: &DM,
         table: Vec<TargetLine<LinearDevTargetParams>>,
     ) -> DmResult<()> {
-        self.suspend(dm, false)?;
+        self.suspend(dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))?;
 
         self.origin_dev.set_table(dm, table)?;
         self.origin_dev.resume(dm)?;
@@ -644,7 +644,7 @@ impl CacheDev {
         dm: &DM,
         table: Vec<TargetLine<LinearDevTargetParams>>,
     ) -> DmResult<()> {
-        self.suspend(dm, false)?;
+        self.suspend(dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))?;
         self.cache_dev.set_table(dm, table)?;
         self.cache_dev.resume(dm)?;
 
@@ -667,7 +667,7 @@ impl CacheDev {
         dm: &DM,
         table: Vec<TargetLine<LinearDevTargetParams>>,
     ) -> DmResult<()> {
-        self.suspend(dm, false)?;
+        self.suspend(dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))?;
         self.meta_dev.set_table(dm, table)?;
         self.meta_dev.resume(dm)?;
 
@@ -1048,8 +1048,12 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let mut cache = minimal_cachedev(&dm, paths);
-        cache.suspend(&dm, false).unwrap();
-        cache.suspend(&dm, false).unwrap();
+        cache
+            .suspend(&dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))
+            .unwrap();
+        cache
+            .suspend(&dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))
+            .unwrap();
         cache.resume(&dm).unwrap();
         cache.resume(&dm).unwrap();
         cache.teardown(&dm).unwrap();

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashSet, fmt, path::PathBuf, str::FromStr};
 
 use crate::{
-    core::{DevId, Device, DeviceInfo, DmName, DmOptions, DmUuid, DM},
+    core::{DevId, Device, DeviceInfo, DmFlags, DmName, DmOptions, DmUuid, DM},
     result::{DmError, DmResult, ErrorEnum},
     shared::{
         device_create, device_exists, device_match, parse_device, parse_value, DmDevice,
@@ -564,7 +564,7 @@ impl LinearDev {
         table: Vec<TargetLine<LinearDevTargetParams>>,
     ) -> DmResult<()> {
         let table = LinearDevTargetTable::new(table);
-        self.suspend(dm, false)?;
+        self.suspend(dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))?;
         self.table_load(dm, &table, DmOptions::default())?;
         self.table = table;
         Ok(())
@@ -806,8 +806,10 @@ mod tests {
         )];
         let mut ld = LinearDev::setup(&dm, &name, None, table).unwrap();
 
-        ld.suspend(&dm, false).unwrap();
-        ld.suspend(&dm, false).unwrap();
+        ld.suspend(&dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))
+            .unwrap();
+        ld.suspend(&dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))
+            .unwrap();
         ld.resume(&dm).unwrap();
         ld.resume(&dm).unwrap();
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -96,15 +96,14 @@ pub trait DmDevice<T: TargetTable> {
     /// The number of sectors available for user data.
     fn size(&self) -> Sectors;
 
-    /// Suspend I/O on the device. If flush is true, flush the device first.
-    fn suspend(&mut self, dm: &DM, flush: bool) -> DmResult<()> {
-        let options = DmOptions::default().set_flags(if flush {
-            DmFlags::DM_SUSPEND
-        } else {
-            DmFlags::DM_SUSPEND | DmFlags::DM_NOFLUSH
-        });
-
-        dm.device_suspend(&DevId::Name(self.name()), options)?;
+    /// Suspend I/O on the device.
+    fn suspend(&mut self, dm: &DM, options: DmOptions) -> DmResult<()> {
+        dm.device_suspend(
+            &DevId::Name(self.name()),
+            DmOptions::default()
+                .set_flags(DmFlags::DM_SUSPEND | options.flags())
+                .set_cookie(options.cookie()),
+        )?;
         Ok(())
     }
 

--- a/src/shared_macros.rs
+++ b/src/shared_macros.rs
@@ -52,13 +52,10 @@ macro_rules! table {
 }
 
 macro_rules! status {
-    ($s:ident, $dm:ident) => {
+    ($s:ident, $dm:ident, $options:ident) => {
         get_status(
-            &$dm.table_status(
-                &$crate::core::DevId::Name($s.name()),
-                $crate::core::DmOptions::default(),
-            )?
-            .1,
+            &$dm.table_status(&$crate::core::DevId::Name($s.name()), $options)?
+                .1,
         )?
         .parse()
     };

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -385,8 +385,8 @@ impl ThinDev {
     }
 
     /// Get the current status of the thin device.
-    pub fn status(&self, dm: &DM) -> DmResult<ThinStatus> {
-        status!(self, dm)
+    pub fn status(&self, dm: &DM, options: DmOptions) -> DmResult<ThinStatus> {
+        status!(self, dm, options)
     }
 
     /// Set the table for the thin device's target
@@ -543,7 +543,7 @@ mod tests {
         assert_eq!(table.params.thin_id, thin_id);
 
         assert_matches!(
-            td.status(&dm).unwrap(),
+            td.status(&dm, DmOptions::default()).unwrap(),
             ThinStatus::Error | ThinStatus::Working(_)
         );
 
@@ -672,7 +672,7 @@ mod tests {
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
 
-        let orig_data_usage = match tp.status(&dm).unwrap() {
+        let orig_data_usage = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -686,7 +686,7 @@ mod tests {
         let mut td = ThinDev::new(&dm, &thin_name, None, td_size, &tp, thin_id).unwrap();
         udev_settle().unwrap();
 
-        let data_usage_1 = match tp.status(&dm).unwrap() {
+        let data_usage_1 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -700,7 +700,7 @@ mod tests {
         let mut ss = td.snapshot(&dm, &ss_name, None, &tp, ss_id).unwrap();
         udev_settle().unwrap();
 
-        let data_usage_2 = match tp.status(&dm).unwrap() {
+        let data_usage_2 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -730,7 +730,7 @@ mod tests {
         let mut td = ThinDev::new(&dm, &thin_name, None, tp.size(), &tp, thin_id).unwrap();
         udev_settle().unwrap();
 
-        let orig_data_usage = match tp.status(&dm).unwrap() {
+        let orig_data_usage = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -739,7 +739,7 @@ mod tests {
 
         xfs_create_fs(&td.devnode()).unwrap();
 
-        let data_usage_1 = match tp.status(&dm).unwrap() {
+        let data_usage_1 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -773,7 +773,7 @@ mod tests {
         }
         umount2(tmp_dir.path(), MntFlags::MNT_DETACH).unwrap();
 
-        let data_usage_2 = match tp.status(&dm).unwrap() {
+        let data_usage_2 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -804,7 +804,7 @@ mod tests {
             ThinDev::new(&dm, &thin_name, None, Sectors(2 * IEC::Mi), &tp, thin_id).unwrap();
         udev_settle().unwrap();
 
-        let orig_data_usage = match tp.status(&dm).unwrap() {
+        let orig_data_usage = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -813,7 +813,7 @@ mod tests {
 
         xfs_create_fs(&td.devnode()).unwrap();
 
-        let data_usage_1 = match tp.status(&dm).unwrap() {
+        let data_usage_1 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -829,7 +829,7 @@ mod tests {
             .unwrap();
         udev_settle().unwrap();
 
-        let data_usage_2 = match tp.status(&dm).unwrap() {
+        let data_usage_2 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -841,7 +841,7 @@ mod tests {
         // Setting the uuid of the snapshot filesystem bumps the usage,
         // but does not increase the usage quite as much as establishing
         // the origin.
-        let data_usage_3 = match tp.status(&dm).unwrap() {
+        let data_usage_3 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -856,7 +856,7 @@ mod tests {
             ThinDev::new(&dm, &thin_name, None, Sectors(2 * IEC::Gi), &tp, thin_id).unwrap();
         udev_settle().unwrap();
 
-        let data_usage_4 = match tp.status(&dm).unwrap() {
+        let data_usage_4 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),
@@ -865,7 +865,7 @@ mod tests {
 
         xfs_create_fs(&td1.devnode()).unwrap();
 
-        let data_usage_5 = match tp.status(&dm).unwrap() {
+        let data_usage_5 = match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => status.usage.used_data,
             ThinPoolStatus::Error => panic!("devicemapper could not obtain thin pool status"),
             ThinPoolStatus::Fail => panic!("failed to get thinpool status"),

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -392,7 +392,7 @@ impl ThinDev {
     /// Set the table for the thin device's target
     pub fn set_table(&mut self, dm: &DM, table: TargetLine<ThinTargetParams>) -> DmResult<()> {
         let table = ThinDevTargetTable::new(table.start, table.length, table.params);
-        self.suspend(dm, false)?;
+        self.suspend(dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))?;
         self.table_load(dm, &table, DmOptions::default())?;
         self.resume(dm)?;
 

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -5,7 +5,7 @@
 use std::{collections::hash_set::HashSet, fmt, path::PathBuf, str::FromStr};
 
 use crate::{
-    core::{DevId, Device, DeviceInfo, DmName, DmOptions, DmUuid, DM},
+    core::{DevId, Device, DeviceInfo, DmFlags, DmName, DmOptions, DmUuid, DM},
     lineardev::{LinearDev, LinearDevTargetParams},
     result::{DmError, DmResult, ErrorEnum},
     shared::{
@@ -544,7 +544,7 @@ impl ThinPoolDev {
         let mut new_table = self.table.clone();
         new_table.table.params.low_water_mark = low_water_mark;
 
-        self.suspend(dm, false)?;
+        self.suspend(dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))?;
         self.table_load(dm, &new_table, DmOptions::default())?;
 
         self.table = new_table;
@@ -568,7 +568,7 @@ impl ThinPoolDev {
         dm: &DM,
         table: Vec<TargetLine<LinearDevTargetParams>>,
     ) -> DmResult<()> {
-        self.suspend(dm, false)?;
+        self.suspend(dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))?;
         self.meta_dev.set_table(dm, table)?;
         self.meta_dev.resume(dm)?;
 
@@ -590,7 +590,7 @@ impl ThinPoolDev {
         dm: &DM,
         table: Vec<TargetLine<LinearDevTargetParams>>,
     ) -> DmResult<()> {
-        self.suspend(dm, false)?;
+        self.suspend(dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))?;
 
         self.data_dev.set_table(dm, table)?;
         self.data_dev.resume(dm)?;
@@ -863,8 +863,10 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
-        tp.suspend(&dm, false).unwrap();
-        tp.suspend(&dm, false).unwrap();
+        tp.suspend(&dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))
+            .unwrap();
+        tp.suspend(&dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))
+            .unwrap();
         tp.resume(&dm).unwrap();
         tp.resume(&dm).unwrap();
         tp.teardown(&dm).unwrap();

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -681,7 +681,7 @@ mod tests {
     use std::path::Path;
 
     use crate::{
-        core::errors::Error,
+        core::{errors::Error, DmFlags},
         testing::{test_name, test_with_spec},
     };
 
@@ -873,6 +873,21 @@ mod tests {
     #[test]
     fn loop_test_suspend() {
         test_with_spec(1, test_suspend);
+    }
+
+    fn test_status_noflush(paths: &[&Path]) {
+        assert!(!paths.is_empty());
+
+        let dm = DM::new().unwrap();
+        let tp = minimal_thinpool(&dm, paths[0]);
+
+        tp.status(&dm, DmOptions::default().set_flags(DmFlags::DM_NOFLUSH))
+            .unwrap();
+    }
+
+    #[test]
+    fn loop_test_status_noflush() {
+        test_with_spec(1, test_status_noflush);
     }
 
     #[test]

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -553,8 +553,8 @@ impl ThinPoolDev {
 
     /// Get the current status of the thinpool.
     /// Returns an error if there was an error getting the status value.
-    pub fn status(&self, dm: &DM) -> DmResult<ThinPoolStatus> {
-        status!(self, dm)
+    pub fn status(&self, dm: &DM, options: DmOptions) -> DmResult<ThinPoolStatus> {
+        status!(self, dm, options)
     }
 
     /// Set the table for the existing metadata device.
@@ -695,7 +695,7 @@ mod tests {
 
         let dm = DM::new().unwrap();
         let mut tp = minimal_thinpool(&dm, paths[0]);
-        match tp.status(&dm).unwrap() {
+        match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status)
                 if status.summary == ThinPoolStatusSummary::Good =>
             {
@@ -799,7 +799,7 @@ mod tests {
         tp.set_data_table(&dm, data_table).unwrap();
         tp.resume(&dm).unwrap();
 
-        match tp.status(&dm).unwrap() {
+        match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => {
                 let usage = &status.usage;
                 assert_eq!(
@@ -840,7 +840,7 @@ mod tests {
         tp.set_meta_table(&dm, meta_table).unwrap();
         tp.resume(&dm).unwrap();
 
-        match tp.status(&dm).unwrap() {
+        match tp.status(&dm, DmOptions::default()).unwrap() {
             ThinPoolStatus::Working(ref status) => {
                 let usage = &status.usage;
                 assert_eq!(usage.total_meta.sectors(), 2u8 * meta_size);


### PR DESCRIPTION
Closes #663 

Generalize ```DmDevice::suspend()``` and ```status()``` functions to take a ```DmOptions``` argument. Many other, device-specific functions invoke ```status()``` or ```suspend()``` methods, in many cases hard-coding the ```DmOptions``` argument that is passed; no effort is made here to generalize these functions as I believe that the code there may require a significant redesign.