### PR TITLE
Increase nix dependency lower bound to 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [".clippy.toml", ".githooks/*", ".gitignore", ".github/*", "Makefile"]
 
 [dependencies]
 bitflags = "1.1.0"
-nix = "0.24.0"
+nix = "0.26.0"
 semver = "1.0.0"
 serde = "1.0.60"
 lazy_static = "1.2.0"

--- a/devicemapper-rs-sys/Cargo.toml
+++ b/devicemapper-rs-sys/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["storage", "devicemapper"]
 categories = ["os::linux-apis", "external-ffi-bindings"]
 
 [dependencies]
-nix = "0.24.0"
+nix = "0.26.0"
 
 [build-dependencies.bindgen]
 default_features = false


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/570