### PR TITLE
build.rs: Add support for finding header paths with pkg-config

### DIFF
--- a/devicemapper-rs-sys/Cargo.toml
+++ b/devicemapper-rs-sys/Cargo.toml
@@ -17,6 +17,9 @@ default-features = false
 features = ["runtime"]
 version = "0.69.0"
 
+[build-dependencies]
+pkg-config = "0.3.31"
+
 [lints.rust]
 warnings = { level = "deny" }
 future_incompatible = { level = "deny", priority = 1 }


### PR DESCRIPTION
This  MR is a follow up from: https://github.com/stratis-storage/libblkid-rs/pull/171

The minimum version chose is from 2018, and I tested I could build against said version. 