### PR TITLE
Add device parameter to DmOptions

### DIFF
--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -11,7 +11,7 @@ use std::{
     slice, str,
 };
 
-use nix::libc::ioctl as nix_ioctl;
+use nix::libc::{dev_t, ioctl as nix_ioctl};
 
 use crate::{
     core::{
@@ -58,6 +58,7 @@ impl DmOptions {
             flags: clean_flags.bits(),
             event_nr,
             data_start: size_of::<dmi::Struct_dm_ioctl>() as u32,
+            dev: dev_t::from(self.device()),
             ..Default::default()
         };
 

--- a/src/core/dm_options.rs
+++ b/src/core/dm_options.rs
@@ -1,13 +1,17 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-use crate::core::dm_flags::{DmCookie, DmFlags};
+use crate::{
+    core::dm_flags::{DmCookie, DmFlags},
+    Device,
+};
 
 /// Encapsulates options for device mapper calls
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct DmOptions {
     flags: DmFlags,
     cookie: DmCookie,
+    device: Device,
 }
 
 impl DmOptions {
@@ -25,6 +29,13 @@ impl DmOptions {
         self
     }
 
+    /// Sets the `Device` value for self. Replaces the previous value.
+    /// Consumes self.
+    pub fn set_device(mut self, device: Device) -> DmOptions {
+        self.device = device;
+        self
+    }
+
     /// Retrieve the flags value
     pub fn flags(&self) -> DmFlags {
         self.flags
@@ -33,5 +44,19 @@ impl DmOptions {
     /// Retrieve the cookie value (used for input in upper 16 bits of event_nr header field).
     pub fn cookie(&self) -> DmCookie {
         self.cookie
+    }
+
+    pub fn device(&self) -> Device {
+        self.device
+    }
+}
+
+impl Default for DmOptions {
+    fn default() -> Self {
+        Self {
+            flags: Default::default(),
+            cookie: Default::default(),
+            device: Device { major: 0, minor: 0 },
+        }
     }
 }


### PR DESCRIPTION
Corresponds to the dev field in the dm_ioctl struct. Used in a few ioctls - in particular, its needed for create with DM_PERSISTENT.