### PR TITLE
Support dm without udev

### DIFF
--- a/src/core/dm.rs
+++ b/src/core/dm.rs
@@ -128,6 +128,11 @@ impl DM {
         hdr.version[1] = ioctl_version.1;
         hdr.version[2] = ioctl_version.2;
 
+        // Clear event_nr for ioctls that don't use it as input to avoid EINVAL
+        if !dmi::ioctl_uses_event_number(ioctl) {
+            hdr.event_nr = 0;
+        }
+
         // Begin udev sync transaction and set DM_UDEV_PRIMARY_SOURCE_FLAG
         // if ioctl command generates uevents.
         let sync = UdevSync::begin(hdr, ioctl)?;
@@ -816,7 +821,7 @@ impl AsRawFd for DM {
 mod tests {
 
     use crate::{
-        core::errors::Error,
+        core::{dm_flags::DmUdevFlags, errors::Error},
         result::DmError,
         testing::{test_name, test_uuid},
     };
@@ -1141,5 +1146,60 @@ mod tests {
         );
         dm.device_remove(&DevId::Name(&name), DmOptions::default())
             .unwrap();
+    }
+
+    /// DmOptions for no-udev test environments: builds on `DmOptions::private()`
+    /// and additionally disables device-mapper's own udev rules.
+    fn no_udev_dm_options() -> DmOptions {
+        DmOptions::private().set_udev_flags(
+            DmOptions::private().udev_flags() | DmUdevFlags::DM_UDEV_DISABLE_DM_RULES_FLAG,
+        )
+    }
+
+    /// The test verifies that DM operations work correctly when udev
+    /// synchronization is fully disabled, simulating the dm-verity device
+    /// creation flow in a no-udev guest VM environment.
+    ///
+    /// It simulates the dm-verity device lifecycle:
+    /// device_create -> table_load -> device_suspend(resume) -> device_info -> device_remove
+    ///
+    /// All operations use no-udev DmOptions. Uses a read-only error target
+    /// (no real block device needed).
+    #[test]
+    fn sudo_test_no_udev_device_lifecycle() {
+        let dm = DM::new().unwrap();
+        let name = test_name("no-udev-lifecycle").expect("is valid DM name");
+        let id = DevId::Name(&name);
+
+        let ro_opts = no_udev_dm_options().set_flags(DmFlags::DM_READONLY);
+        let opts = no_udev_dm_options();
+
+        // Step 1: Create device (read-only, no-udev)
+        let create_info = dm.device_create(&name, None, ro_opts).unwrap();
+        assert_eq!(create_info.name(), Some(&*name));
+
+        // Step 2: Load a trivial error target table
+        let table = vec![(
+            0u64,
+            1024u64, // 512KB in 512-byte sectors
+            "error".into(),
+            "".into(),
+        )];
+        dm.table_load(&id, &table, ro_opts).unwrap();
+
+        // Step 3: Resume device (activate the table)
+        // device_suspend without DM_SUSPEND flag = resume
+        dm.device_suspend(&id, opts).unwrap();
+
+        // Step 4: Verify device is active via device_info
+        // device_info uses DmOptions::default(), but DM_DEV_STATUS_CMD
+        // does not require udev sync, so it works in no-udev environments
+        let info = dm.device_info(&id).unwrap();
+        assert_eq!(info.name(), Some(&*name));
+        // Device should not be suspended after resume
+        assert!(!info.flags().contains(DmFlags::DM_SUSPEND));
+
+        // Step 5: Remove device with no-udev options
+        dm.device_remove(&id, no_udev_dm_options()).unwrap();
     }
 }

--- a/src/core/dm_ioctl.rs
+++ b/src/core/dm_ioctl.rs
@@ -54,3 +54,27 @@ pub(crate) fn ioctl_to_version(ioctl: u8) -> (u32, u32, u32) {
         unreachable!("Unknown device-mapper ioctl command: {}", ioctl);
     }
 }
+
+/// Returns true for ioctls that use `event_nr` as a udev cookie and
+/// participate in udev synchronization via SysV semaphore.
+#[inline]
+pub(crate) fn ioctl_uses_udev_cookie(ioctl: u8) -> bool {
+    matches!(
+        ioctl as u32,
+        DM_DEV_REMOVE_CMD | DM_DEV_RENAME_CMD | DM_DEV_SUSPEND_CMD
+    )
+}
+
+/// Returns true for ioctls whose `event_nr` header field carries meaningful
+/// input that must not be cleared before the ioctl is issued.
+///
+/// Per the kernel header (`dm_ioctl.h`):
+/// - `DM_SUSPEND`, `DM_DEV_REMOVE`, and `DM_DEV_RENAME` use `event_nr` as a
+///   udev cookie for synchronization (see [`ioctl_uses_udev_cookie`]).
+/// - `DM_DEV_WAIT` uses `event_nr` as an event number input but does not
+///   participate in udev synchronization.
+///   For output, all ioctls return the event number, not the cookie.
+#[inline]
+pub(crate) fn ioctl_uses_event_number(ioctl: u8) -> bool {
+    ioctl_uses_udev_cookie(ioctl) || ioctl as u32 == DM_DEV_WAIT_CMD
+}

--- a/src/core/dm_udev_sync.rs
+++ b/src/core/dm_udev_sync.rs
@@ -293,23 +293,23 @@ pub mod sync_semaphore {
         /// Allocate a SysV semaphore according to the device-mapper udev cookie
         /// protocol and set the initial state of the semaphore counter.
         fn begin(hdr: &mut dmi::Struct_dm_ioctl, ioctl: u8) -> DmResult<Self> {
-            if !udev_running() {
-                return Err(DmError::Core(errors::Error::UdevSync(
-                    "Udev daemon is not running: unable to create devices.".to_string(),
-                )));
+            // Udev sync is only performed for ioctls that use event_nr as a
+            // udev cookie: DM_DEV_REMOVE, DM_DEV_RENAME, and DM_DEV_SUSPEND.
+            // DM_DEV_WAIT also uses event_nr as input (event number), but does
+            // not participate in udev synchronization.
+            if !dmi::ioctl_uses_udev_cookie(ioctl)
+                || !*SYSV_SEM_SUPPORTED
+                || (hdr.flags & DmFlags::DM_SUSPEND.bits()) != 0
+                || !udev_running()
+            {
+                hdr.event_nr = 0;
+                return Ok(UdevSync {
+                    cookie: 0,
+                    semid: None,
+                });
             }
 
-            match ioctl as u32 {
-                dmi::DM_DEV_REMOVE_CMD | dmi::DM_DEV_RENAME_CMD | dmi::DM_DEV_SUSPEND_CMD
-                    if *SYSV_SEM_SUPPORTED && (hdr.flags & DmFlags::DM_SUSPEND.bits()) == 0 => {}
-                _ => {
-                    return Ok(UdevSync {
-                        cookie: 0,
-                        semid: None,
-                    });
-                }
-            };
-
+            // Udev sync is required and udev is available, allocate semaphore
             let (base_cookie, semid) = notify_sem_create()?;
 
             // Encode the primary source flag and the random base cookie value into
@@ -385,7 +385,7 @@ pub mod sync_semaphore {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::core::dm_flags::DmUdevFlags;
+        use crate::{core::dm_flags::DmUdevFlags, DmOptions};
 
         // SysV IPC key value for testing ("DMRS" in ASCII characters)
         const IPC_TEST_KEY: i32 = 0x444d5253;
@@ -478,6 +478,51 @@ pub mod sync_semaphore {
                 DmUdevFlags::DM_UDEV_PRIMARY_SOURCE_FLAG.bits()
             );
             assert!(sync.end(DmFlags::empty().bits()).is_ok());
+        }
+
+        /// DmOptions for no-udev test environments: builds on `DmOptions::private()`
+        /// and additionally disables device-mapper's own udev rules.
+        fn no_udev_dm_options() -> DmOptions {
+            DmOptions::private().set_udev_flags(
+                DmOptions::private().udev_flags() | DmUdevFlags::DM_UDEV_DISABLE_DM_RULES_FLAG,
+            )
+        }
+
+        /// Verify that when udev is not running, all udev-sync commands
+        /// return inactive UdevSync without allocating a semaphore.
+        #[test]
+        fn test_udevsync_no_udev_running_all_sync_cmds() {
+            if udev_running() {
+                // This test validates the !udev_running() path; skip when
+                // udev is actually present (e.g. developer workstations).
+                return;
+            }
+
+            for ioctl_cmd in [
+                dmi::DM_DEV_REMOVE_CMD as u8,
+                dmi::DM_DEV_RENAME_CMD as u8,
+                dmi::DM_DEV_SUSPEND_CMD as u8, // resume (no DM_SUSPEND flag)
+            ] {
+                let mut hdr: dmi::Struct_dm_ioctl = devicemapper_sys::dm_ioctl {
+                    event_nr: no_udev_dm_options().flags().bits() << dmi::DM_UDEV_FLAGS_SHIFT,
+                    ..Default::default()
+                };
+
+                let sync = UdevSync::begin(&mut hdr, ioctl_cmd).unwrap();
+                assert_eq!(
+                    sync.cookie, 0,
+                    "ioctl {ioctl_cmd}: no udev should produce inactive UdevSync"
+                );
+                assert_eq!(
+                    sync.semid, None,
+                    "ioctl {ioctl_cmd}: no semaphore should be allocated"
+                );
+                assert_eq!(
+                    hdr.event_nr, 0,
+                    "ioctl {ioctl_cmd}: event_nr must be cleared"
+                );
+                assert!(sync.end(DmFlags::empty().bits()).is_ok());
+            }
         }
     }
 }


### PR DESCRIPTION
It aims to address issue #1035


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device lifecycle now handles missing or disabled udev and operations that don't require udev synchronization gracefully: synchronization metadata is cleared and devices are not left incorrectly suspended.
  * Fast-path avoids errors when the udev daemon is unavailable, allowing operations to proceed without semaphore allocation and ensuring resume/remove flows complete reliably.

* **Tests**
  * Added end-to-end tests covering create/load/suspend/resume/remove flows with udev disabled and when the udev daemon is not running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->