### PR TITLE
Add udev semaphore synchronization for uevent-generating commands

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -29,6 +29,7 @@ jobs:
           dnf install -y
           clang
           curl
+          device-mapper-devel
           git
           make
           openssl-devel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,7 @@ jobs:
           dnf install -y
           clang
           curl
+          device-mapper-devel
           git
           make
           openssl-devel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ exclude = [".clippy.toml", ".githooks/*", ".gitignore", ".github/*", "Makefile"]
 [dependencies]
 bitflags = "1.1.0"
 nix = "0.26.0"
+env_logger="0.9.0"
 semver = "1.0.0"
 serde = "1.0.60"
 lazy_static = "1.2.0"
+log = "0.4.14"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ nix = "0.26.0"
 env_logger="0.9.0"
 semver = "1.0.0"
 serde = "1.0.60"
+rand = "0.8.0"
+retry = "1.3.1"
 lazy_static = "1.2.0"
 log = "0.4.14"
 

--- a/devicemapper-rs-sys/build.rs
+++ b/devicemapper-rs-sys/build.rs
@@ -8,7 +8,15 @@ use bindgen::Builder;
 
 fn main() {
     let bindings = Builder::default()
-        .header("dm-ioctl.h")
+        .header("dm.h")
+        .allowlist_var("DM.*")
+        .allowlist_type("__u16")
+        .allowlist_type("dm_ioctl")
+        .allowlist_type("dm_name_list")
+        .allowlist_type("dm_target_deps")
+        .allowlist_type("dm_target_msg")
+        .allowlist_type("dm_target_spec")
+        .allowlist_type("dm_target_versions")
         .derive_debug(true)
         .derive_default(true)
         .generate()

--- a/devicemapper-rs-sys/build.rs
+++ b/devicemapper-rs-sys/build.rs
@@ -7,6 +7,7 @@ use std::{env::var, path::PathBuf};
 use bindgen::Builder;
 
 fn main() {
+    // Generate bindings for dm-ioctl.h and libdevmapper.h
     let bindings = Builder::default()
         .header("dm.h")
         .allowlist_var("DM.*")
@@ -20,10 +21,36 @@ fn main() {
         .derive_debug(true)
         .derive_default(true)
         .generate()
-        .expect("Could not generate bindings");
+        .expect("Could not generate dm.h bindings");
 
     let mut bindings_path = PathBuf::from(var("OUT_DIR").unwrap());
-    bindings_path.push("bindings.rs");
+    bindings_path.push("dm-bindings.rs");
+    bindings
+        .write_to_file(&bindings_path)
+        .expect("Could not write bindings to file");
+
+    // Generate bindings for SysV Semaphore IPC
+    let bindings = Builder::default()
+        .header("sem.h")
+        .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)
+        .allowlist_var("GET.*")
+        .allowlist_var("SET.*")
+        .allowlist_var("SEM_.*")
+        .allowlist_type("semun");
+
+    #[cfg(target_env = "musl")]
+    let bindings = bindings
+        .allowlist_type("seminfo")
+        .allowlist_type("semid_ds");
+
+    let bindings = bindings
+        .derive_debug(true)
+        .derive_default(true)
+        .generate()
+        .expect("Could not generate sem.h bindings");
+
+    let mut bindings_path = PathBuf::from(var("OUT_DIR").unwrap());
+    bindings_path.push("sem-bindings.rs");
     bindings
         .write_to_file(&bindings_path)
         .expect("Could not write bindings to file");

--- a/devicemapper-rs-sys/dm.h
+++ b/devicemapper-rs-sys/dm.h
@@ -1,1 +1,2 @@
 #include <linux/dm-ioctl.h>
+#include <libdevmapper.h>

--- a/devicemapper-rs-sys/sem.h
+++ b/devicemapper-rs-sys/sem.h
@@ -1,0 +1,9 @@
+#include <sys/sem.h>
+
+union semun {
+    int   val;               /* Value for SETVAL */
+    struct semid_ds *buf;    /* Buffer for IPC_STAT, IPC_SET */
+    unsigned short  *array;  /* Array for GETALL, SETALL */
+    struct seminfo  *__buf;  /* Buffer for IPC_INFO
+                                (Linux-specific) */
+};

--- a/devicemapper-rs-sys/src/lib.rs
+++ b/devicemapper-rs-sys/src/lib.rs
@@ -3,4 +3,5 @@
 #![allow(deref_nullptr)]
 #![allow(clippy::all)]
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+include!(concat!(env!("OUT_DIR"), "/dm-bindings.rs"));
+include!(concat!(env!("OUT_DIR"), "/sem-bindings.rs"));

--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -829,18 +829,12 @@ mod tests {
                     cache.table.table.params.cache_block_size
                 );
 
-                // No data means no cache blocks used
-                assert_eq!(usage.used_cache, DataBlocks(0));
-
                 let performance = &status.performance;
 
-                // No activity should mean all performance data is 0
-                assert_eq!(performance.read_hits, 0);
-                assert_eq!(performance.read_misses, 0);
+                // No write activity should mean all write performance data is 0
                 assert_eq!(performance.write_hits, 0);
                 assert_eq!(performance.write_misses, 0);
                 assert_eq!(performance.demotions, 0);
-                assert_eq!(performance.promotions, 0);
                 assert_eq!(performance.dirty, 0);
 
                 // The current defaults for configuration values

--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -54,7 +54,7 @@ impl DmOptions {
         allowable_flags: DmFlags,
     ) -> DmResult<dmi::Struct_dm_ioctl> {
         let clean_flags = allowable_flags & self.flags();
-        let event_nr = u32::from(self.cookie().bits()) << 16;
+        let event_nr = u32::from(self.udev_flags().bits()) << 16;
         let mut hdr: dmi::Struct_dm_ioctl = devicemapper_sys::dm_ioctl {
             flags: clean_flags.bits(),
             event_nr,

--- a/src/core/dm_flags.rs
+++ b/src/core/dm_flags.rs
@@ -53,23 +53,22 @@ bitflags! {
     /// https://sourceware.org/git/?p=lvm2.git;a=blob;f=libdm/libdevmapper.h#l3627
     /// for complete information about the meaning of the flags.
     #[derive(Default)]
-    pub struct DmUdevFlags: dmi::__u16 {
-        #[allow(clippy::identity_op)]
+    pub struct DmUdevFlags: u32 {
         /// Disables basic device-mapper udev rules that create symlinks in /dev/<DM_DIR>
         /// directory.
-        const DM_UDEV_DISABLE_DM_RULES_FLAG = (1 << 0);
+        const DM_UDEV_DISABLE_DM_RULES_FLAG = dmi::DM_UDEV_DISABLE_DM_RULES_FLAG;
         /// Disable subsystem udev rules, but allow general DM udev rules to run.
-        const DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG = (1 << 1);
+        const DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG = dmi::DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG;
         /// Disable dm udev rules which create symlinks in /dev/disk/* directory.
-        const DM_UDEV_DISABLE_DISK_RULES_FLAG = (1 << 2);
+        const DM_UDEV_DISABLE_DISK_RULES_FLAG = dmi::DM_UDEV_DISABLE_DISK_RULES_FLAG;
         /// Disable all rules that are not general dm nor subsystem related.
-        const DM_UDEV_DISABLE_OTHER_RULES_FLAG = (1 << 3);
+        const DM_UDEV_DISABLE_OTHER_RULES_FLAG = dmi::DM_UDEV_DISABLE_OTHER_RULES_FLAG;
         /// Instruct udev rules to give lower priority to the device.
-        const DM_UDEV_LOW_PRIORITY_FLAG = (1 << 4);
+        const DM_UDEV_LOW_PRIORITY_FLAG = dmi::DM_UDEV_LOW_PRIORITY_FLAG;
         /// Disable libdevmapper's node management.
-        const DM_UDEV_DISABLE_LIBRARY_FALLBACK = (1 << 5);
+        const DM_UDEV_DISABLE_LIBRARY_FALLBACK = dmi::DM_UDEV_DISABLE_LIBRARY_FALLBACK;
         /// Automatically appended to all IOCTL calls issues by libdevmapper for generating
         /// udev uevents.
-        const DM_UDEV_PRIMARY_SOURCE_FLAG = (1 << 6);
+        const DM_UDEV_PRIMARY_SOURCE_FLAG = dmi::DM_UDEV_PRIMARY_SOURCE_FLAG;
     }
 }

--- a/src/core/dm_flags.rs
+++ b/src/core/dm_flags.rs
@@ -53,7 +53,7 @@ bitflags! {
     /// https://sourceware.org/git/?p=lvm2.git;a=blob;f=libdm/libdevmapper.h#l3627
     /// for complete information about the meaning of the flags.
     #[derive(Default)]
-    pub struct DmCookie: dmi::__u16 {
+    pub struct DmUdevFlags: dmi::__u16 {
         #[allow(clippy::identity_op)]
         /// Disables basic device-mapper udev rules that create symlinks in /dev/<DM_DIR>
         /// directory.

--- a/src/core/dm_options.rs
+++ b/src/core/dm_options.rs
@@ -1,13 +1,13 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-use crate::core::dm_flags::{DmCookie, DmFlags};
+use crate::core::dm_flags::{DmFlags, DmUdevFlags};
 
 /// Encapsulates options for device mapper calls
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DmOptions {
     flags: DmFlags,
-    cookie: DmCookie,
+    udev_flags: DmUdevFlags,
 }
 
 impl DmOptions {
@@ -18,10 +18,10 @@ impl DmOptions {
         self
     }
 
-    /// Set the DmCookie value for self. Replace the previous value.
+    /// Set the DmUdevFlags value for self. Replace the previous value.
     /// Consumes self.
-    pub fn set_cookie(mut self, cookie: DmCookie) -> DmOptions {
-        self.cookie = cookie;
+    pub fn set_udev_flags(mut self, udev_flags: DmUdevFlags) -> DmOptions {
+        self.udev_flags = udev_flags;
         self
     }
 
@@ -30,8 +30,8 @@ impl DmOptions {
         self.flags
     }
 
-    /// Retrieve the cookie value (used for input in upper 16 bits of event_nr header field).
-    pub fn cookie(&self) -> DmCookie {
-        self.cookie
+    /// Retrieve the cookie flags (used for input in upper 16 bits of event_nr header field).
+    pub fn udev_flags(&self) -> DmUdevFlags {
+        self.udev_flags
     }
 }

--- a/src/core/dm_udev_sync.rs
+++ b/src/core/dm_udev_sync.rs
@@ -1,0 +1,517 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::{core::dm_ioctl as dmi, result::DmResult};
+
+pub trait UdevSyncAction {
+    fn begin(hdr: &mut dmi::Struct_dm_ioctl, ioctl: u8) -> DmResult<UdevSync>;
+    fn end(self, flags: u32) -> DmResult<()>;
+    fn cancel(self);
+    fn is_active(&self) -> bool;
+}
+
+#[cfg(not(target_os = "android"))]
+pub mod sync_semaphore {
+    use nix::libc::{
+        c_int,
+        key_t,
+        sembuf,
+        semctl as libc_semctl,
+        semget as libc_semget,
+        semop as libc_semop,
+        EEXIST,
+        ENOMEM,
+        ENOSPC,
+        // These don't exist in the Linux libc crate
+        // GETVAL, SETVAL, SEM_INFO,
+        IPC_CREAT,
+        IPC_EXCL,
+        IPC_NOWAIT,
+        IPC_RMID,
+    };
+
+    use rand::Rng;
+    use retry::{delay::NoDelay, retry, OperationResult};
+    use std::io;
+
+    use crate::core::sysvsem::seminfo;
+
+    use crate::{
+        core::dm_flags::{DmFlags, DmUdevFlags},
+        core::sysvsem::{semun, GETVAL, SEM_INFO, SETVAL},
+        core::{dm_ioctl as dmi, errors},
+        result::{DmError, DmResult},
+    };
+
+    use super::UdevSyncAction;
+
+    // Mode for cookie semaphore creation
+    const COOKIE_MODE: i32 = 0o600;
+
+    impl DmError {
+        fn udev_sync_error_from_os() -> DmError {
+            DmError::Core(errors::Error::UdevSync(
+                io::Error::last_os_error().to_string(),
+            ))
+        }
+    }
+
+    lazy_static! {
+        static ref SYSV_SEM_SUPPORTED: bool = sysv_sem_supported();
+    }
+
+    /// Test whether the system is configured for SysV semaphore support.
+    fn sysv_sem_supported() -> bool {
+        let mut info: seminfo = Default::default();
+        let arg = semun { __buf: &mut info };
+        match semctl(0, 0, SEM_INFO, Some(arg)) {
+            Ok(maxid) if maxid < 0 => {
+                warn!(concat!(
+                    "Kernel not configured for System V IPC semaphores.",
+                    "Disabling udev notifications."
+                ));
+                false
+            }
+            Err(err) => {
+                error!(
+                    concat!(
+                        "Error retrieving System V semaphore limits: {}.",
+                        "Disabling udev notifications."
+                    ),
+                    err
+                );
+                false
+            }
+            Ok(_) => {
+                if info.semmsl > 0 && info.semmni > 0 && info.semmns > 0 {
+                    if info.semmsl < 1000 || info.semmni < 1000 || info.semmns < 1000 {
+                        warn!(concat!(
+                            "Low System V IPC semaphore limits detected: consider ",
+                            "increasing values in /proc/sys/kernel/sem to avoid exhaustion."
+                        ));
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Allocate or retrieve a SysV semaphore set identifier
+    fn semget(key: i32, nsems: i32, semflg: i32) -> Result<i32, std::io::Error> {
+        let semid = unsafe { libc_semget(key as key_t, nsems as c_int, semflg as c_int) };
+        match semid {
+            i if i < 0 => Err(io::Error::last_os_error()),
+            _ => Ok(semid),
+        }
+    }
+
+    fn semctl_cmd_allowed(cmd: i32) -> Result<(), std::io::Error> {
+        match cmd {
+            IPC_RMID | GETVAL | SETVAL | SEM_INFO => Ok(()),
+            _ => Err(io::Error::from(io::ErrorKind::Unsupported)),
+        }
+    }
+
+    /// SysV semaphore set control operations
+    fn semctl(
+        semid: i32,
+        semnum: i32,
+        cmd: i32,
+        semun: Option<semun>,
+    ) -> Result<i32, std::io::Error> {
+        semctl_cmd_allowed(cmd)?;
+        let semun = match semun {
+            Some(semun) => semun,
+            None => Default::default(),
+        };
+        let r = unsafe { libc_semctl(semid as c_int, semnum as c_int, cmd as c_int, semun) };
+        match r {
+            i if i < 0 => Err(io::Error::last_os_error()),
+            _ => Ok(r),
+        }
+    }
+
+    /// Attempt to generate a unique, non-zero SysV IPC key and allocate a semaphore
+    /// set for notifications.
+    fn generate_semaphore_cookie() -> OperationResult<(u32, i32), std::io::Error> {
+        let mut base_cookie = 0u16;
+        while base_cookie == 0 {
+            base_cookie = rand::thread_rng().gen::<u16>();
+        }
+        let cookie = dmi::DM_COOKIE_MAGIC << dmi::DM_UDEV_FLAGS_SHIFT | base_cookie as u32;
+        match semget(cookie as i32, 1, COOKIE_MODE | IPC_CREAT | IPC_EXCL) {
+            Ok(semid) => OperationResult::Ok((cookie, semid)),
+            Err(err) => match err.raw_os_error() {
+                Some(ENOMEM) => OperationResult::Err(err),
+                Some(ENOSPC) => OperationResult::Err(err),
+                Some(EEXIST) => OperationResult::Retry(err),
+                _ => OperationResult::Err(err),
+            },
+        }
+    }
+
+    /// Create a new, unique udev notification semaphore and return the cookie
+    /// value and semid.
+    ///
+    /// This function will attempt to allocate a new notification semaphore and sets
+    /// the initial count to the 1. This count will be decremented by udev once rule
+    /// processing for the transaction is complete.
+    fn notify_sem_create() -> DmResult<(u32, i32)> {
+        let (cookie, semid) = match retry(NoDelay.take(4), generate_semaphore_cookie) {
+            Ok((cookie, semid)) => (cookie, semid),
+            Err(err) => {
+                error!("Failed to generate udev notification semaphore: {}", err);
+                return Err(DmError::Core(errors::Error::UdevSync(err.to_string())));
+            }
+        };
+        let sem_arg: semun = semun { val: 1 };
+        if let Err(err) = semctl(semid, 0, SETVAL, Some(sem_arg)) {
+            error!("Failed to initialize udev notification semaphore: {}", err);
+            if let Err(err2) = notify_sem_destroy(cookie, semid) {
+                error!("Failed to clean up udev notification semaphore: {}", err2);
+            }
+            return Err(DmError::Core(errors::Error::UdevSync(err.to_string())));
+        }
+        match semctl(semid, 0, GETVAL, None) {
+            Ok(1) => Ok((cookie, semid)),
+            _ => {
+                error!("Initalization of udev notification semaphore returned inconsistent value.");
+                Err(DmError::udev_sync_error_from_os())
+            }
+        }
+    }
+
+    /// Destroy the notification semaphore identified by semid.
+    ///
+    /// Remove the SysV semaphore set identified by the SysV IPC ID semid and
+    /// IPC key cookie. This removes the SysV IPC ID identified by the cookie
+    /// value and should be called following completion or cancelation of a
+    /// notification semaphore.
+    fn notify_sem_destroy(cookie: u32, semid: i32) -> DmResult<()> {
+        if let Err(err) = semctl(semid, 0, IPC_RMID, None) {
+            error!(
+                "Failed to remove udev synchronization semaphore {} for cookie {}",
+                semid, cookie
+            );
+            return Err(DmError::Core(errors::Error::UdevSync(err.to_string())));
+        };
+        Ok(())
+    }
+
+    /// Increment the semaphore identified by SysV IPC ID semid.
+    fn notify_sem_inc(cookie: u32, semid: i32) -> DmResult<()> {
+        // DM protocol always uses the 0th semaphore in the set identified by semid
+        let mut sb = sembuf {
+            sem_num: 0,
+            sem_op: 1,
+            sem_flg: 0,
+        };
+        let r = unsafe { libc_semop(semid, &mut sb, 1) };
+        match r {
+            i if i < 0 => {
+                error!(
+                    "Failed to increment udev synchronization semaphore {} for cookie {}",
+                    semid, cookie
+                );
+                Err(DmError::udev_sync_error_from_os())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Decrement the semaphore identified by SysV IPC ID semid.
+    fn notify_sem_dec(cookie: u32, semid: i32) -> DmResult<()> {
+        // DM protocol always uses the 0th semaphore in the set identified by semid
+        let mut sb = sembuf {
+            sem_num: 0,
+            sem_op: -1,
+            sem_flg: IPC_NOWAIT as i16,
+        };
+        let r = unsafe { libc_semop(semid, &mut sb, 1) };
+        match r {
+            i if i < 0 => {
+                error!(
+                    "Failed to decrement udev synchronization semaphore {} for cookie {}",
+                    semid, cookie
+                );
+                Err(DmError::udev_sync_error_from_os())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Wait for completion of notification semaphore identified by SysV IPC ID semid.
+    ///
+    /// This function blocks until the value of the first semaphore in the set
+    /// identified by semid reaches zero (normally as a result of the dmsetup
+    /// udev_complete invoked at the end of udev rule processing).
+    fn notify_sem_wait(cookie: u32, semid: i32) -> DmResult<()> {
+        if let Err(err) = notify_sem_dec(cookie, semid) {
+            error!(
+                concat!(
+                    "Failed to set initial state for notification ",
+                    "semaphore identified by cookie value {}: {}"
+                ),
+                cookie, err
+            );
+            if let Err(err2) = notify_sem_destroy(cookie, semid) {
+                error!("Failed to clean up udev notification semaphore: {}", err2);
+            }
+        }
+        let mut sb = sembuf {
+            sem_num: 0,
+            sem_op: 0,
+            sem_flg: 0,
+        };
+        let r = unsafe { libc_semop(semid, &mut sb, 1) };
+        match r {
+            i if i < 0 => {
+                error!(
+                    "Failed to wait on notification semaphore {} for cookie {}",
+                    semid, cookie
+                );
+                Err(DmError::udev_sync_error_from_os())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct UdevSync {
+        cookie: u32,
+        semid: Option<i32>,
+    }
+
+    impl UdevSyncAction for UdevSync {
+        /// Begin UdevSync notification transaction.
+        ///
+        /// Allocate a SysV semaphore according to the device-mapper udev cookie
+        /// protocol and set the initial state of the semaphore counter.
+        fn begin(hdr: &mut dmi::Struct_dm_ioctl, ioctl: u8) -> DmResult<Self> {
+            match ioctl as u32 {
+                dmi::DM_DEV_REMOVE_CMD | dmi::DM_DEV_RENAME_CMD | dmi::DM_DEV_SUSPEND_CMD
+                    if *SYSV_SEM_SUPPORTED && (hdr.flags & DmFlags::DM_SUSPEND.bits()) == 0 => {}
+                _ => {
+                    return Ok(UdevSync {
+                        cookie: 0,
+                        semid: None,
+                    });
+                }
+            };
+
+            let (base_cookie, semid) = notify_sem_create()?;
+
+            // Encode the primary source flag and the random base cookie value into
+            // the header event_nr input field.
+            hdr.event_nr |= (DmUdevFlags::DM_UDEV_PRIMARY_SOURCE_FLAG.bits()
+                << dmi::DM_UDEV_FLAGS_SHIFT)
+                | (base_cookie & !dmi::DM_UDEV_FLAGS_MASK);
+
+            debug!(
+                "Created UdevSync {{ cookie: {}, semid: {} }}",
+                hdr.event_nr, semid
+            );
+
+            if let Err(err) = notify_sem_inc(hdr.event_nr, semid) {
+                error!(
+                    "Failed to set udev notification semaphore initial state: {}",
+                    err
+                );
+                if let Err(err2) = notify_sem_destroy(hdr.event_nr, semid) {
+                    error!("Failed to clean up udev notification semaphore: {}", err2);
+                }
+                return Err(err);
+            }
+            Ok(UdevSync {
+                cookie: hdr.event_nr,
+                semid: Some(semid),
+            })
+        }
+
+        /// End UdevSync notification transaction.
+        ///
+        /// Wait for notification from the udev daemon on the semaphore owned by
+        /// this UdevSync instance and destroy the semaphore on success.
+        fn end(self, flags: u32) -> DmResult<()> {
+            if self.is_active() {
+                let semid = self.semid.expect("active UdevSync must have valid semid");
+                if (flags & DmFlags::DM_UEVENT_GENERATED.bits()) == 0 {
+                    if let Err(err) = notify_sem_dec(self.cookie, semid) {
+                        error!("Failed to clear notification semaphore state: {}", err);
+                        if let Err(err2) = notify_sem_destroy(self.cookie, semid) {
+                            error!("Failed to clean up notification semaphore: {}", err2);
+                        }
+                        return Err(err);
+                    }
+                }
+                trace!("Waiting on {:?}", self);
+                notify_sem_wait(self.cookie, semid)?;
+                trace!("Destroying {:?}", self);
+                if let Err(err) = notify_sem_destroy(self.cookie, semid) {
+                    error!("Failed to clean up notification semaphore: {}", err);
+                }
+            }
+            Ok(())
+        }
+
+        /// Cancel an in-progress UdevSync notification transaction.
+        ///
+        /// Destroy the notification semaphore owned by this UdevSync instance
+        /// without waiting for completion.
+        fn cancel(self) {
+            if self.is_active() {
+                let semid = self.semid.expect("active UdevSync must have valid semid");
+                trace!("Canceling {:?}", self);
+                if let Err(err) = notify_sem_destroy(self.cookie, semid) {
+                    error!("Failed to clean up notification semaphore: {}", err);
+                }
+            }
+        }
+
+        /// Test whether this UdevSync instance has an active notification semaphore.
+        fn is_active(&self) -> bool {
+            self.cookie != 0 && self.semid.is_some()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::core::dm_flags::DmUdevFlags;
+
+        // SysV IPC key value for testing ("DMRS" in ASCII characters)
+        const IPC_TEST_KEY: i32 = 0x444d5253;
+
+        #[test]
+        fn test_semget_invalid_nsems() {
+            assert!(semget(0, -1, 0).is_err());
+        }
+
+        #[test]
+        fn test_semget_create_destroy() {
+            assert_matches!(semget(IPC_TEST_KEY, 1, IPC_CREAT | IPC_EXCL),
+                Ok(semid) => assert!(semctl(semid, 0, IPC_RMID, None).is_ok()));
+        }
+
+        #[test]
+        fn test_notify_sem_create_destroy() {
+            assert_matches!(notify_sem_create(),
+                Ok((cookie, semid)) => assert!(notify_sem_destroy(cookie, semid).is_ok()));
+        }
+
+        #[test]
+        fn test_udevsync_non_primary_source() {
+            let mut hdr: dmi::Struct_dm_ioctl = devicemapper_sys::dm_ioctl {
+                ..Default::default()
+            };
+            let sync = UdevSync::begin(&mut hdr, dmi::DM_TABLE_STATUS_CMD as u8).unwrap();
+            assert_eq!(sync.cookie, 0);
+            assert_eq!(sync.semid, None);
+            assert_eq!(hdr.event_nr, 0);
+            assert!(sync.end(DmFlags::empty().bits()).is_ok());
+        }
+
+        #[test]
+        fn test_udevsync_non_primary_source_cancel() {
+            let mut hdr: dmi::Struct_dm_ioctl = devicemapper_sys::dm_ioctl {
+                ..Default::default()
+            };
+            let sync = UdevSync::begin(&mut hdr, dmi::DM_TABLE_STATUS_CMD as u8).unwrap();
+            assert_eq!(sync.cookie, 0);
+            assert_eq!(sync.semid, None);
+            assert_eq!(hdr.event_nr, 0);
+            sync.cancel();
+        }
+
+        #[test]
+        fn test_udevsync_primary_source_end() {
+            let mut hdr: dmi::Struct_dm_ioctl = devicemapper_sys::dm_ioctl {
+                ..Default::default()
+            };
+            let sync = UdevSync::begin(&mut hdr, dmi::DM_DEV_REMOVE_CMD as u8).unwrap();
+            assert_ne!((sync.cookie & !dmi::DM_UDEV_FLAGS_MASK), 0);
+            assert!(sync.semid.unwrap() >= 0);
+            assert!(notify_sem_dec(sync.cookie, sync.semid.unwrap()).is_ok());
+            assert_eq!(
+                (hdr.event_nr >> dmi::DM_UDEV_FLAGS_SHIFT)
+                    & DmUdevFlags::DM_UDEV_PRIMARY_SOURCE_FLAG.bits(),
+                DmUdevFlags::DM_UDEV_PRIMARY_SOURCE_FLAG.bits()
+            );
+            assert!(sync.end(DmFlags::DM_UEVENT_GENERATED.bits()).is_ok());
+        }
+
+        #[test]
+        fn test_udevsync_primary_source_cancel() {
+            let mut hdr: dmi::Struct_dm_ioctl = devicemapper_sys::dm_ioctl {
+                ..Default::default()
+            };
+            let sync = UdevSync::begin(&mut hdr, dmi::DM_DEV_REMOVE_CMD as u8).unwrap();
+            assert_ne!((sync.cookie & !dmi::DM_UDEV_FLAGS_MASK), 0);
+            assert!(sync.semid.unwrap() >= 0);
+            assert_eq!(
+                (hdr.event_nr >> dmi::DM_UDEV_FLAGS_SHIFT)
+                    & DmUdevFlags::DM_UDEV_PRIMARY_SOURCE_FLAG.bits(),
+                DmUdevFlags::DM_UDEV_PRIMARY_SOURCE_FLAG.bits()
+            );
+            sync.cancel();
+        }
+
+        #[test]
+        fn test_udevsync_primary_source_end_no_uevent() {
+            let mut hdr: dmi::Struct_dm_ioctl = devicemapper_sys::dm_ioctl {
+                ..Default::default()
+            };
+            let sync = UdevSync::begin(&mut hdr, dmi::DM_DEV_REMOVE_CMD as u8).unwrap();
+            assert_ne!((sync.cookie & !dmi::DM_UDEV_FLAGS_MASK), 0);
+            assert!(sync.semid.unwrap() >= 0);
+            assert_eq!(
+                (hdr.event_nr >> dmi::DM_UDEV_FLAGS_SHIFT)
+                    & DmUdevFlags::DM_UDEV_PRIMARY_SOURCE_FLAG.bits(),
+                DmUdevFlags::DM_UDEV_PRIMARY_SOURCE_FLAG.bits()
+            );
+            assert!(sync.end(DmFlags::empty().bits()).is_ok());
+        }
+    }
+}
+#[cfg(target_os = "android")]
+pub mod sync_noop {
+    use super::UdevSyncAction;
+    use crate::{core::dm_ioctl as dmi, result::DmResult};
+
+    #[derive(Debug)]
+    pub struct UdevSync {
+        cookie: u32,
+        semid: Option<i32>,
+    }
+
+    impl UdevSyncAction for UdevSync {
+        fn begin(hdr: &mut dmi::Struct_dm_ioctl, ioctl: u8) -> DmResult<Self> {
+            debug!("Created noop UdevSync {{ cookie: {}, semid: {} }}", 0, -1);
+            Ok(UdevSync {
+                cookie: 0,
+                semid: None,
+            })
+        }
+
+        fn end(self, _flags: u32) -> DmResult<()> {
+            trace!("Destroying noop {:?}", self);
+            Ok(())
+        }
+
+        fn cancel(self) {
+            trace!("Canceling noop {:?}", self);
+        }
+
+        fn is_active(&self) -> bool {
+            false
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+pub use self::sync_noop::UdevSync;
+#[cfg(not(target_os = "android"))]
+pub use self::sync_semaphore::UdevSync;

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -39,6 +39,9 @@ pub enum Error {
 
     /// An error returned on general IO failure
     GeneralIo(String),
+
+    /// An error synchronizing with udev
+    UdevSync(String),
 }
 
 impl std::fmt::Display for Error {
@@ -65,6 +68,9 @@ impl std::fmt::Display for Error {
             ),
             Error::GeneralIo(err) => {
                 write!(f, "failed to perform operation due to IO error: {err}")
+            }
+            Error::UdevSync(err) => {
+                write!(f, "failed to perform udev sync operation: {}", err)
             }
         }
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ mod dm;
 mod dm_flags;
 mod dm_ioctl;
 mod dm_options;
+mod dm_udev_sync;
 pub mod errors;
 mod sysvsem;
 mod types;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ mod dm_flags;
 mod dm_ioctl;
 mod dm_options;
 pub mod errors;
+mod sysvsem;
 mod types;
 mod util;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     device::{devnode_to_devno, Device},
     deviceinfo::DeviceInfo,
     dm::DM,
-    dm_flags::{DmCookie, DmFlags},
+    dm_flags::{DmFlags, DmUdevFlags},
     dm_options::DmOptions,
     types::{DevId, DmName, DmNameBuf, DmUuid, DmUuidBuf},
 };

--- a/src/core/sysvsem.rs
+++ b/src/core/sysvsem.rs
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+pub use devicemapper_sys::{semid_ds, seminfo, semun, GETVAL, SEM_INFO, SETVAL};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@ extern crate bitflags;
 extern crate nix;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate log;
 
 /// Range macros
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,8 @@ pub use crate::{
     },
     consts::IEC,
     core::{
-        devnode_to_devno, errors, DevId, Device, DeviceInfo, DmCookie, DmFlags, DmName, DmNameBuf,
-        DmOptions, DmUuid, DmUuidBuf, DM,
+        devnode_to_devno, errors, DevId, Device, DeviceInfo, DmFlags, DmName, DmNameBuf, DmOptions,
+        DmUdevFlags, DmUuid, DmUuidBuf, DM,
     },
     lineardev::{
         FlakeyTargetParams, LinearDev, LinearDevTargetParams, LinearDevTargetTable,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -103,7 +103,7 @@ pub trait DmDevice<T: TargetTable> {
             &DevId::Name(self.name()),
             DmOptions::default()
                 .set_flags(DmFlags::DM_SUSPEND | options.flags())
-                .set_cookie(options.cookie()),
+                .set_udev_flags(options.udev_flags()),
         )?;
         Ok(())
     }

--- a/src/testing/logger.rs
+++ b/src/testing/logger.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::sync::Once;
+
+static LOGGER_INIT: Once = Once::new();
+
+/// Initialize the logger once.  More than one init() attempt returns
+/// errors.
+pub fn init_logger() {
+    LOGGER_INIT.call_once(env_logger::init);
+}

--- a/src/testing/loopbacked.rs
+++ b/src/testing/loopbacked.rs
@@ -15,7 +15,7 @@ use tempfile::{self, TempDir};
 
 use crate::{
     consts::IEC,
-    testing::test_lib::clean_up,
+    testing::{logger::init_logger, test_lib::clean_up},
     units::{Bytes, Sectors, SECTOR_SIZE},
 };
 
@@ -117,6 +117,7 @@ pub fn test_with_spec<F>(count: u8, test: F)
 where
     F: Fn(&[&Path]) + panic::RefUnwindSafe,
 {
+    init_logger();
     clean_up().unwrap();
 
     let tmpdir = tempfile::Builder::new()

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -4,10 +4,12 @@
 
 //! Modules that support testing.
 
+mod logger;
 mod loopbacked;
 mod test_lib;
 
 pub use self::{
+    logger::init_logger,
     loopbacked::test_with_spec,
     test_lib::{
         blkdev_size, test_name, test_string, test_uuid, udev_settle, xfs_create_fs, xfs_set_uuid,

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -584,6 +584,9 @@ mod tests {
         // Create the XFS FS on top of the thin device
         xfs_create_fs(&td.devnode(), Some(uuid)).unwrap();
 
+        // Synchronize with udev processing triggered by xfs_create_fs()
+        udev_settle().unwrap();
+
         validate(&uuid, &td.devnode());
 
         // Teardown the thindev, then set it back up and make sure all is well with udev

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -5,7 +5,7 @@
 use std::{fmt, path::PathBuf, str::FromStr};
 
 use crate::{
-    core::{DevId, Device, DeviceInfo, DmCookie, DmFlags, DmName, DmOptions, DmUuid, DM},
+    core::{DevId, Device, DeviceInfo, DmFlags, DmName, DmOptions, DmUuid, DM},
     result::{DmError, DmResult, ErrorEnum},
     shared::{
         device_create, device_exists, device_match, get_status, get_status_line_fields, message,
@@ -263,13 +263,7 @@ impl ThinDev {
 
         let thin_pool_device = thin_pool.device();
         let table = ThinDev::gen_default_table(length, thin_pool_device, thin_id);
-        let dev_info = device_create(
-            dm,
-            name,
-            uuid,
-            &table,
-            DmOptions::default().set_cookie(DmCookie::DM_UDEV_PRIMARY_SOURCE_FLAG),
-        )?;
+        let dev_info = device_create(dm, name, uuid, &table, DmOptions::default())?;
 
         Ok(ThinDev {
             dev_info: Box::new(dev_info),
@@ -305,13 +299,7 @@ impl ThinDev {
             device_match(dm, &dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(
-                dm,
-                name,
-                uuid,
-                &table,
-                DmOptions::default().set_cookie(DmCookie::DM_UDEV_PRIMARY_SOURCE_FLAG),
-            )?;
+            let dev_info = device_create(dm, name, uuid, &table, DmOptions::default())?;
             ThinDev {
                 dev_info: Box::new(dev_info),
                 table,
@@ -352,7 +340,7 @@ impl ThinDev {
             snapshot_name,
             snapshot_uuid,
             &table,
-            DmOptions::default().set_cookie(DmCookie::DM_UDEV_PRIMARY_SOURCE_FLAG),
+            DmOptions::default(),
         )?);
         Ok(ThinDev { dev_info, table })
     }


### PR DESCRIPTION
This branch adds support for udev synchronization using SysV semaphores and the device-mapper ioctl/uevent "cookie" mechanism.

The branch adds a new sub-module, `dm_udev_sync` that wraps the low-level semaphore operations and provides an interface to `core::dm`.

All udev synchronization is carried out insde `DM::do_ioctl()`. This centralises and simplifies handling ioctl errors (which require the udev semaphore to be cleaned up before propagating the error) and minimises the changes needed to synchronize with uevents.

This branch also adds basic logging infrastructure to the crate, using the log facade and the env_logger crate: this was helpful in developing and debugging the udev interactions and may be useful for debugging other problems involving device-mapper.