### PR TITLE
Use procfs instead of libmount to read mountinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ once_cell = "1.19.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-libmount = "0.1.11"
 loopdev-3 = "0.5.0"
+procfs = "0.17.0"
 tempfile = "3.7.0"
 
 [dev-dependencies.uuid]


### PR DESCRIPTION
Closes #990 