### PR TITLE
Make internal devices private by default

### DIFF
--- a/src/cachedev.rs
+++ b/src/cachedev.rs
@@ -573,7 +573,7 @@ impl CacheDev {
         }
 
         let table = CacheDev::gen_default_table(&meta, &cache, &origin, cache_block_size);
-        let dev_info = device_create(dm, name, uuid, &table, DmOptions::default())?;
+        let dev_info = device_create(dm, name, uuid, &table, DmOptions::private())?;
 
         Ok(CacheDev {
             dev_info: Box::new(dev_info),
@@ -607,7 +607,7 @@ impl CacheDev {
             device_match(dm, &dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table, DmOptions::default())?;
+            let dev_info = device_create(dm, name, uuid, &table, DmOptions::private())?;
             CacheDev {
                 dev_info: Box::new(dev_info),
                 meta_dev: meta,

--- a/src/core/dm_options.rs
+++ b/src/core/dm_options.rs
@@ -34,4 +34,13 @@ impl DmOptions {
     pub fn udev_flags(&self) -> DmUdevFlags {
         self.udev_flags
     }
+
+    /// Set default udev flags for a private (internal) device.
+    pub fn private() -> DmOptions {
+        DmOptions::default().set_udev_flags(
+            DmUdevFlags::DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG
+                | DmUdevFlags::DM_UDEV_DISABLE_DISK_RULES_FLAG
+                | DmUdevFlags::DM_UDEV_DISABLE_OTHER_RULES_FLAG,
+        )
+    }
 }

--- a/src/lineardev.rs
+++ b/src/lineardev.rs
@@ -539,7 +539,7 @@ impl LinearDev {
             device_match(dm, &dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table, DmOptions::default())?;
+            let dev_info = device_create(dm, name, uuid, &table, DmOptions::private())?;
             LinearDev {
                 dev_info: Box::new(dev_info),
                 table,

--- a/src/thinpooldev.rs
+++ b/src/thinpooldev.rs
@@ -457,7 +457,7 @@ impl ThinPoolDev {
 
         let table =
             ThinPoolDev::gen_table(&meta, &data, data_block_size, low_water_mark, feature_args);
-        let dev_info = device_create(dm, name, uuid, &table, DmOptions::default())?;
+        let dev_info = device_create(dm, name, uuid, &table, DmOptions::private())?;
 
         Ok(ThinPoolDev {
             dev_info: Box::new(dev_info),
@@ -512,7 +512,7 @@ impl ThinPoolDev {
             device_match(dm, &dev, uuid)?;
             dev
         } else {
-            let dev_info = device_create(dm, name, uuid, &table, DmOptions::default())?;
+            let dev_info = device_create(dm, name, uuid, &table, DmOptions::private())?;
             ThinPoolDev {
                 dev_info: Box::new(dev_info),
                 meta_dev: meta,


### PR DESCRIPTION
Pull request #774 adds support to devicemapper-rs for synchronizing with Udev events. This causes the DM_UDEV_PRIMARY_SOURCE flag to be set for all ioctl operations that generate uevents. Previously this flag was only set for `ThinDev` devices (i.e. the top-level thin leaf devices allocated from a thin pool).

This has the unwanted side effect of making other internal device types visible in the Udev database which has consequences for other components (e.g. Udisks).

Restore the previous behaviour of only exposing the `ThinDev` devices by introducing a new `DmOptions::private()` helper to set appropariate DM_UDEV_* flags controlling the visibility of other device types.