### PR TITLE
Increase nix dependency lower bound to 0.31.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".clippy.toml", ".githooks/*", ".gitignore", ".github/*", "Makefile"]
 [dependencies]
 bitflags = "2.3.3"
 cfg-if = "1.0.0"
-nix = {version = "0.30.1", features=["fs", "ioctl", "mount"]}
+nix = {version = "0.31.1", features=["fs", "ioctl", "mount"]}
 env_logger="0.11.0"
 semver = "1.0.0"
 serde = "1.0.60"


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/849