### PR TITLE
Update procfs dev-dependency to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.14"
 [dev-dependencies]
 assert_matches = "1.5.0"
 loopdev-3 = "0.5.0"
-procfs = "0.17.0"
+procfs = "0.18.0"
 tempfile = "3.7.0"
 
 [dev-dependencies.uuid]


### PR DESCRIPTION
Upstream release tag / changelog: https://github.com/eminence/procfs/releases/tag/v0.18.0
Upstream source diff: https://github.com/eminence/procfs/compare/v0.17.0...v0.18.0

This PR is the upstream component of an attempt to upgrade Fedora’s `rust-procfs` package to 0.18 without introducing a `rust-procfs0.17` compat package.