### PR TITLE
Cargo.toml: Exclude .clippy.toml and .githooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["os::linux-apis", "api-bindings"]
 keywords = ["Linux", "device", "mapper", "libdm", "storage"]
 license = "MPL-2.0"
 edition = "2018"
-exclude = [".gitignore", ".github/*", "Makefile"]
+exclude = [".clippy.toml", ".githooks/*", ".gitignore", ".github/*", "Makefile"]
 
 [dependencies]
 bitflags = "1.1.0"


### PR DESCRIPTION
Related: stratis-storage/project#485