### PR TITLE
Stop checking rust dependency versions on Fedora 41

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -55,7 +55,6 @@ jobs:
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=rawhide IGNORE_ARGS="--ignore-category low" make -f ../Makefile check-fedora-versions
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f43 IGNORE_ARGS="--ignore-category low" make -f ../Makefile check-fedora-versions
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f42 IGNORE_ARGS="--ignore-category low" make -f ../Makefile check-fedora-versions
-          COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f41 IGNORE_ARGS="--ignore-category low" make -f ../Makefile check-fedora-versions
         working-directory: devicemapper-rs/devicemapper-rs-sys
       - name: Run comparisons of version specs with package
         # yamllint disable rule:line-length
@@ -63,5 +62,4 @@ jobs:
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=rawhide IGNORE_ARGS="--ignore-category low --ignore-high=devicemapper-sys" make -f Makefile check-fedora-versions
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f43 IGNORE_ARGS="--ignore-category low --ignore-high=devicemapper-sys" make -f Makefile check-fedora-versions
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f42 IGNORE_ARGS="--ignore-category low --ignore-high=devicemapper-sys" make -f Makefile check-fedora-versions
-          COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f41 IGNORE_ARGS="--ignore-category low --ignore-high=devicemapper-sys" make -f Makefile check-fedora-versions
         working-directory: devicemapper-rs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,6 @@ jobs:
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=rawhide make -f ../Makefile check-fedora-versions
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f43 make -f ../Makefile check-fedora-versions
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f42 make -f ../Makefile check-fedora-versions
-          COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f41 make -f ../Makefile check-fedora-versions
         working-directory: devicemapper-rs/devicemapper-rs-sys
       - name: Run comparison of version specs with package
         # yamllint disable rule:line-length
@@ -86,7 +85,6 @@ jobs:
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=rawhide make -f Makefile check-fedora-versions
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f43 make -f Makefile check-fedora-versions
           COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f42 make -f Makefile check-fedora-versions
-          COMPARE_FEDORA_VERSIONS=$GITHUB_WORKSPACE/ci/dependency_management/compare_fedora_versions FEDORA_RELEASE=f41 make -f Makefile check-fedora-versions
         working-directory: devicemapper-rs
 
   semver-checks:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Fedora 41 from CI workflow testing checks across multiple test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->