### PR TITLE
Expose DeviceInfo struct

### DIFF
--- a/src/core/deviceinfo.rs
+++ b/src/core/deviceinfo.rs
@@ -80,6 +80,9 @@ impl TryFrom<dmi::Struct_dm_ioctl> for DeviceInfo {
 }
 
 impl DeviceInfo {
+    /// Parses a DM ioctl structure.
+    ///
+    /// Equivalent to `DeviceInfo::try_from(hdr)`.
     pub fn new(hdr: dmi::Struct_dm_ioctl) -> DmResult<Self> {
         DeviceInfo::try_from(hdr)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,8 @@ pub use crate::{
     },
     consts::IEC,
     core::{
-        devnode_to_devno, errors, DevId, Device, DmCookie, DmFlags, DmName, DmNameBuf, DmOptions,
-        DmUuid, DmUuidBuf, DM,
+        devnode_to_devno, errors, DevId, Device, DeviceInfo, DmCookie, DmFlags, DmName, DmNameBuf,
+        DmOptions, DmUuid, DmUuidBuf, DM,
     },
     lineardev::{
         FlakeyTargetParams, LinearDev, LinearDevTargetParams, LinearDevTargetTable,


### PR DESCRIPTION
Several methods return this structure but since it's not publicly exported, users can't name the type nor get documentation for it.