### PR TITLE
Make CacheDev, LinearDev and ThinPoolDev private on resume()

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -90,7 +90,7 @@ pub trait DmDevice<T: TargetTable> {
 
     /// Resume I/O on the device.
     fn resume(&mut self, dm: &DM) -> DmResult<()> {
-        dm.device_suspend(&DevId::Name(self.name()), DmOptions::default())?;
+        dm.device_suspend(&DevId::Name(self.name()), DmOptions::private())?;
         Ok(())
     }
 

--- a/src/thindev.rs
+++ b/src/thindev.rs
@@ -169,6 +169,11 @@ impl DmDevice<ThinDevTargetTable> for ThinDev {
         name!(self)
     }
 
+    fn resume(&mut self, dm: &DM) -> DmResult<()> {
+        dm.device_suspend(&DevId::Name(self.name()), DmOptions::default())?;
+        Ok(())
+    }
+
     fn size(&self) -> Sectors {
         self.table.table.length
     }


### PR DESCRIPTION
Related https://github.com/stratis-storage/stratisd/issues/3301