### PR TITLE
Disable cargo metadata in pkg-config probe

### DIFF
--- a/devicemapper-rs-sys/build.rs
+++ b/devicemapper-rs-sys/build.rs
@@ -8,7 +8,11 @@ use bindgen::Builder;
 use pkg_config::{Config, Library};
 
 fn libdevmapper_probe() -> Library {
-    match Config::new().atleast_version("1.02.151").probe("devmapper") {
+    match Config::new()
+        .atleast_version("1.02.151")
+        .cargo_metadata(false)
+        .probe("devmapper")
+    {
         Ok(library) => library,
         Err(e) => panic!("Suitable version of libdevmapper not found: {}", e),
     }


### PR DESCRIPTION
Related to #965 

I'll be putting up another PR for the other libraries that use pkg-config.